### PR TITLE
Tables: Remove fixed table indexes.

### DIFF
--- a/generate/msvc/AcpiExec.dsp
+++ b/generate/msvc/AcpiExec.dsp
@@ -534,6 +534,10 @@ SOURCE=..\..\source\components\debugger\dbnames.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\source\components\debugger\dbobject.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\source\COMPONENTS\DEBUGGER\dbstats.c
 # End Source File
 # Begin Source File
@@ -700,10 +704,6 @@ SOURCE=..\..\source\components\disassembler\dmdeferred.c
 # Begin Source File
 
 SOURCE=..\..\source\COMPONENTS\Disassembler\dmnames.c
-# End Source File
-# Begin Source File
-
-SOURCE=..\..\SOURCE\COMPONENTS\disassembler\dmobject.c
 # End Source File
 # Begin Source File
 

--- a/generate/msvc/AcpiSubsystem.dsp
+++ b/generate/msvc/AcpiSubsystem.dsp
@@ -549,10 +549,6 @@ SOURCE=..\..\source\COMPONENTS\Disassembler\dmnames.c
 # End Source File
 # Begin Source File
 
-SOURCE=..\..\SOURCE\COMPONENTS\disassembler\dmobject.c
-# End Source File
-# Begin Source File
-
 SOURCE=..\..\source\COMPONENTS\Disassembler\dmopcode.c
 # End Source File
 # Begin Source File
@@ -618,6 +614,10 @@ SOURCE=..\..\source\components\debugger\dbmethod.c
 # Begin Source File
 
 SOURCE=..\..\source\components\debugger\dbnames.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\source\components\debugger\dbobject.c
 # End Source File
 # Begin Source File
 

--- a/generate/msvc/ApiTest.dsp
+++ b/generate/msvc/ApiTest.dsp
@@ -645,6 +645,10 @@ SOURCE=..\..\source\components\debugger\dbnames.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\source\components\debugger\dbobject.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\source\COMPONENTS\DEBUGGER\dbstats.c
 # End Source File
 # Begin Source File
@@ -866,10 +870,6 @@ SOURCE=..\..\source\components\disassembler\dmdeferred.c
 # Begin Source File
 
 SOURCE=..\..\source\COMPONENTS\Disassembler\dmnames.c
-# End Source File
-# Begin Source File
-
-SOURCE=..\..\SOURCE\COMPONENTS\disassembler\dmobject.c
 # End Source File
 # Begin Source File
 

--- a/generate/msvc/AslCompiler.dsp
+++ b/generate/msvc/AslCompiler.dsp
@@ -602,10 +602,6 @@ SOURCE=..\..\source\COMPONENTS\disassembler\dmnames.c
 # End Source File
 # Begin Source File
 
-SOURCE=..\..\SOURCE\COMPONENTS\disassembler\dmobject.c
-# End Source File
-# Begin Source File
-
 SOURCE=..\..\source\COMPONENTS\disassembler\dmopcode.c
 # End Source File
 # Begin Source File

