### PR TITLE
Acpica 1501 materials

### DIFF
--- a/generate/linux/gen-patch.sh
+++ b/generate/linux/gen-patch.sh
@@ -106,9 +106,9 @@ generate_acpica_desc()
 		AUTHOR_EMAIL="robert.moore@intel.com"
 	fi
 	AUTHOR="${AUTHOR_NAME} <${AUTHOR_EMAIL}>"
-	FORMAT="From %H Mon Sep 17 00:00:00 2001%nFrom: $COMMITTER%nData: %aD%nFrom: $AUTHOR%nSubject: [PATCH $INDEX] ACPICA: %s%n%n%b"
+	FORMAT="From %H Mon Sep 17 00:00:00 2001%nFrom: $COMMITTER%nDate: %aD%nFrom: $AUTHOR%nSubject: [PATCH $INDEX] ACPICA: %s%n%n%b"
 	if [ "x$UPSTREAM" = "xyes" ]; then
-		FORMAT="From %H Mon Sep 17 00:00:00 2001%nFrom: $COMMITTER%nData: %aD%nFrom: $AUTHOR%nSubject: [PATCH $INDEX] ACPICA: %s%n%nACPICA commit %H%n%n%b"
+		FORMAT="From %H Mon Sep 17 00:00:00 2001%nFrom: $COMMITTER%nDate: %aD%nFrom: $AUTHOR%nSubject: [PATCH $INDEX] ACPICA: %s%n%nACPICA commit %H%n%n%b"
 	fi
 	GIT_LOG_FORMAT=`echo $FORMAT`
 	eval "git log -c $1 -1 --format=\"$GIT_LOG_FORMAT\""
