### PR TITLE
Tables: Add mechanism to control early table checksum verification.

### DIFF
--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -424,7 +424,43 @@ AcpiTbInvalidateTable (
 
 /******************************************************************************
  *
- * FUNCTION:    AcpiTbVerifyTable
+ * FUNCTION:    AcpiTbValidateTempTable
+ *
+ * PARAMETERS:  TableDesc           - Table descriptor
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: This function is called to validate the table, the returned
+ *              table descriptor is in "VALIDATED" state.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiTbValidateTempTable (
+    ACPI_TABLE_DESC         *TableDesc)
+{
+
+    if (!TableDesc->Pointer && !AcpiGbl_VerifyTableChecksum)
+    {
+        /*
+         * Only validates the header of the table.
+         * Note that Length contains the size of the mapping after invoking
+         * this work around, this value is required by
+         * AcpiTbReleaseTempTable().
+         * We can do this because in AcpiInitTableDescriptor(), the Length
+         * field of the installed descriptor is filled with the actual
+         * table length obtaining from the table header.
+         */
+        TableDesc->Length = sizeof (ACPI_TABLE_HEADER);
+    }
+
+    return (AcpiTbValidateTable (TableDesc));
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiTbVerifyTempTable
  *
  * PARAMETERS:  TableDesc           - Table descriptor
  *              Signature           - Table signature to verify
