### PR TITLE
Fix build breakages for FreeBSD/ia64 with GCC 4.2.

### DIFF
--- a/source/components/disassembler/dmresrc.c
+++ b/source/components/disassembler/dmresrc.c
@@ -488,7 +488,7 @@ AcpiDmIsResourceTemplate (
     /* Walk the byte list, abort on any invalid descriptor type or length */
 
     Status = AcpiUtWalkAmlResources (WalkState, Aml, Length,
-        NULL, (void **) &EndAml);
+        NULL, ACPI_CAST_INDIRECT_PTR (void, &EndAml));
     if (ACPI_FAILURE (Status))
     {
         return (AE_TYPE);

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -492,7 +492,7 @@ ACPI_EXTERN UINT8                       AcpiGbl_DbOutputFlags;
 
 #ifdef ACPI_DISASSEMBLER
 
-BOOLEAN     ACPI_INIT_GLOBAL (AcpiGbl_IgnoreNoopOperator, FALSE);
+ACPI_EXTERN BOOLEAN     ACPI_INIT_GLOBAL (AcpiGbl_IgnoreNoopOperator, FALSE);
 
 ACPI_EXTERN BOOLEAN                     AcpiGbl_DbOpt_disasm;
 ACPI_EXTERN BOOLEAN                     AcpiGbl_DbOpt_verbose;


### PR DESCRIPTION
These changes fix the following build breakages for FreeBSD/ia64:

http://docs.freebsd.org/cgi/mid.cgi?201301182151.r0ILpVw8026162
http://docs.freebsd.org/cgi/mid.cgi?201301212022.r0LKMwJI012550

Jung-uk Kim
