### PR TITLE
Acpica 64bit

### DIFF
--- a/source/components/tables/tbfadt.c
+++ b/source/components/tables/tbfadt.c
@@ -456,8 +456,16 @@ AcpiTbParseFadt (
 
     if (!AcpiGbl_ReducedHardware)
     {
-        AcpiTbInstallFixedTable ((ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.XFacs,
-            ACPI_SIG_FACS, ACPI_TABLE_INDEX_FACS);
+        if (AcpiGbl_FADT.Facs)
+        {
+            AcpiTbInstallFixedTable ((ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.Facs,
+                ACPI_SIG_FACS, ACPI_TABLE_INDEX_FACS);
+        }
+        if (AcpiGbl_FADT.XFacs)
+        {
+            AcpiTbInstallFixedTable ((ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.XFacs,
+                ACPI_SIG_FACS, ACPI_TABLE_INDEX_X_FACS);
+        }
     }
 }
 
@@ -607,12 +615,9 @@ AcpiTbConvertFadt (
     AcpiGbl_FADT.Header.Length = sizeof (ACPI_TABLE_FADT);
 
     /*
-     * Expand the 32-bit FACS and DSDT addresses to 64-bit as necessary.
+     * Expand the 32-bit DSDT addresses to 64-bit as necessary.
      * Later ACPICA code will always use the X 64-bit field.
      */
-    AcpiGbl_FADT.XFacs = AcpiTbSelectAddress ("FACS",
-        AcpiGbl_FADT.Facs, AcpiGbl_FADT.XFacs);
-
     AcpiGbl_FADT.XDsdt = AcpiTbSelectAddress ("DSDT",
         AcpiGbl_FADT.Dsdt, AcpiGbl_FADT.XDsdt);
 

--- a/source/components/tables/tbutils.c
+++ b/source/components/tables/tbutils.c
@@ -149,9 +149,6 @@ ACPI_STATUS
 AcpiTbInitializeFacs (
     void)
 {
-    ACPI_TABLE_FACS         *Facs32;
-    ACPI_TABLE_FACS         *Facs64;
-
 
     /* If Hardware Reduced flag is set, there is no FACS */
 
@@ -162,21 +159,21 @@ AcpiTbInitializeFacs (
     }
 
     (void) AcpiGetTableByIndex (ACPI_TABLE_INDEX_FACS,
-                ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &Facs32));
+                ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &AcpiGbl_Facs32));
     (void) AcpiGetTableByIndex (ACPI_TABLE_INDEX_X_FACS,
-                ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &Facs64));
-    if (!Facs32 && !Facs64)
+                ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &AcpiGbl_Facs64));
+    if (!AcpiGbl_Facs32 && !AcpiGbl_Facs64)
     {
         return (AE_NO_MEMORY);
     }
 
     if (AcpiGbl_Use32BitFacsAddresses)
     {
-        AcpiGbl_FACS = Facs32 ? Facs32 : Facs64;
+        AcpiGbl_FACS = AcpiGbl_Facs32 ? AcpiGbl_Facs32 : AcpiGbl_Facs64;
     }
     else
     {
-        AcpiGbl_FACS = Facs64 ? Facs64 : Facs32;
+        AcpiGbl_FACS = AcpiGbl_Facs64 ? AcpiGbl_Facs64 : AcpiGbl_Facs32;
     }
 
     return (AE_OK);

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -255,7 +255,8 @@ AcpiTbLoadNamespace (
     (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
     for (i = 0; i < AcpiGbl_RootTableList.CurrentTableCount; ++i)
     {
-        if ((!ACPI_COMPARE_NAME (&(AcpiGbl_RootTableList.Tables[i].Signature),
+        if (!AcpiGbl_RootTableList.Tables[i].Address ||
+            (!ACPI_COMPARE_NAME (&(AcpiGbl_RootTableList.Tables[i].Signature),
                     ACPI_SIG_SSDT) &&
              !ACPI_COMPARE_NAME (&(AcpiGbl_RootTableList.Tables[i].Signature),
                     ACPI_SIG_PSDT)) ||

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -134,6 +134,8 @@ ACPI_GLOBAL (ACPI_TABLE_HEADER,         AcpiGbl_OriginalDsdtHeader);
 
 #if (!ACPI_REDUCED_HARDWARE)
 ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_FACS);
+ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_Facs32);
+ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_Facs64);
 
 #endif /* !ACPI_REDUCED_HARDWARE */
 

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -310,6 +310,7 @@ typedef struct acpi_table_list
 
 #define ACPI_TABLE_INDEX_DSDT           (0)
 #define ACPI_TABLE_INDEX_FACS           (1)
+#define ACPI_TABLE_INDEX_X_FACS         (2)
 
 
 typedef struct acpi_find_context

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -260,9 +260,9 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
  * address. Although ACPICA adheres to the ACPI specification which
  * requires the use of the corresponding 64-bit address if it is non-zero,
  * some machines have been found to have a corrupted non-zero 64-bit
- * address. Default is TRUE, favor the 32-bit addresses.
+ * address. Default is FALSE, do not favor the 32-bit addresses.
  */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_Use32BitFadtAddresses, TRUE);
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_Use32BitFadtAddresses, FALSE);
 
 /*
  * Optionally use 32-bit FACS table addresses.

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -265,6 +265,15 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_Use32BitFadtAddresses, TRUE);
 
 /*
+ * Optionally use 32-bit FACS table addresses.
+ * It is reported that some platforms fail to resume from system suspending
+ * if 64-bit FACS table address is selected:
+ * https://bugzilla.kernel.org/show_bug.cgi?id=74021
+ * Default is TRUE, favor the 32-bit addresses.
+ */
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_Use32BitFacsAddresses, TRUE);
+
+/*
  * Optionally truncate I/O addresses to 16 bits. Provides compatibility
  * with other ACPI implementations. NOTE: During ACPICA initialization,
  * this value is set to TRUE if any Windows OSI strings have been

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -260,9 +260,9 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
  * address. Although ACPICA adheres to the ACPI specification which
  * requires the use of the corresponding 64-bit address if it is non-zero,
  * some machines have been found to have a corrupted non-zero 64-bit
- * address. Default is FALSE, do not favor the 32-bit addresses.
+ * address. Default is TRUE, favor the 32-bit addresses.
  */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_Use32BitFadtAddresses, FALSE);
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_Use32BitFadtAddresses, TRUE);
 
 /*
  * Optionally truncate I/O addresses to 16 bits. Provides compatibility

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -1091,14 +1091,8 @@ AcpiLeaveSleepState (
 ACPI_HW_DEPENDENT_RETURN_STATUS (
 ACPI_STATUS
 AcpiSetFirmwareWakingVector (
-    UINT32                  PhysicalAddress))
-
-#if ACPI_MACHINE_WIDTH == 64
-ACPI_HW_DEPENDENT_RETURN_STATUS (
-ACPI_STATUS
-AcpiSetFirmwareWakingVector64 (
-    UINT64                  PhysicalAddress))
-#endif
+    ACPI_PHYSICAL_ADDRESS   PhysicalAddress,
+    ACPI_PHYSICAL_ADDRESS   PhysicalAddress64))
 
 
 /*


### PR DESCRIPTION
It is reported resuming failure if we enabled 64-bit FADT addresses favor:
https://bugzilla.kernel.org/show_bug.cgi?id=74021

The root cause is:
1. Linux only supports real mode resuming
  32bit waking vector address is used for real mode environment
  64bit waking vector address is used for 32bit or 64bit plat memory environment
2. BIOS may still look at 32-bit FACS reported in the FADT, setting 32bit waking vector of 64-bit FACS reported in the FADT doesn't work.

The series enables 64-bit favor with the exclusion of the above 2 cases
1. For case 1, it is OSPM feature, so we update AcpiSetFirmwareWakingVector() API so that OSPM can determine the value of the both vectors
2. For case 2, we introduce a new AcpiGbl_Use32BitFacsAddresses option to exclude this case, and we load both 32bit and 64bit FACS, set waking vector for both tables in order to be more robust.

For the rest of the addresses favor:
1. PM register addresses
2. DSDT address
We should be able to do a 64bit favor.

This series has been tested by the reporter.