### PR TITLE
iASL: Support POSIX yacc again.

### DIFF
--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -263,8 +263,8 @@ include ../Makefile.rules
 # Function to safely execute yacc
 #
 safe_yacc = \
-	_d=`mktemp -d $(OBJDIR)/$$_f.XXXXXX` &&\
 	_f=`echo $(1) | tr '[:upper:]' '[:lower:]'` &&\
+	_d=`mktemp -d $(OBJDIR)/$$_f.XXXXXX` &&\
 	_t=`basename $(3)` &&\
 	$(YACC) $(YFLAGS) -p$(1) -o$$_d/$$_f.c -d $(2) &&\
 	mv $$_d/$$_f.$${_t\#\#*.} $(3);\

--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -260,10 +260,21 @@ CFLAGS += \
 include ../Makefile.rules
 
 #
+# Function to safely execute yacc
+#
+safe_yacc = \
+	_d=`mktemp -d $(OBJDIR)/$$_f.XXXXXX` &&\
+	_f=`echo $(1) | tr '[:upper:]' '[:lower:]'` &&\
+	_t=`basename $(3)` &&\
+	$(YACC) $(YFLAGS) -p$(1) -o$$_d/$$_f.c -d $(2) &&\
+	mv $$_d/$$_f.$${_t\#\#*.} $(3);\
+	test -d $$_d && rm -fr $$_d
+
+#
 # Macro processing for iASL .y files
 #
 $(OBJDIR)/aslcompiler.y :      $(ASL_PARSER)
-	$(MACROPROC) $(MFLAGS) $(ASL_COMPILER)/aslparser.y > $(OBJDIR)/aslcompiler.y
+	$(MACROPROC) $(MFLAGS) $(ASL_COMPILER)/aslparser.y > $@
 
 #
 # Parser and Lexer - intermediate C files
@@ -271,30 +282,20 @@ $(OBJDIR)/aslcompiler.y :      $(ASL_PARSER)
 $(OBJDIR)/aslcompilerlex.c :   $(ASL_LEXER)
 	$(LEX) $(LFLAGS) -PAslCompiler -o$@ $(ASL_COMPILER)/aslcompiler.l
 
-$(OBJDIR)/aslcompiler.y.h :    $(OBJDIR)/aslcompiler.y
-	$(YACC) $(YFLAGS) -pAslCompiler -o/dev/null --defines=$@ $<
-
-$(OBJDIR)/aslcompilerparse.c : $(OBJDIR)/aslcompiler.y
-	$(YACC) $(YFLAGS) -pAslCompiler -o$@ --defines=/dev/null $<
+$(OBJDIR)/aslcompilerparse.c $(OBJDIR)/aslcompiler.y.h : $(OBJDIR)/aslcompiler.y
+	$(call safe_yacc,AslCompiler,$<,$@)
 
 $(OBJDIR)/dtparserlex.c :      $(ASL_COMPILER)/dtparser.l $(OBJDIR)/dtparser.y.h
 	$(LEX) $(LFLAGS) -PDtParser -o$@ $<
 
-$(OBJDIR)/dtparser.y.h :       $(ASL_COMPILER)/dtparser.y
-	$(YACC) $(YFLAGS) -pDtParser -o/dev/null --defines=$@ $<
-
-$(OBJDIR)/dtparserparse.c :    $(ASL_COMPILER)/dtparser.y
-	$(YACC) $(YFLAGS) -pDtParser -o$@ --defines=/dev/null $<
+$(OBJDIR)/dtparserparse.c $(OBJDIR)/dtparser.y.h :       $(ASL_COMPILER)/dtparser.y
+	$(call safe_yacc,DtParser,$<,$@)
 
 $(OBJDIR)/prparserlex.c :      $(ASL_COMPILER)/prparser.l $(OBJDIR)/prparser.y.h
 	$(LEX) $(LFLAGS) -PPrParser -o$@ $<
 
-$(OBJDIR)/prparser.y.h :       $(ASL_COMPILER)/prparser.y
-	$(YACC) $(YFLAGS) -pPrParser -o/dev/null --defines=$@ $<
-
-$(OBJDIR)/prparserparse.c :    $(ASL_COMPILER)/prparser.y
-	$(YACC) $(YFLAGS) -pPrParser -o$@ --defines=/dev/null $<
-
+$(OBJDIR)/prparserparse.c $(OBJDIR)/prparser.y.h :       $(ASL_COMPILER)/prparser.y
+	$(call safe_yacc,PrParser,$<,$@)
 
 #
 # Parsers and Lexers - final object files


### PR DESCRIPTION
Support for POSIX yacc was broken since d8a0e96. This patch lets us build iasl again with it.