### PR TITLE
Acpica init

### DIFF
--- a/source/compiler/aslstubs.c
+++ b/source/compiler/aslstubs.c
@@ -192,6 +192,13 @@ AcpiDsStoreObjectToLocal (
 }
 
 ACPI_STATUS
+AcpiEvInstallRegionHandlers (
+    void)
+{
+    return (AE_OK);
+}
+
+ACPI_STATUS
 AcpiEvQueueNotifyRequest (
     ACPI_NAMESPACE_NODE     *Node,
     UINT32                  NotifyValue)

--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -708,7 +708,7 @@ AcpiEvExecuteRegMethod (
 
     if (RegionObj2->Extra.Method_REG == NULL ||
         RegionObj->Region.Handler == NULL ||
-        !AcpiGbl_RegMethodsEnabled)
+        !AcpiGbl_NamespaceInitialized)
     {
         return_ACPI_STATUS (AE_OK);
     }

--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -171,7 +171,6 @@ AcpiEvInitializeOpRegions (
 
     /* Run the _REG methods for OpRegions in each default address space */
 
-    AcpiGbl_RegMethodsEnabled = TRUE;
     for (i = 0; i < ACPI_NUM_DEFAULT_SPACES; i++)
     {
         /*

--- a/source/components/hardware/hwxfsleep.c
+++ b/source/components/hardware/hwxfsleep.c
@@ -169,7 +169,7 @@ static ACPI_SLEEP_FUNCTIONS         AcpiSleepDispatch[] =
  *              PhysicalAddress     - 32-bit physical address of ACPI real mode
  *                                    entry point
  *              PhysicalAddress64   - 64-bit physical address of ACPI protected
- *                                    entry point
+ *                                    mode entry point
  *
  * RETURN:      Status
  *
@@ -225,7 +225,7 @@ AcpiHwSetFirmwareWakingVector (
  * PARAMETERS:  PhysicalAddress     - 32-bit physical address of ACPI real mode
  *                                    entry point
  *              PhysicalAddress64   - 64-bit physical address of ACPI protected
- *                                    entry point
+ *                                    mode entry point
  *
  * RETURN:      Status
  *

--- a/source/components/namespace/nsinit.c
+++ b/source/components/namespace/nsinit.c
@@ -118,6 +118,7 @@
 #include "acnamesp.h"
 #include "acdispat.h"
 #include "acinterp.h"
+#include "acevents.h"
 
 #define _COMPONENT          ACPI_NAMESPACE
         ACPI_MODULE_NAME    ("nsinit")
@@ -223,7 +224,7 @@ AcpiNsInitializeObjects (
 
 ACPI_STATUS
 AcpiNsInitializeDevices (
-    void)
+    UINT32                  Flags)
 {
     ACPI_STATUS             Status;
     ACPI_DEVICE_WALK_INFO   Info;
@@ -232,75 +233,103 @@ AcpiNsInitializeDevices (
     ACPI_FUNCTION_TRACE (NsInitializeDevices);
 
 
-    /* Init counters */
-
-    Info.DeviceCount = 0;
-    Info.Num_STA = 0;
-    Info.Num_INI = 0;
-
-    ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT,
-        "Initializing Device/Processor/Thermal objects "
-        "and executing _INI/_STA methods:\n"));
-
-    /* Tree analysis: find all subtrees that contain _INI methods */
-
-    Status = AcpiNsWalkNamespace (ACPI_TYPE_ANY, ACPI_ROOT_OBJECT,
-        ACPI_UINT32_MAX, FALSE, AcpiNsFindIniMethods, NULL, &Info, NULL);
-    if (ACPI_FAILURE (Status))
+    if (!(Flags & ACPI_NO_DEVICE_INIT))
     {
-        goto ErrorExit;
-    }
+        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
+            "[Init] Initializing ACPI Devices\n"));
 
-    /* Allocate the evaluation information block */
+        /* Init counters */
 