@@ -123,6 +123,12 @@ split_desc()
 	{
 		if (SOB==1) {
 			if (match($0, /^Signed-off-by:.*/)) {
+				if (ENVIRON["DOSOB"]==1)
+					print $0
+			} else if (match($0, /^Fixed-by:.*/)) {
+				if (ENVIRON["DOSOB"]==1)
+					print $0
+			} else if (match($0, /^Original-by:.*/)) {
 				if (ENVIRON["DOSOB"]==1)
 					print $0
 			} else if (match($0, /^Acked-by:.*/)) {
@@ -142,7 +148,7 @@ split_desc()
 					print $0
 			} else if (match($0, /^Link:.*/)) {
 				if (ENVIRON["DOSOB"]==1)
-				print $0
+					print $0
 			} else if (match($0, /^Reference:.*/)) {
 				if (ENVIRON["DOSOB"]==1)
 					print $0

--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -943,7 +943,7 @@ AdParseTable (
 
     if (LoadTable)
     {
-        Status = AcpiTbStoreTable ((ACPI_PHYSICAL_ADDRESS) Table, Table,
+        Status = AcpiTbStoreTable (ACPI_PTR_TO_PHYSADDR (Table), Table,
                     Table->Length, ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL,
                     &TableIndex);
         if (ACPI_FAILURE (Status))

--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -136,6 +136,11 @@ AdCreateTableHeader (
     char                    *Filename,
     ACPI_TABLE_HEADER       *Table);
 
+static ACPI_STATUS
+AdStoreTable (
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  *TableIndex);
+
 /* Stubs for ASL compiler */
 
 #ifndef ACPI_ASL_COMPILER
@@ -812,6 +817,43 @@ AdDisplayTables (
 }
 
 
+/*******************************************************************************
+ *
+ * FUNCTION:    AdStoreTable
+ *
+ * PARAMETERS:  Table               - Table header
+ *              TableIndex          - Where the table index is returned
+ *
+ * RETURN:      Status and table index.
+ *
+ * DESCRIPTION: Add an ACPI table to the global table list
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AdStoreTable (
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  *TableIndex)
+{
+    ACPI_STATUS             Status;
+    ACPI_TABLE_DESC         *TableDesc;
+
+
+    Status = AcpiTbGetNextTableDescriptor (TableIndex, &TableDesc);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Initialize added table */
+
+    AcpiTbInitTableDescriptor (TableDesc, ACPI_PTR_TO_PHYSADDR (Table),
+        ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL, Table);
+    AcpiTbValidateTable (TableDesc);
+    return (AE_OK);
+}
+
+
 /******************************************************************************
  *
  * FUNCTION:    AdGetLocalTables
@@ -849,8 +891,7 @@ AdGetLocalTables (
 
     /* Store DSDT in the Table Manager */
 
-    Status = AcpiTbStoreTable (0, NewTable, NewTable->Length,
-                0, &TableIndex);
+    Status = AdStoreTable (NewTable, &TableIndex);
     if (ACPI_FAILURE (Status))
     {
         fprintf (stderr, "Could not store DSDT\n");
@@ -943,9 +984,7 @@ AdParseTable (
 
     if (LoadTable)
     {
-        Status = AcpiTbStoreTable (ACPI_PTR_TO_PHYSADDR (Table), Table,
-                    Table->Length, ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL,
-                    &TableIndex);
+        Status = AdStoreTable (Table, &TableIndex);
         if (ACPI_FAILURE (Status))
         {
             return (Status);

--- a/source/components/dispatcher/dsopcode.c
+++ b/source/components/dispatcher/dsopcode.c
@@ -651,7 +651,7 @@ AcpiDsEvalTableRegionOperands (
         return_ACPI_STATUS (AE_NOT_EXIST);
     }
 
-    ObjDesc->Region.Address = (ACPI_PHYSICAL_ADDRESS) ACPI_TO_INTEGER (Table);
+    ObjDesc->Region.Address = ACPI_PTR_TO_PHYSADDR (Table);
     ObjDesc->Region.Length = Table->Length;
 
     ACPI_DEBUG_PRINT ((ACPI_DB_EXEC, "RgnObj %p Addr %8.8X%8.8X Len %X\n",

--- a/source/components/dispatcher/dsopcode.c
+++ b/source/components/dispatcher/dsopcode.c
@@ -549,7 +549,7 @@ AcpiDsEvalRegionOperands (
 
     ACPI_DEBUG_PRINT ((ACPI_DB_EXEC, "RgnObj %p Addr %8.8X%8.8X Len %X\n",
         ObjDesc,
-        ACPI_FORMAT_NATIVE_UINT (ObjDesc->Region.Address),
+        ACPI_FORMAT_UINT64 (ObjDesc->Region.Address),
         ObjDesc->Region.Length));
 
     /* Now the address and length are valid for this opregion */
@@ -656,7 +656,7 @@ AcpiDsEvalTableRegionOperands (
 
     ACPI_DEBUG_PRINT ((ACPI_DB_EXEC, "RgnObj %p Addr %8.8X%8.8X Len %X\n",
         ObjDesc,
-        ACPI_FORMAT_NATIVE_UINT (ObjDesc->Region.Address),
+        ACPI_FORMAT_UINT64 (ObjDesc->Region.Address),
         ObjDesc->Region.Length));
 
     /* Now the address and length are valid for this opregion */

--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -360,7 +360,7 @@ AcpiEvAddressSpaceDispatch (
     ACPI_DEBUG_PRINT ((ACPI_DB_OPREGION,
         "Handler %p (@%p) Address %8.8X%8.8X [%s]\n",
         &RegionObj->Region.Handler->AddressSpace, Handler,
-        ACPI_FORMAT_NATIVE_UINT (Address),
+        ACPI_FORMAT_UINT64 (Address),
         AcpiUtGetRegionName (RegionObj->Region.SpaceId)));
 
     if (!(HandlerDesc->AddressSpace.HandlerFlags &

--- a/source/components/events/evxfevnt.c
+++ b/source/components/events/evxfevnt.c
@@ -473,7 +473,8 @@ AcpiGetEventStatus (
 
     if (InByte)
     {
-        LocalEventStatus |= ACPI_EVENT_FLAG_ENABLED;
+        LocalEventStatus |=
+            (ACPI_EVENT_FLAG_ENABLED | ACPI_EVENT_FLAG_ENABLE_SET);
     }
 
     /* Fixed event currently active? */
@@ -487,7 +488,7 @@ AcpiGetEventStatus (
 
     if (InByte)
     {
-        LocalEventStatus |= ACPI_EVENT_FLAG_SET;
+        LocalEventStatus |= ACPI_EVENT_FLAG_STATUS_SET;
     }
 
     (*EventStatus) = LocalEventStatus;

--- a/source/components/executer/exdump.c
+++ b/source/components/executer/exdump.c
@@ -856,7 +856,7 @@ AcpiExDumpOperand (
         else
         {
             AcpiOsPrintf (" base %8.8X%8.8X Length %X\n",
-                ACPI_FORMAT_NATIVE_UINT (ObjDesc->Region.Address),
+                ACPI_FORMAT_UINT64 (ObjDesc->Region.Address),
                 ObjDesc->Region.Length);
         }
         break;

--- a/source/components/executer/exfldio.c
+++ b/source/components/executer/exfldio.c
@@ -361,13 +361,13 @@ AcpiExAccessRegion (
     }
 
     ACPI_DEBUG_PRINT_RAW ((ACPI_DB_BFIELD,
-        " Region [%s:%X], Width %X, ByteBase %X, Offset %X at %p\n",
+        " Region [%s:%X], Width %X, ByteBase %X, Offset %X at %8.8X%8.8X\n",
         AcpiUtGetRegionName (RgnDesc->Region.SpaceId),
         RgnDesc->Region.SpaceId,
         ObjDesc->CommonField.AccessByteWidth,
         ObjDesc->CommonField.BaseByteOffset,
         FieldDatumByteOffset,
-        ACPI_CAST_PTR (void, (RgnDesc->Region.Address + RegionOffset))));
+        ACPI_FORMAT_UINT64 (RgnDesc->Region.Address + RegionOffset)));
 
     /* Invoke the appropriate AddressSpace/OpRegion handler */
 

--- a/source/components/executer/exregion.c
+++ b/source/components/executer/exregion.c
@@ -266,7 +266,7 @@ AcpiExSystemMemorySpaceHandler (
         {
             ACPI_ERROR ((AE_INFO,
                 "Could not map memory at 0x%8.8X%8.8X, size %u",
-                ACPI_FORMAT_NATIVE_UINT (Address), (UINT32) MapLength));
+                ACPI_FORMAT_UINT64 (Address), (UINT32) MapLength));
             MemInfo->MappedLength = 0;
             return_ACPI_STATUS (AE_NO_MEMORY);
         }
@@ -286,7 +286,7 @@ AcpiExSystemMemorySpaceHandler (
 
     ACPI_DEBUG_PRINT ((ACPI_DB_INFO,
         "System-Memory (width %u) R/W %u Address=%8.8X%8.8X\n",
-        BitWidth, Function, ACPI_FORMAT_NATIVE_UINT (Address)));
+        BitWidth, Function, ACPI_FORMAT_UINT64 (Address)));
 
     /*
      * Perform the memory read or write
@@ -409,7 +409,7 @@ AcpiExSystemIoSpaceHandler (
 
     ACPI_DEBUG_PRINT ((ACPI_DB_INFO,
         "System-IO (width %u) R/W %u Address=%8.8X%8.8X\n",
-        BitWidth, Function, ACPI_FORMAT_NATIVE_UINT (Address)));
+        BitWidth, Function, ACPI_FORMAT_UINT64 (Address)));
 
     /* Decode the function parameter */
 

--- a/source/components/executer/exregion.c
+++ b/source/components/executer/exregion.c
@@ -261,8 +261,7 @@ AcpiExSystemMemorySpaceHandler (
 
         /* Create a new mapping starting at the address given */
 
-        MemInfo->MappedLogicalAddress = AcpiOsMapMemory (
-            (ACPI_PHYSICAL_ADDRESS) Address, MapLength);
+        MemInfo->MappedLogicalAddress = AcpiOsMapMemory (Address, MapLength);
         if (!MemInfo->MappedLogicalAddress)
         {
             ACPI_ERROR ((AE_INFO,

--- a/source/components/hardware/hwgpe.c
+++ b/source/components/hardware/hwgpe.c
@@ -352,6 +352,19 @@ AcpiHwGetGpeStatus (
         LocalEventStatus |= ACPI_EVENT_FLAG_WAKE_ENABLED;
     }
 
+    /* GPE currently enabled (enable bit == 1)? */
+
+    Status = AcpiHwRead (&InByte, &GpeRegisterInfo->EnableAddress);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    if (RegisterBit & InByte)
+    {
+        LocalEventStatus |= ACPI_EVENT_FLAG_ENABLE_SET;
+    }
+
     /* GPE currently active (status bit == 1)? */
 
     Status = AcpiHwRead (&InByte, &GpeRegisterInfo->StatusAddress);
@@ -362,7 +375,7 @@ AcpiHwGetGpeStatus (
 
     if (RegisterBit & InByte)
     {
-        LocalEventStatus |= ACPI_EVENT_FLAG_SET;
+        LocalEventStatus |= ACPI_EVENT_FLAG_STATUS_SET;
     }
 
     /* Set return value */

--- a/source/components/hardware/hwvalid.c
+++ b/source/components/hardware/hwvalid.c
@@ -227,8 +227,8 @@ AcpiHwValidateIoRequest (
     ByteWidth = ACPI_DIV_8 (BitWidth);
     LastAddress = Address + ByteWidth - 1;
 
-    ACPI_DEBUG_PRINT ((ACPI_DB_IO, "Address %p LastAddress %p Length %X",
-        ACPI_CAST_PTR (void, Address), ACPI_CAST_PTR (void, LastAddress),
+    ACPI_DEBUG_PRINT ((ACPI_DB_IO, "Address %8.8X%8.8X LastAddress %8.8X%8.8X Length %X",
+        ACPI_FORMAT_UINT64 (Address), ACPI_FORMAT_UINT64 (LastAddress),
         ByteWidth));
 
     /* Maximum 16-bit address in I/O space */
@@ -236,8 +236,8 @@ AcpiHwValidateIoRequest (
     if (LastAddress > ACPI_UINT16_MAX)
     {
         ACPI_ERROR ((AE_INFO,
-            "Illegal I/O port address/length above 64K: %p/0x%X",
-            ACPI_CAST_PTR (void, Address), ByteWidth));
+            "Illegal I/O port address/length above 64K: %8.8X%8.8X/0x%X",
+            ACPI_FORMAT_UINT64 (Address), ByteWidth));
         return_ACPI_STATUS (AE_LIMIT);
     }
 
@@ -268,8 +268,8 @@ AcpiHwValidateIoRequest (
             if (AcpiGbl_OsiData >= PortInfo->OsiDependency)
             {
                 ACPI_DEBUG_PRINT ((ACPI_DB_IO,
-                    "Denied AML access to port 0x%p/%X (%s 0x%.4X-0x%.4X)",
-                    ACPI_CAST_PTR (void, Address), ByteWidth, PortInfo->Name,
+                    "Denied AML access to port 0x%8.8X%8.8X/%X (%s 0x%.4X-0x%.4X)",
+                    ACPI_FORMAT_UINT64 (Address), ByteWidth, PortInfo->Name,
                     PortInfo->Start, PortInfo->End));
 
                 return_ACPI_STATUS (AE_AML_ILLEGAL_ADDRESS);

--- a/source/components/namespace/nsdump.c
+++ b/source/components/namespace/nsdump.c
@@ -386,9 +386,9 @@ AcpiNsDumpOneObject (
         {
         case ACPI_TYPE_PROCESSOR:
 
-            AcpiOsPrintf ("ID %02X Len %02X Addr %p\n",
+            AcpiOsPrintf ("ID %02X Len %02X Addr %8.8X%8.8X\n",
                 ObjDesc->Processor.ProcId, ObjDesc->Processor.Length,
-                ACPI_CAST_PTR (void, ObjDesc->Processor.Address));
+                ACPI_FORMAT_UINT64 (ObjDesc->Processor.Address));
             break;
 
         case ACPI_TYPE_DEVICE:

--- a/source/components/namespace/nsdump.c
+++ b/source/components/namespace/nsdump.c
@@ -461,7 +461,7 @@ AcpiNsDumpOneObject (
             if (ObjDesc->Region.Flags & AOPOBJ_DATA_VALID)
             {
                 AcpiOsPrintf (" Addr %8.8X%8.8X Len %.4X\n",
-                    ACPI_FORMAT_NATIVE_UINT (ObjDesc->Region.Address),
+                    ACPI_FORMAT_UINT64 (ObjDesc->Region.Address),
                     ObjDesc->Region.Length);
             }
             else

--- a/source/components/resources/rsaddr.c
+++ b/source/components/resources/rsaddr.c
@@ -149,7 +149,7 @@ ACPI_RSCONVERT_INFO     AcpiRsConvertAddress16[5] =
      * Address Translation Offset
      * Address Length
      */
-    {ACPI_RSC_MOVE16,   ACPI_RS_OFFSET (Data.Address16.Granularity),
+    {ACPI_RSC_MOVE16,   ACPI_RS_OFFSET (Data.Address16.Address.Granularity),
                         AML_OFFSET (Address16.Granularity),
                         5},
 
@@ -189,7 +189,7 @@ ACPI_RSCONVERT_INFO     AcpiRsConvertAddress32[5] =
      * Address Translation Offset
      * Address Length
      */
-    {ACPI_RSC_MOVE32,   ACPI_RS_OFFSET (Data.Address32.Granularity),
+    {ACPI_RSC_MOVE32,   ACPI_RS_OFFSET (Data.Address32.Address.Granularity),
                         AML_OFFSET (Address32.Granularity),
                         5},
 
@@ -229,7 +229,7 @@ ACPI_RSCONVERT_INFO     AcpiRsConvertAddress64[5] =
      * Address Translation Offset
      * Address Length
      */
-    {ACPI_RSC_MOVE64,   ACPI_RS_OFFSET (Data.Address64.Granularity),
+    {ACPI_RSC_MOVE64,   ACPI_RS_OFFSET (Data.Address64.Address.Granularity),
                         AML_OFFSET (Address64.Granularity),
                         5},
 
@@ -275,7 +275,7 @@ ACPI_RSCONVERT_INFO     AcpiRsConvertExtAddress64[5] =
      * Address Length
      * Type-Specific Attribute
      */
-    {ACPI_RSC_MOVE64,   ACPI_RS_OFFSET (Data.ExtAddress64.Granularity),
+    {ACPI_RSC_MOVE64,   ACPI_RS_OFFSET (Data.ExtAddress64.Address.Granularity),
                         AML_OFFSET (ExtAddress64.Granularity),
                         6}
 };

--- a/source/components/resources/rsdump.c
+++ b/source/components/resources/rsdump.c
@@ -469,6 +469,7 @@ AcpiRsDumpAddressCommon (
 }
 
 
+#ifdef ACPI_EXEC_APP
 /*******************************************************************************
  *
  * FUNCTION:    AcpiRsDumpResourceList
@@ -592,6 +593,7 @@ AcpiRsDumpIrqList (
                         PrtElement, PrtElement->Length);
     }
 }
+#endif
 
 
 /*******************************************************************************

--- a/source/components/resources/rsdumpinfo.c
+++ b/source/components/resources/rsdumpinfo.c
@@ -233,11 +233,12 @@ ACPI_RSDUMP_INFO        AcpiRsDumpAddress16[8] =
 {
     {ACPI_RSD_TITLE,    ACPI_RSD_TABLE_SIZE (AcpiRsDumpAddress16),          "16-Bit WORD Address Space",NULL},
     {ACPI_RSD_ADDRESS,  0,                                                  NULL,                       NULL},
-    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Granularity),            "Granularity",              NULL},
-    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Minimum),                "Address Minimum",          NULL},
-    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Maximum),                "Address Maximum",          NULL},
-    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.TranslationOffset),      "Translation Offset",       NULL},
-    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.AddressLength),          "Address Length",           NULL},
+    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Address.Granularity),    "Granularity",              NULL},
+    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Address.Minimum),        "Address Minimum",          NULL},
+    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Address.Maximum),        "Address Maximum",          NULL},
+    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Address.TranslationOffset),
+                                                                            "Translation Offset",       NULL},
+    {ACPI_RSD_UINT16,   ACPI_RSD_OFFSET (Address16.Address.AddressLength),  "Address Length",           NULL},
     {ACPI_RSD_SOURCE,   ACPI_RSD_OFFSET (Address16.ResourceSource),         NULL,                       NULL}
 };
 
@@ -245,11 +246,12 @@ ACPI_RSDUMP_INFO        AcpiRsDumpAddress32[8] =
 {
     {ACPI_RSD_TITLE,    ACPI_RSD_TABLE_SIZE (AcpiRsDumpAddress32),         "32-Bit DWORD Address Space", NULL},
     {ACPI_RSD_ADDRESS,  0,                                                  NULL,                       NULL},
-    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Granularity),            "Granularity",              NULL},
-    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Minimum),                "Address Minimum",          NULL},
-    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Maximum),                "Address Maximum",          NULL},
-    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.TranslationOffset),      "Translation Offset",       NULL},
-    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.AddressLength),          "Address Length",           NULL},
+    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Address.Granularity),    "Granularity",              NULL},
+    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Address.Minimum),        "Address Minimum",          NULL},
+    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Address.Maximum),        "Address Maximum",          NULL},
+    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Address.TranslationOffset),
+                                                                            "Translation Offset",       NULL},
+    {ACPI_RSD_UINT32,   ACPI_RSD_OFFSET (Address32.Address.AddressLength),  "Address Length",           NULL},
     {ACPI_RSD_SOURCE,   ACPI_RSD_OFFSET (Address32.ResourceSource),         NULL,                       NULL}
 };
 
@@ -257,11 +259,12 @@ ACPI_RSDUMP_INFO        AcpiRsDumpAddress64[8] =
 {
     {ACPI_RSD_TITLE,    ACPI_RSD_TABLE_SIZE (AcpiRsDumpAddress64),          "64-Bit QWORD Address Space", NULL},
     {ACPI_RSD_ADDRESS,  0,                                                  NULL,                       NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Granularity),            "Granularity",              NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Minimum),                "Address Minimum",          NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Maximum),                "Address Maximum",          NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.TranslationOffset),      "Translation Offset",       NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.AddressLength),          "Address Length",           NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Address.Granularity),    "Granularity",              NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Address.Minimum),        "Address Minimum",          NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Address.Maximum),        "Address Maximum",          NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Address.TranslationOffset),
+                                                                            "Translation Offset",       NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (Address64.Address.AddressLength),  "Address Length",           NULL},
     {ACPI_RSD_SOURCE,   ACPI_RSD_OFFSET (Address64.ResourceSource),         NULL,                       NULL}
 };
 
@@ -269,11 +272,13 @@ ACPI_RSDUMP_INFO        AcpiRsDumpExtAddress64[8] =
 {
     {ACPI_RSD_TITLE,    ACPI_RSD_TABLE_SIZE (AcpiRsDumpExtAddress64),       "64-Bit Extended Address Space", NULL},
     {ACPI_RSD_ADDRESS,  0,                                                  NULL,                       NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Granularity),         "Granularity",              NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Minimum),             "Address Minimum",          NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Maximum),             "Address Maximum",          NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.TranslationOffset),   "Translation Offset",       NULL},
-    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.AddressLength),       "Address Length",           NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Address.Granularity), "Granularity",              NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Address.Minimum),     "Address Minimum",          NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Address.Maximum),     "Address Maximum",          NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Address.TranslationOffset),
+                                                                            "Translation Offset",       NULL},
+    {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.Address.AddressLength),
+                                                                            "Address Length",           NULL},
     {ACPI_RSD_UINT64,   ACPI_RSD_OFFSET (ExtAddress64.TypeSpecific),        "Type-Specific Attribute",  NULL}
 };
 

--- a/source/components/resources/rsxface.c
+++ b/source/components/resources/rsxface.c
@@ -133,11 +133,11 @@
     ACPI_COPY_FIELD(Out, In, MinAddressFixed);           \
     ACPI_COPY_FIELD(Out, In, MaxAddressFixed);           \
     ACPI_COPY_FIELD(Out, In, Info);                      \
-    ACPI_COPY_FIELD(Out, In, Granularity);               \
-    ACPI_COPY_FIELD(Out, In, Minimum);                   \
-    ACPI_COPY_FIELD(Out, In, Maximum);                   \
-    ACPI_COPY_FIELD(Out, In, TranslationOffset);         \
-    ACPI_COPY_FIELD(Out, In, AddressLength);             \
+    ACPI_COPY_FIELD(Out, In, Address.Granularity);       \
+    ACPI_COPY_FIELD(Out, In, Address.Minimum);           \
+    ACPI_COPY_FIELD(Out, In, Address.Maximum);           \
+    ACPI_COPY_FIELD(Out, In, Address.TranslationOffset); \
+    ACPI_COPY_FIELD(Out, In, Address.AddressLength);     \
     ACPI_COPY_FIELD(Out, In, ResourceSource);
 
 

--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -511,11 +511,11 @@ AcpiTbVerifyTempTable (
         if (ACPI_FAILURE (Status))
         {
             ACPI_EXCEPTION ((AE_INFO, AE_NO_MEMORY,
-                "%4.4s " ACPI_PRINTF_UINT
+                "%4.4s 0x%8.8X%8.8X"
                 " Attempted table install failed",
                 AcpiUtValidAcpiName (TableDesc->Signature.Ascii) ?
                     TableDesc->Signature.Ascii : "????",
-                ACPI_FORMAT_TO_UINT (TableDesc->Address)));
+                ACPI_FORMAT_UINT64 (TableDesc->Address)));
             goto InvalidateAndExit;
         }
     }

--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -193,7 +193,8 @@ AcpiTbAcquireTable (
     case ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL:
     case ACPI_TABLE_ORIGIN_EXTERNAL_VIRTUAL:
 
-        Table = ACPI_CAST_PTR (ACPI_TABLE_HEADER, TableDesc->Address);
+        Table = ACPI_CAST_PTR (ACPI_TABLE_HEADER,
+                    ACPI_PHYSADDR_TO_PTR (TableDesc->Address));
         break;
 
     default:
@@ -299,7 +300,8 @@ AcpiTbAcquireTempTable (
     case ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL:
     case ACPI_TABLE_ORIGIN_EXTERNAL_VIRTUAL:
 
-        TableHeader = ACPI_CAST_PTR (ACPI_TABLE_HEADER, Address);
+        TableHeader = ACPI_CAST_PTR (ACPI_TABLE_HEADER,
+                        ACPI_PHYSADDR_TO_PTR (Address));
         if (!TableHeader)
         {
             return (AE_NO_MEMORY);

--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -603,21 +603,24 @@ AcpiTbResizeRootTableList (
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiTbGetNextRootIndex
+ * FUNCTION:    AcpiTbGetNextTableDescriptor
  *
  * PARAMETERS:  TableIndex          - Where table index is returned
+ *              TableDesc           - Where table descriptor is returned
  *
- * RETURN:      Status and table index.
+ * RETURN:      Status and table index/descriptor.
  *
  * DESCRIPTION: Allocate a new ACPI table entry to the global table list
  *
  ******************************************************************************/
 
 ACPI_STATUS
-AcpiTbGetNextRootIndex (
-    UINT32                  *TableIndex)
+AcpiTbGetNextTableDescriptor (
+    UINT32                  *TableIndex,
+    ACPI_TABLE_DESC         **TableDesc)
 {
     ACPI_STATUS             Status;
+    UINT32                  i;
 
 
     /* Ensure that there is room for the table in the Root Table List */
@@ -632,8 +635,18 @@ AcpiTbGetNextRootIndex (
         }
     }
 
-    *TableIndex = AcpiGbl_RootTableList.CurrentTableCount;
+    i = AcpiGbl_RootTableList.CurrentTableCount;
     AcpiGbl_RootTableList.CurrentTableCount++;
+
+    if (TableIndex)
+    {
+        *TableIndex = i;
+    }
+    if (TableDesc)
+    {
+        *TableDesc = &AcpiGbl_RootTableList.Tables[i];
+    }
+
     return (AE_OK);
 }
 

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -531,11 +531,11 @@ FinishOverride:
         return;
     }
 
-    ACPI_INFO ((AE_INFO, "%4.4s " ACPI_PRINTF_UINT
-        " %s table override, new table: " ACPI_PRINTF_UINT,
+    ACPI_INFO ((AE_INFO, "%4.4s 0x%8.8X%8.8X"
+        " %s table override, new table: 0x%8.8X%8.8X",
         OldTableDesc->Signature.Ascii,
-        ACPI_FORMAT_TO_UINT (OldTableDesc->Address),
-        OverrideType, ACPI_FORMAT_TO_UINT (NewTableDesc.Address)));
+        ACPI_FORMAT_UINT64 (OldTableDesc->Address),
+        OverrideType, ACPI_FORMAT_UINT64 (NewTableDesc.Address)));
 
     /* We can now uninstall the original table */
 

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -447,7 +447,7 @@ AcpiTbInstallStandardTable (
 
     /* Add the table to the global root table list */
 
-    Status = AcpiTbGetNextRootIndex (&i);
+    Status = AcpiTbGetNextTableDescriptor (&i, NULL);
     if (ACPI_FAILURE (Status))
     {
         goto ReleaseAndExit;
@@ -551,49 +551,6 @@ FinishOverride:
     /* Release the temporary table descriptor */
 
     AcpiTbReleaseTempTable (&NewTableDesc);
-}
-
-
-/*******************************************************************************
- *
- * FUNCTION:    AcpiTbStoreTable
- *
- * PARAMETERS:  Address             - Table address
- *              Table               - Table header
- *              Length              - Table length
- *              Flags               - Install flags
- *              TableIndex          - Where the table index is returned
- *
- * RETURN:      Status and table index.
- *
- * DESCRIPTION: Add an ACPI table to the global table list
- *
- ******************************************************************************/
-
-ACPI_STATUS
-AcpiTbStoreTable (
-    ACPI_PHYSICAL_ADDRESS   Address,
-    ACPI_TABLE_HEADER       *Table,
-    UINT32                  Length,
-    UINT8                   Flags,
-    UINT32                  *TableIndex)
-{
-    ACPI_STATUS             Status;
-    ACPI_TABLE_DESC         *TableDesc;
-
-
-    Status = AcpiTbGetNextRootIndex (TableIndex);
-    if (ACPI_FAILURE (Status))
-    {
-        return (Status);
-    }
-
-    /* Initialize added table */
-
-    TableDesc = &AcpiGbl_RootTableList.Tables[*TableIndex];
-    AcpiTbInitTableDescriptor (TableDesc, Address, Flags, Table);
-    TableDesc->Pointer = Table;
-    return (AE_OK);
 }
 
 

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -274,7 +274,7 @@ AcpiTbInstallFixedTable (
     if (ACPI_FAILURE (Status))
     {
         ACPI_ERROR ((AE_INFO, "Could not acquire table length at %p",
-            ACPI_CAST_PTR (void, Address)));
+            ACPI_PHYSADDR_TO_PTR (Address)));
         return_ACPI_STATUS (Status);
     }
 
@@ -341,7 +341,7 @@ AcpiTbInstallStandardTable (
     if (ACPI_FAILURE (Status))
     {
         ACPI_ERROR ((AE_INFO, "Could not acquire table length at %p",
-            ACPI_CAST_PTR (void, Address)));
+            ACPI_PHYSADDR_TO_PTR (Address)));
         return_ACPI_STATUS (Status);
     }
 
@@ -354,7 +354,7 @@ AcpiTbInstallStandardTable (
         ACPI_COMPARE_NAME (&NewTableDesc.Signature, ACPI_SIG_SSDT))
     {
         ACPI_INFO ((AE_INFO, "Ignoring installation of %4.4s at %p",
-            NewTableDesc.Signature.Ascii, ACPI_CAST_PTR (void, Address)));
+            NewTableDesc.Signature.Ascii, ACPI_PHYSADDR_TO_PTR (Address)));
         goto ReleaseAndExit;
     }
 
@@ -630,7 +630,7 @@ AcpiTbUninstallTable (
     if ((TableDesc->Flags & ACPI_TABLE_ORIGIN_MASK) ==
         ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL)
     {
-        ACPI_FREE (ACPI_CAST_PTR (void, TableDesc->Address));
+        ACPI_FREE (ACPI_PHYSADDR_TO_PTR (TableDesc->Address));
     }
 
     TableDesc->Address = ACPI_PTR_TO_PHYSADDR (NULL);

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -440,7 +440,6 @@ AcpiTbInstallStandardTable (
                  */
                 AcpiTbUninstallTable (&NewTableDesc);
                 *TableIndex = i;
-               (void) AcpiUtReleaseMutex (ACPI_MTX_TABLES);
                 return_ACPI_STATUS (AE_OK);
             }
         }

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -273,8 +273,8 @@ AcpiTbInstallFixedTable (
                 ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL);
     if (ACPI_FAILURE (Status))
     {
-        ACPI_ERROR ((AE_INFO, "Could not acquire table length at %p",
-            ACPI_PHYSADDR_TO_PTR (Address)));
+        ACPI_ERROR ((AE_INFO, "Could not acquire table length at %8.8X%8.8X",
+            ACPI_FORMAT_UINT64 (Address)));
         return_ACPI_STATUS (Status);
     }
 
@@ -340,8 +340,8 @@ AcpiTbInstallStandardTable (
     Status = AcpiTbAcquireTempTable (&NewTableDesc, Address, Flags);
     if (ACPI_FAILURE (Status))
     {
-        ACPI_ERROR ((AE_INFO, "Could not acquire table length at %p",
-            ACPI_PHYSADDR_TO_PTR (Address)));
+        ACPI_ERROR ((AE_INFO, "Could not acquire table length at %8.8X%8.8X",
+            ACPI_FORMAT_UINT64 (Address)));
         return_ACPI_STATUS (Status);
     }
 
@@ -353,8 +353,8 @@ AcpiTbInstallStandardTable (
         AcpiGbl_DisableSsdtTableInstall &&
         ACPI_COMPARE_NAME (&NewTableDesc.Signature, ACPI_SIG_SSDT))
     {
-        ACPI_INFO ((AE_INFO, "Ignoring installation of %4.4s at %p",
-            NewTableDesc.Signature.Ascii, ACPI_PHYSADDR_TO_PTR (Address)));
+        ACPI_INFO ((AE_INFO, "Ignoring installation of %4.4s at %8.8X%8.8X",
+            NewTableDesc.Signature.Ascii, ACPI_FORMAT_UINT64 (Address)));
         goto ReleaseAndExit;
     }
 

--- a/source/components/tables/tbprint.c
+++ b/source/components/tables/tbprint.c
@@ -216,18 +216,12 @@ AcpiTbPrintTableHeader (
     ACPI_TABLE_HEADER       LocalHeader;
 
 
-    /*
-     * The reason that we use ACPI_PRINTF_UINT and ACPI_FORMAT_TO_UINT is to
-     * support both 32-bit and 64-bit hosts/addresses in a consistent manner.
-     * The %p specifier does not emit uniform output on all hosts. On some,
-     * leading zeros are not supported.
-     */
     if (ACPI_COMPARE_NAME (Header->Signature, ACPI_SIG_FACS))
     {
         /* FACS only has signature and length fields */
 
-        ACPI_INFO ((AE_INFO, "%-4.4s " ACPI_PRINTF_UINT " %06X",
-            Header->Signature, ACPI_FORMAT_TO_UINT (Address),
+        ACPI_INFO ((AE_INFO, "%-4.4s 0x%8.8X%8.8X %06X",
+            Header->Signature, ACPI_FORMAT_UINT64 (Address),
             Header->Length));
     }
     else if (ACPI_VALIDATE_RSDP_SIG (Header->Signature))
@@ -238,8 +232,8 @@ AcpiTbPrintTableHeader (
             ACPI_CAST_PTR (ACPI_TABLE_RSDP, Header)->OemId, ACPI_OEM_ID_SIZE);
         AcpiTbFixString (LocalHeader.OemId, ACPI_OEM_ID_SIZE);
 
-        ACPI_INFO ((AE_INFO, "RSDP " ACPI_PRINTF_UINT " %06X (v%.2d %-6.6s)",
-            ACPI_FORMAT_TO_UINT (Address),
+        ACPI_INFO ((AE_INFO, "RSDP 0x%8.8X%8.8X %06X (v%.2d %-6.6s)",
+            ACPI_FORMAT_UINT64 (Address),
             (ACPI_CAST_PTR (ACPI_TABLE_RSDP, Header)->Revision > 0) ?
                 ACPI_CAST_PTR (ACPI_TABLE_RSDP, Header)->Length : 20,
             ACPI_CAST_PTR (ACPI_TABLE_RSDP, Header)->Revision,
@@ -252,9 +246,9 @@ AcpiTbPrintTableHeader (
         AcpiTbCleanupTableHeader (&LocalHeader, Header);
 
         ACPI_INFO ((AE_INFO,
-            "%-4.4s " ACPI_PRINTF_UINT
+            "%-4.4s 0x%8.8X%8.8X"
             " %06X (v%.2d %-6.6s %-8.8s %08X %-4.4s %08X)",
-            LocalHeader.Signature, ACPI_FORMAT_TO_UINT (Address),
+            LocalHeader.Signature, ACPI_FORMAT_UINT64 (Address),
             LocalHeader.Length, LocalHeader.Revision, LocalHeader.OemId,
             LocalHeader.OemTableId, LocalHeader.OemRevision,
             LocalHeader.AslCompilerId, LocalHeader.AslCompilerRevision));

--- a/source/components/tables/tbxfroot.c
+++ b/source/components/tables/tbxfroot.c
@@ -230,7 +230,7 @@ AcpiTbValidateRsdp (
 
 ACPI_STATUS
 AcpiFindRootPointer (
-    ACPI_SIZE               *TableAddress)
+    ACPI_PHYSICAL_ADDRESS   *TableAddress)
 {
     UINT8                   *TablePtr;
     UINT8                   *MemRover;
@@ -290,7 +290,7 @@ AcpiFindRootPointer (
 
             PhysicalAddress += (UINT32) ACPI_PTR_DIFF (MemRover, TablePtr);
 
-            *TableAddress = PhysicalAddress;
+            *TableAddress = (ACPI_PHYSICAL_ADDRESS) PhysicalAddress;
             return_ACPI_STATUS (AE_OK);
         }
     }
@@ -321,7 +321,7 @@ AcpiFindRootPointer (
         PhysicalAddress = (UINT32)
             (ACPI_HI_RSDP_WINDOW_BASE + ACPI_PTR_DIFF (MemRover, TablePtr));
 
-        *TableAddress = PhysicalAddress;
+        *TableAddress = (ACPI_PHYSICAL_ADDRESS) PhysicalAddress;
         return_ACPI_STATUS (AE_OK);
     }
 

--- a/source/components/utilities/utaddress.c
+++ b/source/components/utilities/utaddress.c
@@ -189,10 +189,10 @@ AcpiUtAddAddressRange (
     AcpiGbl_AddressRangeList[SpaceId] = RangeInfo;
 
     ACPI_DEBUG_PRINT ((ACPI_DB_NAMES,
-        "\nAdded [%4.4s] address range: 0x%p-0x%p\n",
+        "\nAdded [%4.4s] address range: 0x%8.8X%8.8X-0x%8.8X%8.8X\n",
         AcpiUtGetNodeName (RangeInfo->RegionNode),
-        ACPI_CAST_PTR (void, Address),
-        ACPI_CAST_PTR (void, RangeInfo->EndAddress)));
+        ACPI_FORMAT_UINT64 (Address),
+        ACPI_FORMAT_UINT64 (RangeInfo->EndAddress)));
 
     (void) AcpiUtReleaseMutex (ACPI_MTX_NAMESPACE);
     return_ACPI_STATUS (AE_OK);
@@ -251,10 +251,10 @@ AcpiUtRemoveAddressRange (
             }
 
             ACPI_DEBUG_PRINT ((ACPI_DB_NAMES,
-                "\nRemoved [%4.4s] address range: 0x%p-0x%p\n",
+                "\nRemoved [%4.4s] address range: 0x%8.8X%8.8X-0x%8.8X%8.8X\n",
                 AcpiUtGetNodeName (RangeInfo->RegionNode),
-                ACPI_CAST_PTR (void, RangeInfo->StartAddress),
-                ACPI_CAST_PTR (void, RangeInfo->EndAddress)));
+                ACPI_FORMAT_UINT64 (RangeInfo->StartAddress),
+                ACPI_FORMAT_UINT64 (RangeInfo->EndAddress)));
 
             ACPI_FREE (RangeInfo);
             return_VOID;
@@ -338,12 +338,12 @@ AcpiUtCheckAddressRange (
                 Pathname = AcpiNsGetExternalPathname (RangeInfo->RegionNode);
 
                 ACPI_WARNING ((AE_INFO,
-                    "%s range 0x%p-0x%p conflicts with OpRegion 0x%p-0x%p (%s)",
+                    "%s range 0x%8.8X%8.8X-0x%8.8X%8.8X conflicts with OpRegion 0x%8.8X%8.8X-0x%8.8X%8.8X (%s)",
                     AcpiUtGetRegionName (SpaceId),
-                    ACPI_CAST_PTR (void, Address),
-                    ACPI_CAST_PTR (void, EndAddress),
-                    ACPI_CAST_PTR (void, RangeInfo->StartAddress),
-                    ACPI_CAST_PTR (void, RangeInfo->EndAddress),
+                    ACPI_FORMAT_UINT64 (Address),
+                    ACPI_FORMAT_UINT64 (EndAddress),
+                    ACPI_FORMAT_UINT64 (RangeInfo->StartAddress),
+                    ACPI_FORMAT_UINT64 (RangeInfo->EndAddress),
                     Pathname));
                 ACPI_FREE (Pathname);
             }

--- a/source/components/utilities/utmisc.c
+++ b/source/components/utilities/utmisc.c
@@ -156,6 +156,7 @@ AcpiUtIsPciRootBridge (
 }
 
 
+#if (defined ACPI_ASL_COMPILER || defined ACPI_EXEC_APP)
 /*******************************************************************************
  *
  * FUNCTION:    AcpiUtIsAmlTable
@@ -186,6 +187,7 @@ AcpiUtIsAmlTable (
 
     return (FALSE);
 }
+#endif
 
 
 /*******************************************************************************

--- a/source/components/utilities/utstate.c
+++ b/source/components/utilities/utstate.c
@@ -122,44 +122,6 @@
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiUtCreatePkgStateAndPush
- *
- * PARAMETERS:  Object          - Object to be added to the new state
- *              Action          - Increment/Decrement
- *              StateList       - List the state will be added to
- *
- * RETURN:      Status
- *
- * DESCRIPTION: Create a new state and push it
- *
- ******************************************************************************/
-
-ACPI_STATUS
-AcpiUtCreatePkgStateAndPush (
-    void                    *InternalObject,
-    void                    *ExternalObject,
-    UINT16                  Index,
-    ACPI_GENERIC_STATE      **StateList)
-{
-    ACPI_GENERIC_STATE       *State;
-
-
-    ACPI_FUNCTION_ENTRY ();
-
-
-    State = AcpiUtCreatePkgState (InternalObject, ExternalObject, Index);
-    if (!State)
-    {
-        return (AE_NO_MEMORY);
-    }
-
-    AcpiUtPushGenericState (StateList, State);
-    return (AE_OK);
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    AcpiUtPushGenericState
  *
  * PARAMETERS:  ListHead            - Head of the state stack

--- a/source/components/utilities/utuuid.c
+++ b/source/components/utilities/utuuid.c
@@ -120,6 +120,7 @@
         ACPI_MODULE_NAME    ("utuuid")
 
 
+#if (defined ACPI_ASL_COMPILER || defined ACPI_EXEC_APP || defined ACPI_HELP_APP)
 /*
  * UUID support functions.
  *
@@ -171,3 +172,4 @@ AcpiUtConvertStringToUuid (
             AcpiUtAsciiCharToHex (InString[AcpiGbl_MapToUuidOffset[i] + 1]);
     }
 }
+#endif

--- a/source/include/acapps.h
+++ b/source/include/acapps.h
@@ -141,15 +141,15 @@
 /* Macros for signons and file headers */
 
 #define ACPI_COMMON_SIGNON(UtilityName) \
-    "\n%s\n%s version %8.8X%s [%s]\n%s\n\n", \
+    "\n%s\n%s version %8.8X%s\n%s\n\n", \
     ACPICA_NAME, \
-    UtilityName, ((UINT32) ACPI_CA_VERSION), ACPI_WIDTH, __DATE__, \
+    UtilityName, ((UINT32) ACPI_CA_VERSION), ACPI_WIDTH, \
     ACPICA_COPYRIGHT
 
 #define ACPI_COMMON_HEADER(UtilityName, Prefix) \
-    "%s%s\n%s%s version %8.8X%s [%s]\n%s%s\n%s\n", \
+    "%s%s\n%s%s version %8.8X%s\n%s%s\n%s\n", \
     Prefix, ACPICA_NAME, \
-    Prefix, UtilityName, ((UINT32) ACPI_CA_VERSION), ACPI_WIDTH, __DATE__, \
+    Prefix, UtilityName, ((UINT32) ACPI_CA_VERSION), ACPI_WIDTH, \
     Prefix, ACPICA_COPYRIGHT, \
     Prefix
 

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -136,22 +136,11 @@
 #define ACPI_SET64(ptr, val)            (*ACPI_CAST64 (ptr) = (UINT64) (val))
 
 /*
- * printf() format helpers. These macros are workarounds for the difficulties
+ * printf() format helper. This macros is a workaround for the difficulties
  * with emitting 64-bit integers and 64-bit pointers with the same code
  * for both 32-bit and 64-bit hosts.
  */
 #define ACPI_FORMAT_UINT64(i)           ACPI_HIDWORD(i), ACPI_LODWORD(i)
-
-#if ACPI_MACHINE_WIDTH == 64
-#define ACPI_FORMAT_NATIVE_UINT(i)      ACPI_FORMAT_UINT64(i)
-#define ACPI_FORMAT_TO_UINT(i)          ACPI_FORMAT_UINT64(i)
-#define ACPI_PRINTF_UINT                 "0x%8.8X%8.8X"
-
-#else
-#define ACPI_FORMAT_NATIVE_UINT(i)      0, (UINT32) (i)
-#define ACPI_FORMAT_TO_UINT(i)          (UINT32) (i)
-#define ACPI_PRINTF_UINT                 "0x%8.8X"
-#endif
 
 
 /*

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -575,7 +575,7 @@ AcpiReallocateRootTable (
 ACPI_EXTERNAL_RETURN_STATUS (
 ACPI_STATUS
 AcpiFindRootPointer (
-    ACPI_SIZE               *RsdpAddress))
+    ACPI_PHYSICAL_ADDRESS   *RsdpAddress))
 
 ACPI_EXTERNAL_RETURN_STATUS (
 ACPI_STATUS

--- a/source/include/acresrc.h
+++ b/source/include/acresrc.h
@@ -427,6 +427,7 @@ AcpiRsSetResourceLength (
 /*
  * rsdump
  */
+#ifdef ACPI_EXEC_APP
 void
 AcpiRsDumpResourceList (
     ACPI_RESOURCE           *Resource);
@@ -434,6 +435,7 @@ AcpiRsDumpResourceList (
 void
 AcpiRsDumpIrqList (
     UINT8                   *RouteTable);
+#endif
 
 
 /*

--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -417,6 +417,36 @@ typedef struct acpi_resource_source
     UINT8                           MaxAddressFixed; \
     ACPI_RESOURCE_ATTRIBUTE         Info;
 
+typedef struct acpi_address16_attribute
+{
+    UINT16                          Granularity;
+    UINT16                          Minimum;
+    UINT16                          Maximum;
+    UINT16                          TranslationOffset;
+    UINT16                          AddressLength;
+
+} ACPI_ADDRESS16_ATTRIBUTE;
+
+typedef struct acpi_address32_attribute
+{
+    UINT32                          Granularity;
+    UINT32                          Minimum;
+    UINT32                          Maximum;
+    UINT32                          TranslationOffset;
+    UINT32                          AddressLength;
+
+} ACPI_ADDRESS32_ATTRIBUTE;
+
+typedef struct acpi_address64_attribute
+{
+    UINT64                          Granularity;
+    UINT64                          Minimum;
+    UINT64                          Maximum;
+    UINT64                          TranslationOffset;
+    UINT64                          AddressLength;
+
+} ACPI_ADDRESS64_ATTRIBUTE;
+
 typedef struct acpi_resource_address
 {
     ACPI_RESOURCE_ADDRESS_COMMON
@@ -426,11 +456,7 @@ typedef struct acpi_resource_address
 typedef struct acpi_resource_address16
 {
     ACPI_RESOURCE_ADDRESS_COMMON
-    UINT16                          Granularity;
-    UINT16                          Minimum;
-    UINT16                          Maximum;
-    UINT16                          TranslationOffset;
-    UINT16                          AddressLength;
+    ACPI_ADDRESS16_ATTRIBUTE        Address;
     ACPI_RESOURCE_SOURCE            ResourceSource;
 
 } ACPI_RESOURCE_ADDRESS16;
@@ -438,11 +464,7 @@ typedef struct acpi_resource_address16
 typedef struct acpi_resource_address32
 {
     ACPI_RESOURCE_ADDRESS_COMMON
-    UINT32                          Granularity;
-    UINT32                          Minimum;
-    UINT32                          Maximum;
-    UINT32                          TranslationOffset;
-    UINT32                          AddressLength;
+    ACPI_ADDRESS32_ATTRIBUTE        Address;
     ACPI_RESOURCE_SOURCE            ResourceSource;
 
 } ACPI_RESOURCE_ADDRESS32;
@@ -450,11 +472,7 @@ typedef struct acpi_resource_address32
 typedef struct acpi_resource_address64
 {
     ACPI_RESOURCE_ADDRESS_COMMON
-    UINT64                          Granularity;
-    UINT64                          Minimum;
-    UINT64                          Maximum;
-    UINT64                          TranslationOffset;
-    UINT64                          AddressLength;
+    ACPI_ADDRESS64_ATTRIBUTE        Address;
     ACPI_RESOURCE_SOURCE            ResourceSource;
 
 } ACPI_RESOURCE_ADDRESS64;
@@ -463,11 +481,7 @@ typedef struct acpi_resource_extended_address64
 {
     ACPI_RESOURCE_ADDRESS_COMMON
     UINT8                           RevisionID;
-    UINT64                          Granularity;
-    UINT64                          Minimum;
-    UINT64                          Maximum;
-    UINT64                          TranslationOffset;
-    UINT64                          AddressLength;
+    ACPI_ADDRESS64_ATTRIBUTE        Address;
     UINT64                          TypeSpecific;
 
 } ACPI_RESOURCE_EXTENDED_ADDRESS64;

--- a/source/include/actables.h
+++ b/source/include/actables.h
@@ -142,8 +142,9 @@ AcpiTbScanMemoryForRsdp (
  * tbdata - table data structure management
  */
 ACPI_STATUS
-AcpiTbGetNextRootIndex (
-    UINT32                  *TableIndex);
+AcpiTbGetNextTableDescriptor (
+    UINT32                  *TableIndex,
+    ACPI_TABLE_DESC         **TableDesc);
 
 void
 AcpiTbInitTableDescriptor (
@@ -243,14 +244,6 @@ AcpiTbInstallStandardTable (
     UINT8                   Flags,
     BOOLEAN                 Reload,
     BOOLEAN                 Override,
-    UINT32                  *TableIndex);
-
-ACPI_STATUS
-AcpiTbStoreTable (
-    ACPI_PHYSICAL_ADDRESS   Address,
-    ACPI_TABLE_HEADER       *Table,
-    UINT32                  Length,
-    UINT8                   Flags,
     UINT32                  *TableIndex);
 
 void

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -273,8 +273,28 @@ typedef int                             INT32;
 
 typedef INT32                           ACPI_NATIVE_INT;
 typedef UINT32                          ACPI_SIZE;
+
+#ifdef ACPI_32BIT_PHYSICAL_ADDRESS
+
+/*
+ * OSPMs can define this to shrink the size of the structures for 32-bit
+ * none PAE environment. ASL compiler may always define this to generate
+ * 32-bit OSPM compliant tables.
+ */
 typedef UINT32                          ACPI_IO_ADDRESS;
 typedef UINT32                          ACPI_PHYSICAL_ADDRESS;
+
+#else /* ACPI_32BIT_PHYSICAL_ADDRESS */
+
+/*
+ * It is reported that, after some calculations, the physical addresses can
+ * wrap over the 32-bit boundary on 32-bit PAE environment.
+ * https://bugzilla.kernel.org/show_bug.cgi?id=87971
+ */
+typedef UINT64                          ACPI_IO_ADDRESS;
+typedef UINT64                          ACPI_PHYSICAL_ADDRESS;
+
+#endif /* ACPI_32BIT_PHYSICAL_ADDRESS */
 
 #define ACPI_MAX_PTR                    ACPI_UINT32_MAX
 #define ACPI_SIZE_MAX                   ACPI_UINT32_MAX

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -812,23 +812,26 @@ typedef UINT32                          ACPI_EVENT_TYPE;
  * The encoding of ACPI_EVENT_STATUS is illustrated below.
  * Note that a set bit (1) indicates the property is TRUE
  * (e.g. if bit 0 is set then the event is enabled).
- * +-------------+-+-+-+-+
- * |   Bits 31:4 |3|2|1|0|
- * +-------------+-+-+-+-+
- *          |     | | | |
- *          |     | | | +- Enabled?
- *          |     | | +--- Enabled for wake?
- *          |     | +----- Set?
- *          |     +------- Has a handler?
- *          +------------- <Reserved>
+ * +-------------+-+-+-+-+-+
+ * |   Bits 31:5 |4|3|2|1|0|
+ * +-------------+-+-+-+-+-+
+ *          |     | | | | |
+ *          |     | | | | +- Enabled?
+ *          |     | | | +--- Enabled for wake?
+ *          |     | | +----- Status bit set?
+ *          |     | +------- Enable bit set?
+ *          |     +--------- Has a handler?
+ *          +--------------- <Reserved>
  */
 typedef UINT32                          ACPI_EVENT_STATUS;
 
 #define ACPI_EVENT_FLAG_DISABLED        (ACPI_EVENT_STATUS) 0x00
 #define ACPI_EVENT_FLAG_ENABLED         (ACPI_EVENT_STATUS) 0x01
 #define ACPI_EVENT_FLAG_WAKE_ENABLED    (ACPI_EVENT_STATUS) 0x02
-#define ACPI_EVENT_FLAG_SET             (ACPI_EVENT_STATUS) 0x04
-#define ACPI_EVENT_FLAG_HAS_HANDLER     (ACPI_EVENT_STATUS) 0x08
+#define ACPI_EVENT_FLAG_STATUS_SET      (ACPI_EVENT_STATUS) 0x04
+#define ACPI_EVENT_FLAG_ENABLE_SET      (ACPI_EVENT_STATUS) 0x08
+#define ACPI_EVENT_FLAG_HAS_HANDLER     (ACPI_EVENT_STATUS) 0x10
+#define ACPI_EVENT_FLAG_SET             ACPI_EVENT_FLAG_STATUS_SET
 
 /* Actions for AcpiSetGpe, AcpiGpeWakeup, AcpiHwLowSetGpe */
 

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -854,13 +854,6 @@ AcpiUtCreateUpdateStateAndPush (
     UINT16                  Action,
     ACPI_GENERIC_STATE      **StateList);
 
-ACPI_STATUS
-AcpiUtCreatePkgStateAndPush (
-    void                    *InternalObject,
-    void                    *ExternalObject,
-    UINT16                  Index,
-    ACPI_GENERIC_STATE      **StateList);
-
 ACPI_GENERIC_STATE *
 AcpiUtCreateControlState (
     void);

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -795,6 +795,12 @@ const ACPI_PREDEFINED_INFO *
 AcpiUtMatchPredefinedMethod (
     char                        *Name);
 
+void
+AcpiUtGetExpectedReturnTypes (
+    char                    *Buffer,
+    UINT32                  ExpectedBtypes);
+
+#if (defined ACPI_ASL_COMPILER || defined ACPI_HELP_APP)
 const ACPI_PREDEFINED_INFO *
 AcpiUtMatchResourceName (
     char                        *Name);
@@ -805,15 +811,11 @@ AcpiUtDisplayPredefinedMethod (
     const ACPI_PREDEFINED_INFO  *ThisName,
     BOOLEAN                     MultiLine);
 
-void
-AcpiUtGetExpectedReturnTypes (
-    char                    *Buffer,
-    UINT32                  ExpectedBtypes);
-
 UINT32
 AcpiUtGetResourceBitWidth (
     char                    *Buffer,
     UINT16                  Types);
+#endif
 
 
 /*
@@ -892,9 +894,11 @@ BOOLEAN
 AcpiUtIsPciRootBridge (
     char                    *Id);
 
+#if (defined ACPI_ASL_COMPILER || defined ACPI_EXEC_APP)
 BOOLEAN
 AcpiUtIsAmlTable (
     ACPI_TABLE_HEADER       *Table);
+#endif
 
 ACPI_STATUS
 AcpiUtWalkPackageTree (
@@ -983,6 +987,7 @@ void
 AcpiUtStrupr (
     char                    *SrcString);
 
+#ifdef ACPI_ASL_COMPILER
 void
 AcpiUtStrlwr (
     char                    *SrcString);
@@ -991,6 +996,7 @@ int
 AcpiUtStricmp (
     char                    *String1,
     char                    *String2);
+#endif
 
 ACPI_STATUS
 AcpiUtStrtoul64 (
@@ -1003,9 +1009,11 @@ AcpiUtPrintString (
     char                    *String,
     UINT16                  MaxLength);
 
+#if defined ACPI_ASL_COMPILER || defined ACPI_EXEC_APP
 void
 UtConvertBackslashes (
     char                    *Pathname);
+#endif
 
 BOOLEAN
 AcpiUtValidAcpiName (
@@ -1252,9 +1260,11 @@ AcpiUtFilePrintf (
 /*
  * utuuid -- UUID support functions
  */
+#if (defined ACPI_ASL_COMPILER || defined ACPI_EXEC_APP || defined ACPI_HELP_APP)
 void
 AcpiUtConvertStringToUuid (
     char                    *InString,
     UINT8                   *UuidBuffer);
+#endif
 
 #endif /* _ACUTILS_H */

--- a/source/include/platform/acenv.h
+++ b/source/include/platform/acenv.h
@@ -149,6 +149,7 @@
 #define ACPI_LARGE_NAMESPACE_NODE
 #define ACPI_DATA_TABLE_DISASSEMBLY
 #define ACPI_SINGLE_THREADED
+#define ACPI_32BIT_PHYSICAL_ADDRESS
 #endif
 
 /* AcpiExec configuration. Multithreaded with full AML debugger */

--- a/source/os_specific/service_layers/osunixmap.c
+++ b/source/os_specific/service_layers/osunixmap.c
@@ -238,6 +238,6 @@ AcpiOsUnmapMemory (
 
 
     PageSize = AcpiOsGetPageSize ();
-    Offset = (ACPI_PHYSICAL_ADDRESS) Where % PageSize;
+    Offset = ACPI_TO_INTEGER (Where) % PageSize;
     munmap ((UINT8 *) Where - Offset, (Length + Offset));
 }

--- a/source/tools/acpiexec/aetables.c
+++ b/source/tools/acpiexec/aetables.c
@@ -630,5 +630,5 @@ AcpiOsGetRootPointer (
     void)
 {
 
-    return ((ACPI_PHYSICAL_ADDRESS) &LocalRSDP);
+    return (ACPI_PTR_TO_PHYSADDR (&LocalRSDP));
 }

--- a/source/tools/acpinames/antables.c
+++ b/source/tools/acpinames/antables.c
@@ -368,5 +368,5 @@ AcpiOsGetRootPointer (
     void)
 {
 
-    return ((ACPI_PHYSICAL_ADDRESS) &LocalRSDP);
+    return (ACPI_PTR_TO_PHYSADDR (&LocalRSDP));
 }

--- a/source/tools/acpisrc/astable.c
+++ b/source/tools/acpisrc/astable.c
@@ -244,6 +244,9 @@ ACPI_STRING_TABLE           LinuxDataTypes[] = {
 
 ACPI_TYPED_IDENTIFIER_TABLE           AcpiIdentifiers[] = {
 
+    {"ACPI_ADDRESS16_ATTRIBUTE",            SRC_TYPE_STRUCT},
+    {"ACPI_ADDRESS32_ATTRIBUTE",            SRC_TYPE_STRUCT},
+    {"ACPI_ADDRESS64_ATTRIBUTE",            SRC_TYPE_STRUCT},
     {"ACPI_ADDRESS_RANGE",                  SRC_TYPE_STRUCT},
     {"ACPI_ADR_SPACE_HANDLER",              SRC_TYPE_SIMPLE},
     {"ACPI_ADR_SPACE_SETUP",                SRC_TYPE_SIMPLE},

--- a/source/tools/examples/extables.c
+++ b/source/tools/examples/extables.c
@@ -307,7 +307,7 @@ AcpiOsGetRootPointer (
     void)
 {
 
-    return ((ACPI_PHYSICAL_ADDRESS) RsdpCode);
+    return (ACPI_PTR_TO_PHYSADDR (RsdpCode));
 }
 
 


### PR DESCRIPTION
This patchset includes materials that can be merged during 201501 release cycle.
They include:
1. The GPE patch to return register values.
2. 4 ACPICA community materials.
3. 1 Linux ACPI community material.
4. The 32-bit PAE kernel fix.
5. A script fix detected by kernel bugzilla reporter.

Please review.