### PR TITLE
iASL: Add two workarounds for a very old GCC bug.

### DIFF
--- a/source/compiler/aslmapenter.c
+++ b/source/compiler/aslmapenter.c
@@ -288,6 +288,7 @@ MpCreateGpioInfo (
     ACPI_GPIO_INFO          *Info;
     ACPI_GPIO_INFO          *NextGpio;
     ACPI_GPIO_INFO          *PrevGpio;
+    char                    *Buffer;
 
 
     /*
@@ -295,8 +296,8 @@ MpCreateGpioInfo (
      * sorted by both source device name and then the pin number. There is
      * one block per pin.
      */
-    Info = ACPI_CAST_PTR (ACPI_GPIO_INFO,
-        UtStringCacheCalloc (sizeof (ACPI_GPIO_INFO)));
+    Buffer = UtStringCacheCalloc (sizeof (ACPI_GPIO_INFO));
+    Info = ACPI_CAST_PTR (ACPI_GPIO_INFO, Buffer);
 
     NextGpio = Gbl_GpioList;
     PrevGpio = NULL;
@@ -365,14 +366,15 @@ MpCreateSerialInfo (
     ACPI_SERIAL_INFO        *Info;
     ACPI_SERIAL_INFO        *NextSerial;
     ACPI_SERIAL_INFO        *PrevSerial;
+    char                    *Buffer;
 
 
     /*
      * Allocate a new info block and insert it into the global Serial list
      * sorted by both source device name and then the address.
      */
-    Info = ACPI_CAST_PTR (ACPI_SERIAL_INFO,
-        UtStringCacheCalloc (sizeof (ACPI_SERIAL_INFO)));
+    Buffer = UtStringCacheCalloc (sizeof (ACPI_SERIAL_INFO));
+    Info = ACPI_CAST_PTR (ACPI_SERIAL_INFO, Buffer);
 
     NextSerial = Gbl_SerialList;
     PrevSerial = NULL;


### PR DESCRIPTION
warning: cast from function call of type 'char *' to non-matching type 'long unsigned int'