### PR TITLE
Acpica debug stub

### DIFF
--- a/source/components/debugger/dbdisply.c
+++ b/source/components/debugger/dbdisply.c
@@ -815,6 +815,13 @@ AcpiDbDisplayResultObject (
     ACPI_WALK_STATE         *WalkState)
 {
 
+#ifndef ACPI_APPLICATION
+    if (AcpiGbl_DbThreadId != AcpiOsGetThreadId())
+    {
+        return;
+    }
+#endif
+
     /* Only display if single stepping */
 
     if (!AcpiGbl_CmSingleStep)
@@ -846,6 +853,13 @@ AcpiDbDisplayArgumentObject (
     ACPI_OPERAND_OBJECT     *ObjDesc,
     ACPI_WALK_STATE         *WalkState)
 {
+
+#ifndef ACPI_APPLICATION
+    if (AcpiGbl_DbThreadId != AcpiOsGetThreadId())
+    {
+        return;
+    }
+#endif
 
     if (!AcpiGbl_CmSingleStep)
     {

--- a/source/components/debugger/dbxface.c
+++ b/source/components/debugger/dbxface.c
@@ -224,6 +224,40 @@ AcpiDbStartCommand (
 
 /*******************************************************************************
  *
+ * FUNCTION:    AcpiDbSignalBreakPoint
+ *
+ * PARAMETERS:  WalkState       - Current walk
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Called for AML_BREAK_POINT_OP
+ *
+ ******************************************************************************/
+
+void
+AcpiDbSignalBreakPoint (
+    ACPI_WALK_STATE         *WalkState)
+{
+
+#ifndef ACPI_APPLICATION
+    if (AcpiGbl_DbThreadId != AcpiOsGetThreadId ())
+    {
+        return;
+    }
+#endif
+
+    /*
+     * Set the single-step flag. This will cause the debugger (if present)
+     * to break to the console within the AML debugger at the start of the
+     * next AML instruction.
+     */
+    AcpiGbl_CmSingleStep = TRUE;
+    AcpiOsPrintf ("**break** Executed AML BreakPoint opcode\n");
+}
+
+
+/*******************************************************************************
+ *
  * FUNCTION:    AcpiDbSingleStep
  *
  * PARAMETERS:  WalkState       - Current walk

--- a/source/components/dispatcher/dscontrol.c
+++ b/source/components/dispatcher/dscontrol.c
@@ -119,6 +119,7 @@
 #include "amlcode.h"
 #include "acdispat.h"
 #include "acinterp.h"
+#include "acdebug.h"
 
 #define _COMPONENT          ACPI_DISPATCHER
         ACPI_MODULE_NAME    ("dscontrol")
@@ -431,14 +432,7 @@ AcpiDsExecEndControlOp (
 
     case AML_BREAK_POINT_OP:
 
-        /*
-         * Set the single-step flag. This will cause the debugger (if present)
-         * to break to the console within the AML debugger at the start of the
-         * next AML instruction.
-         */
-        ACPI_DEBUGGER_EXEC (AcpiGbl_CmSingleStep = TRUE);
-        ACPI_DEBUGGER_EXEC (
-            AcpiOsPrintf ("**break** Executed AML BreakPoint opcode\n"));
+        AcpiDbSignalBreakPoint (WalkState);
 
         /* Call to the OSL in case OS wants a piece of the action */
 

--- a/source/components/dispatcher/dsutils.c
+++ b/source/components/dispatcher/dsutils.c
@@ -717,8 +717,7 @@ AcpiDsCreateOperand (
             return_ACPI_STATUS (Status);
         }
 
-        ACPI_DEBUGGER_EXEC (
-            AcpiDbDisplayArgumentObject (ObjDesc, WalkState));
+        AcpiDbDisplayArgumentObject (ObjDesc, WalkState);
     }
     else
     {
@@ -757,8 +756,8 @@ AcpiDsCreateOperand (
             ACPI_DEBUG_PRINT ((ACPI_DB_DISPATCH,
                 "Argument previously created, already stacked\n"));
 
-            ACPI_DEBUGGER_EXEC (AcpiDbDisplayArgumentObject (
-                WalkState->Operands [WalkState->NumOperands - 1], WalkState));
+            AcpiDbDisplayArgumentObject (
+                WalkState->Operands [WalkState->NumOperands - 1], WalkState);
 
             /*
              * Use value that was already previously returned
@@ -805,8 +804,7 @@ AcpiDsCreateOperand (
             return_ACPI_STATUS (Status);
         }
 
-        ACPI_DEBUGGER_EXEC (
-            AcpiDbDisplayArgumentObject (ObjDesc, WalkState));
+        AcpiDbDisplayArgumentObject (ObjDesc, WalkState);
     }
 
     return_ACPI_STATUS (AE_OK);

--- a/source/components/dispatcher/dswexec.c
+++ b/source/components/dispatcher/dswexec.c
@@ -265,10 +265,9 @@ Cleanup:
         "Completed a predicate eval=%X Op=%p\n",
         WalkState->ControlState->Common.Value, WalkState->Op));
 
-     /* Break to debugger to display result */
+    /* Break to debugger to display result */
 
-    ACPI_DEBUGGER_EXEC (
-        AcpiDbDisplayResultObject (LocalObjDesc, WalkState));
+    AcpiDbDisplayResultObject (LocalObjDesc, WalkState);
 
     /*
      * Delete the predicate result object (we know that
@@ -494,8 +493,11 @@ AcpiDsExecEndOp (
 
     /* Call debugger for single step support (DEBUG build only) */
 
-    ACPI_DEBUGGER_EXEC (Status = AcpiDbSingleStep (WalkState, Op, OpClass));
-    ACPI_DEBUGGER_EXEC (if (ACPI_FAILURE (Status)) {return_ACPI_STATUS (Status);});
+    Status = AcpiDbSingleStep (WalkState, Op, OpClass);
+    if (ACPI_FAILURE (Status))
+    {
+        return_ACPI_STATUS (Status);
+    }
 
     /* Decode the Opcode Class */
 
@@ -827,8 +829,7 @@ Cleanup:
     {
         /* Break to debugger to display result */
 
-        ACPI_DEBUGGER_EXEC (AcpiDbDisplayResultObject (
-            WalkState->ResultObj,WalkState));
+        AcpiDbDisplayResultObject (WalkState->ResultObj,WalkState);
 
         /*
          * Delete the result op if and only if:

--- a/source/include/acdebug.h
+++ b/source/include/acdebug.h
@@ -163,11 +163,17 @@ typedef struct acpi_db_execute_walk
 /*
  * dbxface - external debugger interfaces
  */
+ACPI_DBR_DEPENDENT_RETURN_OK (
 ACPI_STATUS
 AcpiDbSingleStep (
     ACPI_WALK_STATE         *WalkState,
     ACPI_PARSE_OBJECT       *Op,
-    UINT32                  OpType);
+    UINT32                  OpType))
+
+ACPI_DBR_DEPENDENT_RETURN_VOID (
+void
+AcpiDbSignalBreakPoint (
+    ACPI_WALK_STATE         *WalkState))
 
 
 /*
@@ -362,10 +368,11 @@ AcpiDbDecodeAndDisplayObject (
     char                    *Target,
     char                    *OutputType);
 
+ACPI_DBR_DEPENDENT_RETURN_VOID (
 void
 AcpiDbDisplayResultObject (
     ACPI_OPERAND_OBJECT     *ObjDesc,
-    ACPI_WALK_STATE         *WalkState);
+    ACPI_WALK_STATE         *WalkState))
 
 ACPI_STATUS
 AcpiDbDisplayAllMethods (
@@ -391,10 +398,11 @@ void
 AcpiDbDisplayObjectType (
     char                    *ObjectArg);
 
+ACPI_DBR_DEPENDENT_RETURN_VOID (
 void
 AcpiDbDisplayArgumentObject (
     ACPI_OPERAND_OBJECT     *ObjDesc,
-    ACPI_WALK_STATE         *WalkState);
+    ACPI_WALK_STATE         *WalkState))
 
 
 /*

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -478,18 +478,6 @@
 
 
 /*
- * Some code only gets executed when the debugger is built in.
- * Note that this is entirely independent of whether the
- * DEBUG_PRINT stuff (set by ACPI_DEBUG_OUTPUT) is on, or not.
- */
-#ifdef ACPI_DEBUGGER
-#define ACPI_DEBUGGER_EXEC(a)           a
-#else
-#define ACPI_DEBUGGER_EXEC(a)
-#endif
-
-
-/*
  * Macros used for ACPICA utilities only
  */
 

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -449,6 +449,30 @@ ACPI_GLOBAL (BOOLEAN,               AcpiGbl_SystemAwakeAndRunning);
 #endif /* ACPI_APPLICATION */
 
 
+/*
+ * Debugger prototypes
+ *
+ * All interfaces used by debugger will be configured
+ * out of the ACPICA build unless the ACPI_DEBUGGER
+ * flag is defined.
+ */
+#ifdef ACPI_DEBUGGER
+#define ACPI_DBR_DEPENDENT_RETURN_OK(Prototype) \
+    ACPI_EXTERNAL_RETURN_OK(Prototype)
+
+#define ACPI_DBR_DEPENDENT_RETURN_VOID(Prototype) \
+    ACPI_EXTERNAL_RETURN_VOID(Prototype)
+
+#else
+#define ACPI_DBR_DEPENDENT_RETURN_OK(Prototype) \
+    static ACPI_INLINE Prototype {return(AE_OK);}
+
+#define ACPI_DBR_DEPENDENT_RETURN_VOID(Prototype) \
+    static ACPI_INLINE Prototype {return;}
+
+#endif /* ACPI_DEBUGGER */
+
+
 /*****************************************************************************
  *
  * ACPICA public interface prototypes


### PR DESCRIPTION
Runtime stub mechanism for debugger functions that can be invoked by the rest of the ACPICA world.
So they are interfaces exported by the debugger that can be invoked by the interpreter.
If we do not make them stubs in a correct way, we can see debugger output in the kernel logs.

Thanks
-Lv