-    Info.EvaluateInfo = ACPI_ALLOCATE_ZEROED (sizeof (ACPI_EVALUATE_INFO));
-    if (!Info.EvaluateInfo)
-    {
-        Status = AE_NO_MEMORY;
-        goto ErrorExit;
+        Info.DeviceCount = 0;
+        Info.Num_STA = 0;
+        Info.Num_INI = 0;
+
+        ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT,
+            "Initializing Device/Processor/Thermal objects "
+            "and executing _INI/_STA methods:\n"));
+
+        /* Tree analysis: find all subtrees that contain _INI methods */
+
+        Status = AcpiNsWalkNamespace (ACPI_TYPE_ANY, ACPI_ROOT_OBJECT,
+            ACPI_UINT32_MAX, FALSE, AcpiNsFindIniMethods, NULL, &Info, NULL);
+        if (ACPI_FAILURE (Status))
+        {
+            goto ErrorExit;
+        }
+
+        /* Allocate the evaluation information block */
+
+        Info.EvaluateInfo = ACPI_ALLOCATE_ZEROED (sizeof (ACPI_EVALUATE_INFO));
+        if (!Info.EvaluateInfo)
+        {
+            Status = AE_NO_MEMORY;
+            goto ErrorExit;
+        }
+
+        /*
+         * Execute the "global" _INI method that may appear at the root.
+         * This support is provided for Windows compatibility (Vista+) and
+         * is not part of the ACPI specification.
+         */
+        Info.EvaluateInfo->PrefixNode = AcpiGbl_RootNode;
+        Info.EvaluateInfo->RelativePathname = METHOD_NAME__INI;
+        Info.EvaluateInfo->Parameters = NULL;
+        Info.EvaluateInfo->Flags = ACPI_IGNORE_RETURN_VALUE;
+
+        Status = AcpiNsEvaluate (Info.EvaluateInfo);
+        if (ACPI_SUCCESS (Status))
+        {
+            Info.Num_INI++;
+        }
     }
 
     /*
-     * Execute the "global" _INI method that may appear at the root. This
-     * support is provided for Windows compatibility (Vista+) and is not
-     * part of the ACPI specification.
+     * Run all _REG methods
+     *
+     * Note: Any objects accessed by the _REG methods will be automatically
+     * initialized, even if they contain executable AML (see the call to
+     * AcpiNsInitializeObjects below).
      */
-    Info.EvaluateInfo->PrefixNode = AcpiGbl_RootNode;
-    Info.EvaluateInfo->RelativePathname = METHOD_NAME__INI;
-    Info.EvaluateInfo->Parameters = NULL;
-    Info.EvaluateInfo->Flags = ACPI_IGNORE_RETURN_VALUE;
-
-    Status = AcpiNsEvaluate (Info.EvaluateInfo);
-    if (ACPI_SUCCESS (Status))
+    if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
     {
-        Info.Num_INI++;
+        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
+            "[Init] Executing _REG OpRegion methods\n"));
+
+        Status = AcpiEvInitializeOpRegions ();
+        if (ACPI_FAILURE (Status))
+        {
+            goto ErrorExit;
+        }
     }
 
-    /* Walk namespace to execute all _INIs on present devices */
-
-    Status = AcpiNsWalkNamespace (ACPI_TYPE_ANY, ACPI_ROOT_OBJECT,
-        ACPI_UINT32_MAX, FALSE, AcpiNsInitOneDevice, NULL, &Info, NULL);
-
-    /*
-     * Any _OSI requests should be completed by now. If the BIOS has
-     * requested any Windows OSI strings, we will always truncate
-     * I/O addresses to 16 bits -- for Windows compatibility.
-     */
-    if (AcpiGbl_OsiData >= ACPI_OSI_WIN_2000)
+    if (!(Flags & ACPI_NO_DEVICE_INIT))
     {
-        AcpiGbl_TruncateIoAddresses = TRUE;
-    }
+        /* Walk namespace to execute all _INIs on present devices */
 
-    ACPI_FREE (Info.EvaluateInfo);
-    if (ACPI_FAILURE (Status))
-    {
-        goto ErrorExit;
-    }
+        Status = AcpiNsWalkNamespace (ACPI_TYPE_ANY, ACPI_ROOT_OBJECT,
+            ACPI_UINT32_MAX, FALSE, AcpiNsInitOneDevice, NULL, &Info, NULL);
 
