### PR TITLE
acpidump: Convert the default behavior to dump from /sys/firmware/acp…

### DIFF
--- a/source/tools/acpidump/acpidump.h
+++ b/source/tools/acpidump/acpidump.h
@@ -139,7 +139,7 @@
 EXTERN BOOLEAN              INIT_GLOBAL (Gbl_SummaryMode, FALSE);
 EXTERN BOOLEAN              INIT_GLOBAL (Gbl_VerboseMode, FALSE);
 EXTERN BOOLEAN              INIT_GLOBAL (Gbl_BinaryMode, FALSE);
-EXTERN BOOLEAN              INIT_GLOBAL (Gbl_DumpCustomizedTables, FALSE);
+EXTERN BOOLEAN              INIT_GLOBAL (Gbl_DumpCustomizedTables, TRUE);
 EXTERN BOOLEAN              INIT_GLOBAL (Gbl_DoNotDumpXsdt, FALSE);
 EXTERN ACPI_FILE            INIT_GLOBAL (Gbl_OutputFile, NULL);
 EXTERN char                 INIT_GLOBAL (*Gbl_OutputFilename, NULL);

--- a/source/tools/acpidump/apmain.c
+++ b/source/tools/acpidump/apmain.c
@@ -164,7 +164,7 @@ UINT32                      CurrentAction = 0;
 
 
 #define AP_UTILITY_NAME             "ACPI Binary Table Dump Utility"
-#define AP_SUPPORTED_OPTIONS        "?a:bcf:hn:o:r:svxz"
+#define AP_SUPPORTED_OPTIONS        "?a:bc:f:hn:o:r:svxz"
 
 
 /******************************************************************************
@@ -183,7 +183,6 @@ ApDisplayUsage (
     ACPI_USAGE_HEADER ("acpidump [options]");
 
     ACPI_OPTION ("-b",                      "Dump tables to binary files");
-    ACPI_OPTION ("-c",                      "Dump customized tables");
     ACPI_OPTION ("-h -?",                   "This help message");
     ACPI_OPTION ("-o <File>",               "Redirect output to file");
     ACPI_OPTION ("-r <Address>",            "Dump tables from specified RSDP");
@@ -194,6 +193,7 @@ ApDisplayUsage (
     ACPI_USAGE_TEXT ("\nTable Options:\n");
 
     ACPI_OPTION ("-a <Address>",            "Get table via a physical address");
+    ACPI_OPTION ("-c <on|off>",             "Turning on/off customized table dumping");
     ACPI_OPTION ("-f <BinaryFile>",         "Get table via a binary file");
     ACPI_OPTION ("-n <Signature>",          "Get table via a name/signature");
     ACPI_OPTION ("-x",                      "Do not use but dump XSDT");
@@ -277,7 +277,20 @@ ApDoOptions (
 
     case 'c':   /* Dump customized tables */
 
-        Gbl_DumpCustomizedTables = TRUE;
+        if (!strcmp (AcpiGbl_Optarg, "on"))
+        {
+            Gbl_DumpCustomizedTables = TRUE;
+        }
+        else if (!strcmp (AcpiGbl_Optarg, "off"))
+        {
+            Gbl_DumpCustomizedTables = FALSE;
+        }
+        else
+        {
+            AcpiLogError ("%s: Cannot handle this switch, please use on|off\n",
+                AcpiGbl_Optarg);
+            return (-1);
+        }
         continue;
 
     case 'h':


### PR DESCRIPTION
…i/tables.

In order to work without any additional option to dump tables when /dev/mem
doesn't exist, this patch switches the default behavior of acpidump to dump
from /sys/firmware/acpi/tables. Reported by Al Stone, Fixed by Lv Zheng.

Reported-by: Al Stone <ahs3@redhat.com>
Signed-off-by: Lv Zheng <lv.zheng@intel.com>