### PR TITLE
Makefile: 'Mac OS X' properly detected.

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -46,7 +46,11 @@ COMPILEOBJ = $(CC) -c $(CFLAGS) $(OPT_CFLAGS) -o $@ $<
 LINKPROG =   $(CC) $(OBJECTS) -o $(PROG) $(LDFLAGS)
 PREFIX ?=    /usr
 INSTALLDIR = $(PREFIX)/bin
+UNAME_S := $(shell uname -s)
 
+ifeq ($(UNAME_S),Darwin)  # Assume Mac OS X
+HOST =       _APPLE
+endif
 ifeq ($(HOST), _APPLE)
 INSTALL  =   cp
 INSTALLFLAGS ?= -f


### PR DESCRIPTION
Avoid every make in Mac OS X to require an additional parameter or environment configuration.
All done with a simple test in Makefile, that does not interfere in other systems.
