### PR TITLE
aclocal: Put parens around some definitions.

### DIFF
--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -161,7 +161,7 @@ union acpi_parse_object;
 #define ACPI_MTX_MEMORY                 5   /* Debug memory tracking lists */
 
 #define ACPI_MAX_MUTEX                  5
-#define ACPI_NUM_MUTEX                  ACPI_MAX_MUTEX+1
+#define ACPI_NUM_MUTEX                  (ACPI_MAX_MUTEX+1)
 
 
 /* Lock structure for reader/writer interfaces */
@@ -183,12 +183,12 @@ typedef struct acpi_rw_lock
 #define ACPI_LOCK_HARDWARE              1
 
 #define ACPI_MAX_LOCK                   1
-#define ACPI_NUM_LOCK                   ACPI_MAX_LOCK+1
+#define ACPI_NUM_LOCK                   (ACPI_MAX_LOCK+1)
 
 
 /* This Thread ID means that the mutex is not in use (unlocked) */
 
-#define ACPI_MUTEX_NOT_ACQUIRED         (ACPI_THREAD_ID) -1
+#define ACPI_MUTEX_NOT_ACQUIRED         ((ACPI_THREAD_ID) -1)
 
 /* This Thread ID means an invalid thread ID */
 


### PR DESCRIPTION
Looking at where these are used, this shouldn't result in any behavioral changes, but it's best practices to have them.