-    ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT,
-        "    Executed %u _INI methods requiring %u _STA executions "
-        "(examined %u objects)\n",
-        Info.Num_INI, Info.Num_STA, Info.DeviceCount));
+        /*
+         * Any _OSI requests should be completed by now. If the BIOS has
+         * requested any Windows OSI strings, we will always truncate
+         * I/O addresses to 16 bits -- for Windows compatibility.
+         */
+        if (AcpiGbl_OsiData >= ACPI_OSI_WIN_2000)
+        {
+            AcpiGbl_TruncateIoAddresses = TRUE;
+        }
+
+        ACPI_FREE (Info.EvaluateInfo);
+        if (ACPI_FAILURE (Status))
+        {
+            goto ErrorExit;
+        }
+
+        ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT,
+            "    Executed %u _INI methods requiring %u _STA executions "
+            "(examined %u objects)\n",
+            Info.Num_INI, Info.Num_STA, Info.DeviceCount));
+    }
 
     return_ACPI_STATUS (Status);
 

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -119,6 +119,7 @@
 #include "accommon.h"
 #include "acnamesp.h"
 #include "actables.h"
+#include "acevents.h"
 
 #define _COMPONENT          ACPI_TABLES
         ACPI_MODULE_NAME    ("tbxfload")
@@ -145,6 +146,28 @@ AcpiLoadTables (
 
     ACPI_FUNCTION_TRACE (AcpiLoadTables);
 
+
+    /*
+     * Install the default operation region handlers. These are the
+     * handlers that are defined by the ACPI specification to be
+     * "always accessible" -- namely, SystemMemory, SystemIO, and
+     * PCI_Config. This also means that no _REG methods need to be
+     * run for these address spaces. We need to have these handlers
+     * installed before any AML code can be executed, especially any
+     * module-level code (11/2015).
+     * Note that we allow OSPMs to install their own region handlers
+     * between AcpiInitializeSubsystem() and AcpiLoadTables() to use
+     * their customized default region handlers.
+     */
+    if (AcpiGbl_GroupModuleLevelCode)
+    {
+        Status = AcpiEvInstallRegionHandlers ();
+        if (ACPI_FAILURE (Status) && Status != AE_ALREADY_EXISTS)
+        {
+            ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
+            return_ACPI_STATUS (Status);
+        }
+    }
 
     /* Load the namespace from the tables */
 

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -406,36 +406,15 @@ AcpiInitializeObjects (
         }
     }
 
-    /*
-     * Run all _REG methods
-     *
-     * Note: Any objects accessed by the _REG methods will be automatically
-     * initialized, even if they contain executable AML (see the call to
-     * AcpiNsInitializeObjects below).
-     */
     AcpiGbl_RegMethodsEnabled = TRUE;
-    if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
-    {
-        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
-            "[Init] Executing _REG OpRegion methods\n"));
-
-        Status = AcpiEvInitializeOpRegions ();
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
-    }
 
     /*
-     * Initialize all device objects in the namespace. This runs the device
-     * _STA and _INI methods.
+     * Initialize all device/region objects in the namespace. This runs
+     * the device _STA and _INI methods and region _REG methods.
      */
-    if (!(Flags & ACPI_NO_DEVICE_INIT))
+    if (!(Flags & (ACPI_NO_DEVICE_INIT | ACPI_NO_ADDRESS_SPACE_INIT)))
     {
-        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
-            "[Init] Initializing ACPI Devices\n"));
-
-        Status = AcpiNsInitializeDevices ();
+        Status = AcpiNsInitializeDevices (Flags);
         if (ACPI_FAILURE (Status))
         {
             return_ACPI_STATUS (Status);

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -204,25 +204,6 @@ AcpiInitializeSubsystem (
         return_ACPI_STATUS (Status);
     }
 
-    if (!AcpiGbl_OverrideDefaultRegionHandlers)
-    {
-        /*
-         * Install the default operation region handlers. These are the
-         * handlers that are defined by the ACPI specification to be
-         * "always accessible" -- namely, SystemMemory, SystemIO, and
-         * PCI_Config. This also means that no _REG methods need to be
-         * run for these address spaces. We need to have these handlers
-         * installed before any AML code can be executed, especially any
-         * module-level code (11/2015).
-         */
-        Status = AcpiEvInstallRegionHandlers ();
-        if (ACPI_FAILURE (Status))
-        {
-            ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
-            return_ACPI_STATUS (Status);
-        }
-    }
-
     return_ACPI_STATUS (AE_OK);
 }
 
