### PR TITLE
Work around an ancient GCC bug.

### DIFF
--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -510,6 +510,7 @@ DtCompileTable (
     UINT8                   *Buffer;
     UINT8                   *FlagBuffer = NULL;
     UINT32                  CurrentFlagByteOffset = 0;
+    char                    *String;
     ACPI_STATUS             Status;
 
 
@@ -537,7 +538,8 @@ DtCompileTable (
 
     if (Length > 0)
     {
-        Subtable->Buffer = ACPI_CAST_PTR (UINT8, UtStringCacheCalloc (Length));
+        String = UtStringCacheCalloc (Length);
+        Subtable->Buffer = ACPI_CAST_PTR (UINT8, String);
     }
     Subtable->Length = Length;
     Subtable->TotalLength = Length;

--- a/source/compiler/dtsubtable.c
+++ b/source/compiler/dtsubtable.c
@@ -145,13 +145,15 @@ DtCreateSubtable (
     DT_SUBTABLE             **RetSubtable)
 {
     DT_SUBTABLE             *Subtable;
+    char                    *String;
 
 
     Subtable = UtSubtableCacheCalloc ();
 
     /* Create a new buffer for the subtable data */
 
-    Subtable->Buffer = ACPI_CAST_PTR (UINT8, UtStringCacheCalloc (Length));
+    String = UtStringCacheCalloc (Length);
+    Subtable->Buffer = ACPI_CAST_PTR (UINT8, String);
     ACPI_MEMCPY (Subtable->Buffer, Buffer, Length);
 
     Subtable->Length = Length;


### PR DESCRIPTION
warning: cast from function call of type 'char *' to non-matching type 'long unsigned int'