@@ -437,19 +473,19 @@ AcpiTbInvalidateTable (
  *****************************************************************************/
 
 ACPI_STATUS
-AcpiTbVerifyTable (
+AcpiTbVerifyTempTable (
     ACPI_TABLE_DESC         *TableDesc,
     char                    *Signature)
 {
     ACPI_STATUS             Status = AE_OK;
 
 
-    ACPI_FUNCTION_TRACE (TbVerifyTable);
+    ACPI_FUNCTION_TRACE (TbVerifyTempTable);
 
 
     /* Validate the table */
 
-    Status = AcpiTbValidateTable (TableDesc);
+    Status = AcpiTbValidateTempTable (TableDesc);
     if (ACPI_FAILURE (Status))
     {
         return_ACPI_STATUS (AE_NO_MEMORY);
@@ -469,16 +505,19 @@ AcpiTbVerifyTable (
 
     /* Verify the checksum */
 
-    Status = AcpiTbVerifyChecksum (TableDesc->Pointer, TableDesc->Length);
-    if (ACPI_FAILURE (Status))
+    if (AcpiGbl_VerifyTableChecksum)
     {
-        ACPI_EXCEPTION ((AE_INFO, AE_NO_MEMORY,
-            "%4.4s " ACPI_PRINTF_UINT
-            " Attempted table install failed",
-            AcpiUtValidAcpiName (TableDesc->Signature.Ascii) ?
-                TableDesc->Signature.Ascii : "????",
-            ACPI_FORMAT_TO_UINT (TableDesc->Address)));
-        goto InvalidateAndExit;
+        Status = AcpiTbVerifyChecksum (TableDesc->Pointer, TableDesc->Length);
+        if (ACPI_FAILURE (Status))
+        {
+            ACPI_EXCEPTION ((AE_INFO, AE_NO_MEMORY,
+                "%4.4s " ACPI_PRINTF_UINT
+                " Attempted table install failed",
+                AcpiUtValidAcpiName (TableDesc->Signature.Ascii) ?
+                    TableDesc->Signature.Ascii : "????",
+                ACPI_FORMAT_TO_UINT (TableDesc->Address)));
+            goto InvalidateAndExit;
+        }
     }
 
     return_ACPI_STATUS (AE_OK);

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -282,7 +282,7 @@ AcpiTbInstallFixedTable (
 
     /* Validate and verify a table before installation */
 
-    Status = AcpiTbVerifyTable (&NewTableDesc, Signature);
+    Status = AcpiTbVerifyTempTable (&NewTableDesc, Signature);
     if (ACPI_FAILURE (Status))
     {
         goto ReleaseAndExit;
@@ -362,7 +362,7 @@ AcpiTbInstallStandardTable (
 
     /* Validate and verify a table before installation */
 
-    Status = AcpiTbVerifyTable (&NewTableDesc, NULL);
+    Status = AcpiTbVerifyTempTable (&NewTableDesc, NULL);
     if (ACPI_FAILURE (Status))
     {
         goto ReleaseAndExit;
@@ -527,7 +527,7 @@ FinishOverride:
 
     /* Validate and verify a table before overriding */
 
-    Status = AcpiTbVerifyTable (&NewTableDesc, NULL);
+    Status = AcpiTbVerifyTempTable (&NewTableDesc, NULL);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -549,7 +549,7 @@ FinishOverride:
      */
     AcpiTbInitTableDescriptor (OldTableDesc, NewTableDesc.Address,
         NewTableDesc.Flags, NewTableDesc.Pointer);
-    AcpiTbValidateTable (OldTableDesc);
+    AcpiTbValidateTempTable (OldTableDesc);
 
     /* Release the temporary table descriptor */
 

--- a/source/components/tables/tbutils.c
+++ b/source/components/tables/tbutils.c
@@ -499,10 +499,6 @@ NextTable:
         TableEntry += TableEntrySize;
     }
 
-    /*
-     * It is not possible to map more than one entry in some environments,
-     * so unmap the root table here before mapping other tables
-     */
     AcpiOsUnmapMemory (Table, Length);
 
     return_ACPI_STATUS (AE_OK);

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -234,6 +234,15 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_CreateOsiMethod, TRUE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_UseDefaultRegisterWidths, TRUE);
 
 /*
+ * Whether or not to verify the table checksum before installation. Set
+ * this to TRUE to verify the table checksum before install it to the table
+ * manager. Note that enabling this option causes errors to happen in some
+ * OSPMs during early initialization stages. Default behavior is to do such
+ * verification.
+ */
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_VerifyTableChecksum, TRUE);
+
+/*
  * Optionally enable output from the AML Debug Object.
  */
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_EnableAmlDebugObject, FALSE);

--- a/source/include/actables.h
+++ b/source/include/actables.h
@@ -158,6 +158,15 @@ void
 AcpiTbReleaseTempTable (
     ACPI_TABLE_DESC         *TableDesc);
 
+ACPI_STATUS
+AcpiTbValidateTempTable (
+    ACPI_TABLE_DESC         *TableDesc);
+
+ACPI_STATUS
+AcpiTbVerifyTempTable (
+    ACPI_TABLE_DESC         *TableDesc,
+    char                    *Signature);
+
 BOOLEAN
 AcpiTbIsTableLoaded (
     UINT32                  TableIndex);
@@ -206,11 +215,6 @@ AcpiTbValidateTable (
 void
 AcpiTbInvalidateTable (
     ACPI_TABLE_DESC         *TableDesc);
-
-ACPI_STATUS
-AcpiTbVerifyTable (
-    ACPI_TABLE_DESC         *TableDesc,
-    char                    *Signature);
 
 void
 AcpiTbOverrideTable (


### PR DESCRIPTION
The following regression is reported when the table length is very large:
 WARNING: CPU: 0 PID: 0 at mm/early_ioremap.c:136 __early_ioremap+0x11f/0x1f2()
 Modules linked in:
 CPU: 0 PID: 0 Comm: swapper Not tainted 3.15.0-rc1-00017-g86dfc6f3-dirty #298
 Hardware name: Intel Corporation S2600CP/S2600CP, BIOS SE5C600.86B.99.99.x036.091920111209 09/19/2011
  0000000000000009 ffffffff81b75c40 ffffffff817c627b 0000000000000000
  ffffffff81b75c78 ffffffff81067b5d 000000000000007b 8000000000000563
  00000000b96b20dc 0000000000000001 ffffffffff300e0c ffffffff81b75c88
 Call Trace:
  [<ffffffff817c627b>] dump_stack+0x45/0x56
  [<ffffffff81067b5d>] warn_slowpath_common+0x7d/0xa0
  [<ffffffff81067c3a>] warn_slowpath_null+0x1a/0x20
  [<ffffffff81d4b9d5>] __early_ioremap+0x11f/0x1f2
  [<ffffffff81d4bc5b>] early_ioremap+0x13/0x15
  [<ffffffff81d2b8f3>] __acpi_map_table+0x13/0x18
  [<ffffffff817b8d1a>] acpi_os_map_memory+0x26/0x14e
  [<ffffffff813ff018>] acpi_tb_acquire_table+0x42/0x70
  [<ffffffff813ff086>] acpi_tb_validate_table+0x27/0x37
  [<ffffffff813ff0e5>] acpi_tb_verify_table+0x22/0xd8
  [<ffffffff813ff6a8>] acpi_tb_install_non_fixed_table+0x60/0x1c9
  [<ffffffff81d61024>] acpi_tb_parse_root_table+0x218/0x26a
  [<ffffffff81d1b120>] ? early_idt_handlers+0x120/0x120
  [<ffffffff81d610cd>] acpi_initialize_tables+0x57/0x59
  [<ffffffff81d5f25d>] acpi_table_init+0x1b/0x99
  [<ffffffff81d2bca0>] acpi_boot_table_init+0x1e/0x85
  [<ffffffff81d23043>] setup_arch+0x99d/0xcc6
  [<ffffffff81d1b120>] ? early_idt_handlers+0x120/0x120
  [<ffffffff81d1bbbe>] start_kernel+0x8b/0x415
  [<ffffffff81d1b120>] ? early_idt_handlers+0x120/0x120
  [<ffffffff81d1b5ee>] x86_64_start_reservations+0x2a/0x2c
  [<ffffffff81d1b72e>] x86_64_start_kernel+0x13e/0x14d
 ---[ end trace 11ae599a1898f4e7 ]---
This is due to the size limitation of the x86 early IO mapping.
There is a large SSDT table on such platform that exceeds this limitation:
 ACPI: SSDT 0x00000000B9638018 07A0C4 (v02 INTEL  S2600CP  00004000 INTL 20100331)

It sounds strange that in the 64-bit virtual memory address space, we
cannot map a single ACPI table to do checksum verification. The root cause
is:
1. ACPICA doesn't split IO memory mapping and table mapping;
2. Linux x86 OSL implements AcpiOsMapMemory() using a size limited fix-map
   mechanism during early boot stage, which is more suitable for only IO
   mappings.

ACPICA originally only mapped table header for signature validation, and
this header mapping is required by OSL override mechanism. There was no
checksum verification because we could not map the whole table using this
OSL. While the following ACPICA commit enforces checksum verification by
mapping the whole table during Linux boot stage and it finally triggers
this issue on some platforms:
  Commit: bf959821a98985b69b118ad6e6676a142c2e3241
  Subject: Tables: Fix table checksums verification before installation.

Before doing further cleanups for the OSL table mapping and override
implementation, this patch introduces an option for such OSPMs to
temporarily discard the checksum verification feature. It then can be
re-enabled easily when the ACPICA and the underlying OSL is ready.

This patch also deletes a comment around the limitation of mappings because
it is not correct. The limitation is not how many times we can map in the
early stage, but the OSL mapping facility may not be suitable for mapping
the ACPI tables and thus may complain us the size limitation.

The AcpiTbVerifyTable() is renamed to AcpiTbVerifyTempTable() due to the
work around added, it now only applies to the table descriptor that hasn't
been installed and cannot be used in other cases. Lv Zheng.

Signed-off-by: Lv Zheng lv.zheng@intel.com
Reported-and-tested-by: Yuanhan Liu yuanhan.liu@linux.intel.com
