### PR TITLE
AcpiDump/FreeBSD: tidy up

### DIFF
--- a/source/os_specific/service_layers/osfreebsdtbl.c
+++ b/source/os_specific/service_layers/osfreebsdtbl.c
@@ -1060,20 +1060,5 @@ OslMapTable (
         }
     }
 
-    /* FACS does not have a checksum */
-
-    if (ACPI_COMPARE_NAME (MappedTable->Signature, ACPI_SIG_FACS))
-    {
-        return (AE_OK);
-    }
-
-    /* Validate checksum for most tables */
-
-    if (AcpiTbChecksum (ACPI_CAST8 (MappedTable), Length))
-    {
-        fprintf (stderr, "Warning: wrong checksum for %4.4s\n",
-            MappedTable->Signature);
-    }
-
     return (AE_OK);
 }

--- a/source/tools/acpidump/apdump.c
+++ b/source/tools/acpidump/apdump.c
@@ -192,9 +192,10 @@ ApDumpTableBuffer (
 
      /* Validate the table checksum (except FACS - has no checksum) */
 
-    if (!ACPI_COMPARE_NAME (Table->Signature, ACPI_SIG_FACS))
+    if (!ACPI_COMPARE_NAME (Table->Signature, ACPI_SIG_FACS) &&
+        AcpiTbChecksum (ACPI_CAST8 (Table), Table->Length))
     {
-        (void) AcpiTbVerifyChecksum (Table, Table->Length);
+        fprintf (stderr, "Warning: wrong checksum for %4.4s\n", Table->Signature);
     }
 
     /* Print only the header if requested */


### PR DESCRIPTION
- Make sure to unmap memory in error cases.
- Remove a pointless casting.
- Match the table header first, then fully map the table.
- Consistently return AE_BAD_ADDRESS for mmap(2) failures.
- Do not print duplicate checksum errors.