@@ -259,25 +240,21 @@ AcpiEnableSubsystem (
      */
     AcpiGbl_EarlyInitialization = FALSE;
 
-    if (AcpiGbl_OverrideDefaultRegionHandlers)
+    /*
+     * Install the default operation region handlers. These are the
+     * handlers that are defined by the ACPI specification to be
+     * "always accessible" -- namely, SystemMemory, SystemIO, and
+     * PCI_Config. This also means that no _REG methods need to be
+     * run for these address spaces. We need to have these handlers
+     * installed before any AML code can be executed, especially any
+     * module-level code (11/2015).
+     */
+    Status = AcpiEvInstallRegionHandlers ();
+    if (ACPI_FAILURE (Status))
     {
-        /*
-         * Install the default operation region handlers. These are the
-         * handlers that are defined by the ACPI specification to be
-         * "always accessible" -- namely, SystemMemory, SystemIO, and
-         * PCI_Config. This also means that no _REG methods need to be
-         * run for these address spaces. We need to have these handlers
-         * installed before any AML code can be executed, especially any
-         * module-level code (11/2015).
-         */
-        Status = AcpiEvInstallRegionHandlers ();
-        if (ACPI_FAILURE (Status))
-        {
-            ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
-            return_ACPI_STATUS (Status);
-        }
+        ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
+        return_ACPI_STATUS (Status);
     }
-
 
 #if (!ACPI_REDUCED_HARDWARE)
 

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -364,26 +364,6 @@ AcpiInitializeObjects (
     ACPI_FUNCTION_TRACE (AcpiInitializeObjects);
 
 
-    /*
-     * Run all _REG methods
-     *
-     * Note: Any objects accessed by the _REG methods will be automatically
-     * initialized, even if they contain executable AML (see the call to
-     * AcpiNsInitializeObjects below).
-     */
-    AcpiGbl_RegMethodsEnabled = TRUE;
-    if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
-    {
-        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
-            "[Init] Executing _REG OpRegion methods\n"));
-
-        Status = AcpiEvInitializeOpRegions ();
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
-    }
-
 #ifdef ACPI_EXEC_APP
     /*
      * This call implements the "initialization file" option for AcpiExec.
@@ -420,6 +400,26 @@ AcpiInitializeObjects (
             "[Init] Completing Initialization of ACPI Objects\n"));
 
         Status = AcpiNsInitializeObjects ();
+        if (ACPI_FAILURE (Status))
+        {
+            return_ACPI_STATUS (Status);
+        }
+    }
+
+    /*
+     * Run all _REG methods
+     *
+     * Note: Any objects accessed by the _REG methods will be automatically
+     * initialized, even if they contain executable AML (see the call to
+     * AcpiNsInitializeObjects below).
+     */
+    AcpiGbl_RegMethodsEnabled = TRUE;
+    if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
+    {
+        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
+            "[Init] Executing _REG OpRegion methods\n"));
+
+        Status = AcpiEvInitializeOpRegions ();
         if (ACPI_FAILURE (Status))
         {
             return_ACPI_STATUS (Status);

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -368,6 +368,7 @@ AcpiInitializeObjects (
      * initialized, even if they contain executable AML (see the call to
      * AcpiNsInitializeObjects below).
      */
+    AcpiGbl_RegMethodsEnabled = TRUE;
     if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
     {
         ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -406,7 +406,7 @@ AcpiInitializeObjects (
         }
     }
 
-    AcpiGbl_RegMethodsEnabled = TRUE;
+    AcpiGbl_NamespaceInitialized = TRUE;
 
     /*
      * Initialize all device/region objects in the namespace. This runs

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -249,11 +249,14 @@ AcpiEnableSubsystem (
      * installed before any AML code can be executed, especially any
      * module-level code (11/2015).
      */
-    Status = AcpiEvInstallRegionHandlers ();
-    if (ACPI_FAILURE (Status))
+    if (!AcpiGbl_GroupModuleLevelCode)
     {
-        ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
-        return_ACPI_STATUS (Status);
+        Status = AcpiEvInstallRegionHandlers ();
+        if (ACPI_FAILURE (Status))
+        {
+            ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
+            return_ACPI_STATUS (Status);
+        }
     }
 
 #if (!ACPI_REDUCED_HARDWARE)

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -158,8 +158,6 @@ ACPI_GLOBAL (UINT8,                     AcpiGbl_IntegerBitWidth);
 ACPI_GLOBAL (UINT8,                     AcpiGbl_IntegerByteWidth);
 ACPI_GLOBAL (UINT8,                     AcpiGbl_IntegerNybbleWidth);
 
-ACPI_INIT_GLOBAL (UINT8,                AcpiGbl_GroupModuleLevelCode, FALSE);
-
 
 /*****************************************************************************
  *

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -240,7 +240,7 @@ ACPI_GLOBAL (UINT8,                     AcpiGbl_NextOwnerIdOffset);
 
 /* Initialization sequencing */
 
-ACPI_INIT_GLOBAL (BOOLEAN,              AcpiGbl_RegMethodsEnabled, FALSE);
+ACPI_INIT_GLOBAL (BOOLEAN,              AcpiGbl_NamespaceInitialized, FALSE);
 
 /* Misc */
 

--- a/source/include/acnamesp.h
+++ b/source/include/acnamesp.h
@@ -166,7 +166,7 @@ AcpiNsInitializeObjects (
 
 ACPI_STATUS
 AcpiNsInitializeDevices (
-    void);
+    UINT32                  Flags);
 
 
 /*

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -264,11 +264,6 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_CopyDsdtLocally, FALSE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
 
 /*
- * Optionally allow default region handlers to be overridden.
- */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_OverrideDefaultRegionHandlers, FALSE);
-
-/*
  * Optionally use 32-bit FADT addresses if and when there is a conflict
  * (address mismatch) between the 32-bit and 64-bit versions of the
  * address. Although ACPICA adheres to the ACPI specification which

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -264,6 +264,11 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_CopyDsdtLocally, FALSE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
 
 /*
+ * Optionally support group module level code.
+ */
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_GroupModuleLevelCode, FALSE);
+
+/*
  * Optionally use 32-bit FADT addresses if and when there is a conflict
  * (address mismatch) between the 32-bit and 64-bit versions of the
  * address. Although ACPICA adheres to the ACPI specification which

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -540,7 +540,6 @@ main (
 
     /* Init ACPICA and start debugger thread */
 
