### PR TITLE
acpidump: Allow customized tables to be dumped without accessing /dev…

### DIFF
--- a/source/os_specific/service_layers/oslinuxtbl.c
+++ b/source/os_specific/service_layers/oslinuxtbl.c
@@ -758,68 +758,68 @@ OslTableInitialize (
         return (AE_OK);
     }
 
-    /* Get RSDP from memory */
-
-    Status = OslLoadRsdp ();
-    if (ACPI_FAILURE (Status))
-    {
-        return (Status);
-    }
-
-    /* Get XSDT from memory */
-
-    if (Gbl_Rsdp.Revision && !Gbl_DoNotDumpXsdt)
-    {
-        if (Gbl_Xsdt)
-        {
-            free (Gbl_Xsdt);
-            Gbl_Xsdt = NULL;
-        }
-
-        Gbl_Revision = 2;
-        Status = OslGetBiosTable (ACPI_SIG_XSDT, 0,
-            ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Xsdt), &Address);
-        if (ACPI_FAILURE (Status))
-        {
-            return (Status);
-        }
-    }
-
-    /* Get RSDT from memory */
-
-    if (Gbl_Rsdp.RsdtPhysicalAddress)
-    {
-        if (Gbl_Rsdt)
-        {
-            free (Gbl_Rsdt);
-            Gbl_Rsdt = NULL;
-        }
-
-        Status = OslGetBiosTable (ACPI_SIG_RSDT, 0,
-            ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Rsdt), &Address);
-        if (ACPI_FAILURE (Status))
-        {
-            return (Status);
-        }
-    }
-
-    /* Get FADT from memory */
-
-    if (Gbl_Fadt)
-    {
-        free (Gbl_Fadt);
-        Gbl_Fadt = NULL;
-    }
-
-    Status = OslGetBiosTable (ACPI_SIG_FADT, 0,
-        ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Fadt), &Gbl_FadtAddress);
-    if (ACPI_FAILURE (Status))
-    {
-        return (Status);
-    }
-
     if (!Gbl_DumpCustomizedTables)
     {
+        /* Get RSDP from memory */
+
+        Status = OslLoadRsdp ();
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+
+        /* Get XSDT from memory */
+
+        if (Gbl_Rsdp.Revision && !Gbl_DoNotDumpXsdt)
+        {
+            if (Gbl_Xsdt)
+            {
+                free (Gbl_Xsdt);
+                Gbl_Xsdt = NULL;
+            }
+
+            Gbl_Revision = 2;
+            Status = OslGetBiosTable (ACPI_SIG_XSDT, 0,
+                ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Xsdt), &Address);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+
+        /* Get RSDT from memory */
+
+        if (Gbl_Rsdp.RsdtPhysicalAddress)
+        {
+            if (Gbl_Rsdt)
+            {
+                free (Gbl_Rsdt);
+                Gbl_Rsdt = NULL;
+            }
+
+            Status = OslGetBiosTable (ACPI_SIG_RSDT, 0,
+                ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Rsdt), &Address);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+        }
+
+        /* Get FADT from memory */
+
+        if (Gbl_Fadt)
+        {
+            free (Gbl_Fadt);
+            Gbl_Fadt = NULL;
+        }
+
+        Status = OslGetBiosTable (ACPI_SIG_FADT, 0,
+            ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Fadt), &Gbl_FadtAddress);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+
         /* Add mandatory tables to global table list first */
 
         Status = OslAddTableToList (ACPI_RSDP_NAME, 0);


### PR DESCRIPTION
…/mem.

The /dev/mem can be configured out, in which case, acpidump should still
work with "-c" option as tables can be found in /sys/firmware/acpi/tables.
This patch allows acpidump to work without /dev/mem.
This patch has been tested with "acpidump -c" and "acpidump -c -n FADT".
And it worked as expected. Lv Zheng.

Signed-off-by: Lv Zheng <lv.zheng@intel.com>