--- a/source/components/hardware/hwxfsleep.c
+++ b/source/components/hardware/hwxfsleep.c
@@ -241,21 +241,9 @@ AcpiSetFirmwareWakingVector (
 
     ACPI_FUNCTION_TRACE (AcpiSetFirmwareWakingVector);
 
-    /* If Hardware Reduced flag is set, there is no FACS */
-
-    if (AcpiGbl_ReducedHardware)
+    if (AcpiGbl_FACS)
     {
-        return_ACPI_STATUS (AE_OK);
-    }
-
-    if (AcpiGbl_Facs32)
-    {
-        (void) AcpiHwSetFirmwareWakingVector (AcpiGbl_Facs32,
-                    PhysicalAddress, PhysicalAddress64);
-    }
-    if (AcpiGbl_Facs64)
-    {
-        (void) AcpiHwSetFirmwareWakingVector (AcpiGbl_Facs64,
+        (void) AcpiHwSetFirmwareWakingVector (AcpiGbl_FACS,
                     PhysicalAddress, PhysicalAddress64);
     }
 

--- a/source/components/tables/tbfadt.c
+++ b/source/components/tables/tbfadt.c
@@ -448,7 +448,7 @@ AcpiTbParseFadt (
     /* Obtain the DSDT and FACS tables via their addresses within the FADT */
 
     AcpiTbInstallFixedTable ((ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.XDsdt,
-        ACPI_SIG_DSDT, ACPI_TABLE_INDEX_DSDT);
+        ACPI_SIG_DSDT, &AcpiGbl_DsdtIndex);
 
     /* If Hardware Reduced flag is set, there is no FACS */
 
@@ -457,12 +457,12 @@ AcpiTbParseFadt (
         if (AcpiGbl_FADT.Facs)
         {
             AcpiTbInstallFixedTable ((ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.Facs,
-                ACPI_SIG_FACS, ACPI_TABLE_INDEX_FACS);
+                ACPI_SIG_FACS, &AcpiGbl_FacsIndex);
         }
         if (AcpiGbl_FADT.XFacs)
         {
             AcpiTbInstallFixedTable ((ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.XFacs,
-                ACPI_SIG_FACS, ACPI_TABLE_INDEX_X_FACS);
+                ACPI_SIG_FACS, &AcpiGbl_XFacsIndex);
         }
     }
 }

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -180,9 +180,9 @@ AcpiTbCompareTables (
  *
  * FUNCTION:    AcpiTbInstallTableWithOverride
  *
- * PARAMETERS:  TableIndex              - Index into root table array
- *              NewTableDesc            - New table descriptor to install
+ * PARAMETERS:  NewTableDesc            - New table descriptor to install
  *              Override                - Whether override should be performed
+ *              TableIndex              - Where the table index is returned
  *
  * RETURN:      None
  *
@@ -195,12 +195,16 @@ AcpiTbCompareTables (
 
 void
 AcpiTbInstallTableWithOverride (
-    UINT32                  TableIndex,
     ACPI_TABLE_DESC         *NewTableDesc,
-    BOOLEAN                 Override)
+    BOOLEAN                 Override,
+    UINT32                  *TableIndex)
 {
+    UINT32                  i;
+    ACPI_STATUS             Status;
 
-    if (TableIndex >= AcpiGbl_RootTableList.CurrentTableCount)
+
+    Status = AcpiTbGetNextTableDescriptor (&i, NULL);
+    if (ACPI_FAILURE (Status))
     {
         return;
     }
@@ -217,14 +221,18 @@ AcpiTbInstallTableWithOverride (
         AcpiTbOverrideTable (NewTableDesc);
     }
 
-    AcpiTbInitTableDescriptor (&AcpiGbl_RootTableList.Tables[TableIndex],
+    AcpiTbInitTableDescriptor (&AcpiGbl_RootTableList.Tables[i],
         NewTableDesc->Address, NewTableDesc->Flags, NewTableDesc->Pointer);
 
     AcpiTbPrintTableHeader (NewTableDesc->Address, NewTableDesc->Pointer);
 
+    /* This synchronizes AcpiGbl_DsdtIndex */
+
+    *TableIndex = i;
+
     /* Set the global integer width (based upon revision of the DSDT) */
 
-    if (TableIndex == ACPI_TABLE_INDEX_DSDT)
+    if (i == AcpiGbl_DsdtIndex)
     {
         AcpiUtSetIntegerWidth (NewTableDesc->Pointer->Revision);
     }
@@ -238,7 +246,7 @@ AcpiTbInstallTableWithOverride (
  * PARAMETERS:  Address                 - Physical address of DSDT or FACS
  *              Signature               - Table signature, NULL if no need to
  *                                        match
- *              TableIndex              - Index into root table array
+ *              TableIndex              - Where the table index is returned
  *
  * RETURN:      Status
  *
@@ -251,7 +259,7 @@ ACPI_STATUS
 AcpiTbInstallFixedTable (
     ACPI_PHYSICAL_ADDRESS   Address,
     char                    *Signature,
-    UINT32                  TableIndex)
+    UINT32                  *TableIndex)
 {
     ACPI_TABLE_DESC         NewTableDesc;
     ACPI_STATUS             Status;
@@ -286,7 +294,9 @@ AcpiTbInstallFixedTable (
         goto ReleaseAndExit;
     }
 
-    AcpiTbInstallTableWithOverride (TableIndex, &NewTableDesc, TRUE);
+    /* Add the table to the global root table list */
+
+    AcpiTbInstallTableWithOverride (&NewTableDesc, TRUE, TableIndex);
 
 ReleaseAndExit:
 
@@ -447,14 +457,7 @@ AcpiTbInstallStandardTable (
 
     /* Add the table to the global root table list */
 
-    Status = AcpiTbGetNextTableDescriptor (&i, NULL);
-    if (ACPI_FAILURE (Status))
-    {
-        goto ReleaseAndExit;
-    }
-
-    *TableIndex = i;
-    AcpiTbInstallTableWithOverride (i, &NewTableDesc, Override);
+    AcpiTbInstallTableWithOverride (&NewTableDesc, Override, TableIndex);
 
 ReleaseAndExit:
 

--- a/source/components/tables/tbutils.c
+++ b/source/components/tables/tbutils.c
@@ -147,6 +147,8 @@ ACPI_STATUS
 AcpiTbInitializeFacs (
     void)
 {
+    ACPI_TABLE_FACS         *Facs;
+
 
     /* If Hardware Reduced flag is set, there is no FACS */
 
@@ -159,14 +161,14 @@ AcpiTbInitializeFacs (
              (!AcpiGbl_FADT.Facs || !AcpiGbl_Use32BitFacsAddresses))
     {
         (void) AcpiGetTableByIndex (AcpiGbl_XFacsIndex,
-                    ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &AcpiGbl_Facs32));
-        AcpiGbl_FACS = AcpiGbl_Facs32;
+                    ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &Facs));
+        AcpiGbl_FACS = Facs;
     }
     else if (AcpiGbl_FADT.Facs)
     {
         (void) AcpiGetTableByIndex (AcpiGbl_FacsIndex,
-                    ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &AcpiGbl_Facs64));
-        AcpiGbl_FACS = AcpiGbl_Facs64;
+                    ACPI_CAST_INDIRECT_PTR (ACPI_TABLE_HEADER, &Facs));
+        AcpiGbl_FACS = Facs;
     }
 
     /* If there is no FACS, just continue. There was already an error msg */

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -202,10 +202,10 @@ AcpiTbLoadNamespace (
      */
     if (!AcpiGbl_RootTableList.CurrentTableCount ||
         !ACPI_COMPARE_NAME (
-            &(AcpiGbl_RootTableList.Tables[ACPI_TABLE_INDEX_DSDT].Signature),
+            &(AcpiGbl_RootTableList.Tables[AcpiGbl_DsdtIndex].Signature),
             ACPI_SIG_DSDT) ||
          ACPI_FAILURE (AcpiTbValidateTable (
-            &AcpiGbl_RootTableList.Tables[ACPI_TABLE_INDEX_DSDT])))
+            &AcpiGbl_RootTableList.Tables[AcpiGbl_DsdtIndex])))
     {
         Status = AE_NO_ACPI_TABLES;
         goto UnlockAndExit;
@@ -217,7 +217,7 @@ AcpiTbLoadNamespace (
      * array can change dynamically as tables are loaded at run-time. Note:
      * .Pointer field is not validated until after call to AcpiTbValidateTable.
      */
-    AcpiGbl_DSDT = AcpiGbl_RootTableList.Tables[ACPI_TABLE_INDEX_DSDT].Pointer;
+    AcpiGbl_DSDT = AcpiGbl_RootTableList.Tables[AcpiGbl_DsdtIndex].Pointer;
 
     /*
      * Optionally copy the entire DSDT to local memory (instead of simply
@@ -227,7 +227,7 @@ AcpiTbLoadNamespace (
      */
     if (AcpiGbl_CopyDsdtLocally)
     {
-        NewDsdt = AcpiTbCopyDsdt (ACPI_TABLE_INDEX_DSDT);
+        NewDsdt = AcpiTbCopyDsdt (AcpiGbl_DsdtIndex);
         if (NewDsdt)
         {
             AcpiGbl_DSDT = NewDsdt;
@@ -245,7 +245,7 @@ AcpiTbLoadNamespace (
 
     /* Load and parse tables */
 
-    Status = AcpiNsLoadTable (ACPI_TABLE_INDEX_DSDT, AcpiGbl_RootNode);
+    Status = AcpiNsLoadTable (AcpiGbl_DsdtIndex, AcpiGbl_RootNode);
     if (ACPI_FAILURE (Status))
     {
         ACPI_EXCEPTION ((AE_INFO, Status, "[DSDT] table load failed"));

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -137,8 +137,6 @@ ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_XFacsIndex, ACPI_INVALID_TABLE_I
 
 #if (!ACPI_REDUCED_HARDWARE)
 ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_FACS);
-ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_Facs32);
-ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_Facs64);
 
 #endif /* !ACPI_REDUCED_HARDWARE */
 

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -131,6 +131,9 @@ ACPI_GLOBAL (ACPI_TABLE_LIST,           AcpiGbl_RootTableList);
 
 ACPI_GLOBAL (ACPI_TABLE_HEADER *,       AcpiGbl_DSDT);
 ACPI_GLOBAL (ACPI_TABLE_HEADER,         AcpiGbl_OriginalDsdtHeader);
+ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_DsdtIndex, ACPI_INVALID_TABLE_INDEX);
+ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_FacsIndex, ACPI_INVALID_TABLE_INDEX);
+ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_XFacsIndex, ACPI_INVALID_TABLE_INDEX);
 
 #if (!ACPI_REDUCED_HARDWARE)
 ACPI_GLOBAL (ACPI_TABLE_FACS *,         AcpiGbl_FACS);

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -310,11 +310,9 @@ typedef struct acpi_table_list
 #define ACPI_ROOT_ALLOW_RESIZE          (2)
 
 
-/* Predefined (fixed) table indexes */
+/* Predefined table indexes */
 
-#define ACPI_TABLE_INDEX_DSDT           (0)
-#define ACPI_TABLE_INDEX_FACS           (1)
-#define ACPI_TABLE_INDEX_X_FACS         (2)
+#define ACPI_INVALID_TABLE_INDEX        (0xFFFFFFFF)
 
 
 typedef struct acpi_find_context

--- a/source/include/actables.h
+++ b/source/include/actables.h
@@ -308,15 +308,15 @@ AcpiTbCopyDsdt (
 
 void
 AcpiTbInstallTableWithOverride (
-    UINT32                  TableIndex,
     ACPI_TABLE_DESC         *NewTableDesc,
-    BOOLEAN                 Override);
+    BOOLEAN                 Override,
+    UINT32                  *TableIndex);
 
 ACPI_STATUS
 AcpiTbInstallFixedTable (
     ACPI_PHYSICAL_ADDRESS   Address,
     char                    *Signature,
-    UINT32                  TableIndex);
+    UINT32                  *TableIndex);
 
 ACPI_STATUS
 AcpiTbParseRootTable (


### PR DESCRIPTION
The fixed table indexes leave holes in the global table list.
1. One hole can be seen when there is only 1 FACS provided by the BIOS.
2. Tow holes can be seen when it is a reduced hardware platform.
The holes do not break OSPMs but has broken ACPI debugger "tables"
command.

Also the fixed table indexes may make the address of the standard tables
installed earlier than DSDT to be overridden from the global table list.

This patch removes fixed table indexes and make indexes determined by the
table loaders. This can fix all above issues. Lv Zheng.

Signed-off-by: Lv Zheng <lv.zheng@intel.com>