### PR TITLE
Debugger: Cleanup debugging outputs to dump name path without trailin…

### DIFF
--- a/source/components/debugger/dbdisply.c
+++ b/source/components/debugger/dbdisply.c
@@ -404,7 +404,7 @@ AcpiDbDecodeAndDisplayObject (
 DumpNode:
     /* Now dump the NS node */
 
-    Status = AcpiGetName (Node, ACPI_FULL_PATHNAME, &RetBuf);
+    Status = AcpiGetName (Node, ACPI_FULL_PATHNAME_NO_TRAILING, &RetBuf);
     if (ACPI_FAILURE (Status))
     {
         AcpiOsPrintf ("Could not convert name to pathname\n");
@@ -914,7 +914,8 @@ AcpiDbDisplayGpes (
         GpeBlock = GpeXruptInfo->GpeBlockListHead;
         while (GpeBlock)
         {
-            Status = AcpiGetName (GpeBlock->Node, ACPI_FULL_PATHNAME, &RetBuf);
+            Status = AcpiGetName (GpeBlock->Node,
+                        ACPI_FULL_PATHNAME_NO_TRAILING, &RetBuf);
             if (ACPI_FAILURE (Status))
             {
                 AcpiOsPrintf ("Could not convert name to pathname\n");

--- a/source/components/debugger/dbnames.c
+++ b/source/components/debugger/dbnames.c
@@ -457,7 +457,7 @@ AcpiDbWalkAndMatchName (
     /* Get the full pathname to this object */
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
-    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, FALSE);
+    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, TRUE);
     if (ACPI_FAILURE (Status))
     {
         AcpiOsPrintf ("Could Not get pathname for object %p\n", ObjHandle);
@@ -654,7 +654,7 @@ AcpiDbWalkForSpecificObjects (
     /* Get and display the full pathname to this object */
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
-    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, FALSE);
+    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, TRUE);
     if (ACPI_FAILURE (Status))
     {
         AcpiOsPrintf ("Could Not get pathname for object %p\n", ObjHandle);
@@ -958,7 +958,7 @@ AcpiDbBusWalk (
     /* Get the full path to this device object */
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
-    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, FALSE);
+    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, TRUE);
     if (ACPI_FAILURE (Status))
     {
         AcpiOsPrintf ("Could Not get pathname for object %p\n", ObjHandle);

--- a/source/components/dispatcher/dsdebug.c
+++ b/source/components/dispatcher/dsdebug.c
@@ -168,7 +168,7 @@ AcpiDsPrintNodePathname (
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
 
-    Status = AcpiNsHandleToPathname (Node, &Buffer, FALSE);
+    Status = AcpiNsHandleToPathname (Node, &Buffer, TRUE);
     if (ACPI_SUCCESS (Status))
     {
         if (Message)

--- a/source/components/executer/exdump.c
+++ b/source/components/executer/exdump.c
@@ -1112,7 +1112,7 @@ AcpiExDumpReferenceObj (
         AcpiOsPrintf (" %p ", ObjDesc->Reference.Node);
 
         Status = AcpiNsHandleToPathname (ObjDesc->Reference.Node,
-                    &RetBuf, FALSE);
+                    &RetBuf, TRUE);
         if (ACPI_FAILURE (Status))
         {
             AcpiOsPrintf (" Could not convert name to pathname\n");

--- a/source/components/namespace/nsutils.c
+++ b/source/components/namespace/nsutils.c
@@ -162,7 +162,7 @@ AcpiNsPrintNodePathname (
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
 
-    Status = AcpiNsHandleToPathname (Node, &Buffer, FALSE);
+    Status = AcpiNsHandleToPathname (Node, &Buffer, TRUE);
     if (ACPI_SUCCESS (Status))
     {
         if (Message)

--- a/source/components/utilities/utmisc.c
+++ b/source/components/utilities/utmisc.c
@@ -490,7 +490,7 @@ AcpiUtDisplayInitPathname (
     /* Get the full pathname to the node */
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
-    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, FALSE);
+    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, TRUE);
     if (ACPI_FAILURE (Status))
     {
         return;

--- a/source/tools/acpiexec/aeexec.c
+++ b/source/tools/acpiexec/aeexec.c
@@ -737,7 +737,8 @@ AeMiscellaneousTests (
     ReturnBuf.Length = 32;
     ReturnBuf.Pointer = Buffer;
 
-    Status = AcpiGetName (ACPI_ROOT_OBJECT, ACPI_FULL_PATHNAME, &ReturnBuf);
+    Status = AcpiGetName (ACPI_ROOT_OBJECT,
+                ACPI_FULL_PATHNAME_NO_TRAILING, &ReturnBuf);
     AE_CHECK_OK (AcpiGetName, Status);
 
     /* Get Devices */


### PR DESCRIPTION
…g underscores.

It is better to use unified ASL path name to interact with the developers.

There are following AcpiNsBuildNormalizedPathname() users invoking it for
debugging purposes (acpiexec test results are attached):

1. AcpiUtDisplayInitPathname (AcpiNsHandleToPathname):
     ---------------------------------------------
      Initializing Region        \_SB.H_EC.ECF2
     ---------------------------------------------
2. AcpiNsPrintNodePathname (AcpiNsHandleToPathname):
     ---------------------------------------------
     - ex \_SB.H_EC._STA
     Evaluating \_SB.H_EC._STA
     ---------------------------------------------
3. AcpiDsPrintNodePathname (AcpiNsHandleToPathname):
     ---------------------------------------------
     - level 211b console
     - execute \M1
     ...
     **** Exception AE_AML_UNINITIALIZED_ARG during execution of method [\M1] (Node 009CB6B8)
     ---------------------------------------------
4. AcpiExDumpReferenceObj (AcpiNsHandleToPathname):
     ---------------------------------------------
     - dump \_TZ.FAN4._PR0
     ...
     [00] 00835E98 [Object Reference] Type [Named Object] 05 00828878 \_TZ.FN04
     ---------------------------------------------
5. AcpiDbBusWalk (AcpiNsHandleToPathname):
     ---------------------------------------------
     - businfo
     \_SB.PCI0                        Type 6
     ...
     ---------------------------------------------
6. AcpiDbWalkAndMatchName (AcpiNsHandleToPathname):
     ---------------------------------------------
     - find _PR0
                       \_TZ.FAN4._PR0 Package      002D8DF8 01 Elements 01
     ---------------------------------------------
7. AcpiDbWalkForSpecificObjects (AcpiNsHandleToPathname):
     ---------------------------------------------
     - methods
     ...
                       \_SB.PCI0._PRT Method       0026D918 01 Args 0 Len 0005 Aml 0026B199
     ...
     ---------------------------------------------
8. AcpiDbDecodeAndDispalyObject (AcpiGetName):
     ---------------------------------------------
     - gpes
     Block 0 - Info 003AC7B0  DeviceNode 003A0E08 [\_GPE] - FADT-defined GPE block
     ...
     ---------------------------------------------
9. AcpiDbDisplayGpes (AcpiGetName):
     ---------------------------------------------
     - dump \_GPE
     Object (003A0E08) Pathname:  \_GPE
     ---------------------------------------------
10.AeMiscellaneousTests (AcpiGetName):
     No output available

This patch cleans up all of the above usages. Lv Zheng.

Signed-off-by: Lv Zheng <lv.zheng@intel.com>