### PR TITLE
Fix invalid free

### DIFF
--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -414,7 +414,6 @@ AdAmlDisassemble (
         {
             fprintf (stderr, "Could not open output file %s\n", DisasmFilename);
             Status = AE_ERROR;
-            ACPI_FREE (DisasmFilename);
             goto Cleanup;
         }
 


### PR DESCRIPTION
Fixes a crash in case DisasmFilename can't be opened.
DisasmFilename is allocated from the string cache, it should not be
free()d.