### PR TITLE
Fix a potential memory leak

### DIFF
--- a/source/components/utilities/utosi.c
+++ b/source/components/utilities/utosi.c
@@ -464,7 +464,8 @@ AcpiUtOsiImplementation (
     Status = AcpiOsAcquireMutex (AcpiGbl_OsiMutex, ACPI_WAIT_FOREVER);
     if (ACPI_FAILURE (Status))
     {
-        return (Status);
+        AcpiUtDeleteObjectDesc (ReturnDesc);
+        return_ACPI_STATUS (Status);
     }
 
     /* Lookup the interface in the global _OSI list */


### PR DESCRIPTION
Actually, it was in the original patch (fd8dd36f626ee59ee4f205cb106bf6686ea8b6eb)
but somehow missed in the actual merge (7db6eef89bfdb1a4d8e0c2299b212004bf7cbc9f).
