### PR TITLE
Upstream part of the NetBSD changes to its platform config

### DIFF
--- a/source/include/platform/acnetbsd.h
+++ b/source/include/platform/acnetbsd.h
@@ -120,6 +120,10 @@
 
 #include "acgcc.h"
 
+#define ACPI_UINTPTR_T          uintptr_t
+#define ACPI_USE_LOCAL_CACHE
+#define ACPI_CAST_PTHREAD_T(x)  ((ACPI_THREAD_ID) ACPI_TO_INTEGER (x))
+
 #ifdef _LP64
 #define ACPI_MACHINE_WIDTH      64
 #else
@@ -129,8 +133,10 @@
 #define COMPILER_DEPENDENT_INT64  int64_t
 #define COMPILER_DEPENDENT_UINT64 uint64_t
 
-#ifdef _KERNEL
+#if defined(_KERNEL) || defined(_STANDALONE)
+#ifdef _KERNEL_OPT
 #include "opt_acpi.h"           /* collect build-time options here */
+#endif /* _KERNEL_OPT */
 
 #include <sys/param.h>
 #include <sys/systm.h>
@@ -160,15 +166,10 @@
 #endif /* DDB */
 #endif /* ACPI_DEBUG */
 
-static __inline int
-isprint(int ch)
-{
-        return(isspace(ch) || isascii(ch));
-}
-
-#else /* _KERNEL */
+#else /* defined(_KERNEL) || defined(_STANDALONE) */
 
 #include <ctype.h>
+#include <stdint.h>
 
 /* Not building kernel code, so use libc */
 #define ACPI_USE_STANDARD_HEADERS
@@ -179,7 +180,7 @@ isprint(int ch)
 /* XXX */
 #define __inline inline
 
-#endif /* _KERNEL */
+#endif /* defined(_KERNEL) || defined(_STANDALONE) */
 
 /* Always use NetBSD code over our local versions */
 #define ACPI_USE_SYSTEM_CLIBRARY


### PR DESCRIPTION
The downstram NetBSD version for the reference:
http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/external/bsd/acpica/dist/include/platform/acnetbsd.h

First test pull request for acpica.
The intention is to push all improvements upstream and reduce diff between acpica found in the NetBSD sources and current git release.