### PR TITLE
Executer: Fix trivial issues in AcpiGetSerialAccessBytes().

### DIFF
--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -136,7 +136,7 @@ AcpiExGetSerialAccessLength (
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiGetSerialAccessBytes
+ * FUNCTION:    AcpiExGetSerialAccessLength
  *
  * PARAMETERS:  AccessorType    - The type of the protocol indicated by region
  *                                field access attributes
@@ -187,7 +187,7 @@ AcpiExGetSerialAccessLength (
     case AML_FIELD_ATTRIB_BLOCK_CALL:
     default:
 
-        Length = ACPI_GSBUS_BUFFER_SIZE;
+        Length = ACPI_GSBUS_BUFFER_SIZE - 2;
         break;
     }
 


### PR DESCRIPTION
This patch fixes trivial issues in AcpiGetSerialAccessBytes(), no real
functional bugs. Lv Zheng.

Signed-off-by: Lv Zheng lv.zheng@intel.com