-    AcpiGbl_OverrideDefaultRegionHandlers = TRUE;
     Status = AcpiInitializeSubsystem ();
     ACPI_CHECK_OK (AcpiInitializeSubsystem, Status);
     if (ACPI_FAILURE (Status))

--- a/source/tools/examples/examples.c
+++ b/source/tools/examples/examples.c
@@ -248,7 +248,6 @@ InitializeFullAcpica (void)
 
     /* Initialize the ACPICA subsystem */
 
-    AcpiGbl_OverrideDefaultRegionHandlers = TRUE;
     Status = AcpiInitializeSubsystem ();
     if (ACPI_FAILURE (Status))
     {
@@ -356,7 +355,6 @@ InitializeAcpi (
 
     /* Initialize the ACPICA subsystem */
 
-    AcpiGbl_OverrideDefaultRegionHandlers = TRUE;
     Status = AcpiInitializeSubsystem ();
     if (ACPI_FAILURE (Status))
     {


### PR DESCRIPTION
It is proven that for _REV >= 2 platforms where ECDT is provided, EC._REG is not required to be invoked, this makes EmbeddedControl another early available operation region like SystemMemory/SystemIo/PciConfig that can be accessed during namespace initialization.
While other evaluations and region accesses may only happen after the namespace is initialized.

ACPI spec proposed a way to offer an ECAV method, in which, when _REV >= 2, EC accesses are allowed, otherwise, EC accesses are only allowed if EC._REG has been executed.
But many platofmrs are not implemented in this way, they set ECOK which should be set in EC._REG to indicate the availability of EC accesses in \\_SB._INI without providing ECAV.
In order not to break such platforms during the bug fixing of early operation region availibility, we need to ensure \\_SB._INI to be the first control method evaluated by the AML interpreter.

We have proven this fact via qemu.