### PR TITLE
Acpica module

### DIFF
--- a/source/compiler/aslstubs.c
+++ b/source/compiler/aslstubs.c
@@ -136,6 +136,13 @@ AcpiNsExecModuleCodeList (
 }
 
 ACPI_STATUS
+AcpiNsInitializeObjects (
+    void)
+{
+    return (AE_OK);
+}
+
+ACPI_STATUS
 AcpiHwReadPort (
     ACPI_IO_ADDRESS         Address,
     UINT32                  *Value,

--- a/source/components/executer/exconfig.c
+++ b/source/components/executer/exconfig.c
@@ -202,7 +202,10 @@ AcpiExAddTable (
     /* Execute any module-level code that was found in the table */
 
     AcpiExExitInterpreter ();
-    AcpiNsExecModuleCodeList ();
+    if (AcpiGbl_GroupModuleLevelCode)
+    {
+        AcpiNsExecModuleCodeList ();
+    }
     AcpiExEnterInterpreter ();
 
     /*

--- a/source/components/namespace/nsinit.c
+++ b/source/components/namespace/nsinit.c
@@ -171,6 +171,8 @@ AcpiNsInitializeObjects (
     ACPI_FUNCTION_TRACE (NsInitializeObjects);
 
 
+    ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
+        "[Init] Completing Initialization of ACPI Objects\n"));
     ACPI_DEBUG_PRINT ((ACPI_DB_DISPATCH,
         "**** Starting initialization of namespace objects ****\n"));
     ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT,

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -183,6 +183,22 @@ AcpiLoadTables (
             "While loading namespace from ACPI tables"));
     }
 
+    if (!AcpiGbl_GroupModuleLevelCode)
+    {
+        /*
+         * Initialize the objects that remain uninitialized. This
+         * runs the executable AML that may be part of the
+         * declaration of these objects:
+         * OperationRegions, BufferFields, Buffers, and Packages.
+         */
+        Status = AcpiNsInitializeObjects ();
+        if (ACPI_FAILURE (Status))
+        {
+            return_ACPI_STATUS (Status);
+        }
+    }
+
+    AcpiGbl_NamespaceInitialized = TRUE;
     return_ACPI_STATUS (Status);
 }
 

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -159,14 +159,11 @@ AcpiLoadTables (
      * between AcpiInitializeSubsystem() and AcpiLoadTables() to use
      * their customized default region handlers.
      */
-    if (AcpiGbl_GroupModuleLevelCode)
+    Status = AcpiEvInstallRegionHandlers ();
+    if (ACPI_FAILURE (Status))
     {
-        Status = AcpiEvInstallRegionHandlers ();
-        if (ACPI_FAILURE (Status) && Status != AE_ALREADY_EXISTS)
-        {
-            ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
-            return_ACPI_STATUS (Status);
-        }
+        ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
+        return_ACPI_STATUS (Status);
     }
 
     /* Load the namespace from the tables */

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -368,26 +368,22 @@ AcpiInitializeObjects (
     if (AcpiGbl_GroupModuleLevelCode)
     {
         AcpiNsExecModuleCodeList ();
-    }
 
-    /*
-     * Initialize the objects that remain uninitialized. This runs the
-     * executable AML that may be part of the declaration of these objects:
-     * OperationRegions, BufferFields, Buffers, and Packages.
-     */
-    if (!(Flags & ACPI_NO_OBJECT_INIT))
-    {
-        ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
-            "[Init] Completing Initialization of ACPI Objects\n"));
-
-        Status = AcpiNsInitializeObjects ();
-        if (ACPI_FAILURE (Status))
+        /*
+         * Initialize the objects that remain uninitialized. This
+         * runs the executable AML that may be part of the
+         * declaration of these objects:
+         * OperationRegions, BufferFields, Buffers, and Packages.
+         */
+        if (!(Flags & ACPI_NO_OBJECT_INIT))
         {
-            return_ACPI_STATUS (Status);
+            Status = AcpiNsInitializeObjects ();
+            if (ACPI_FAILURE (Status))
+            {
+                return_ACPI_STATUS (Status);
+            }
         }
     }
-
-    AcpiGbl_NamespaceInitialized = TRUE;
 
     /*
      * Initialize all device/region objects in the namespace. This runs

--- a/source/components/utilities/utxfinit.c
+++ b/source/components/utilities/utxfinit.c
@@ -240,25 +240,6 @@ AcpiEnableSubsystem (
      */
     AcpiGbl_EarlyInitialization = FALSE;
 
-    /*
-     * Install the default operation region handlers. These are the
-     * handlers that are defined by the ACPI specification to be
-     * "always accessible" -- namely, SystemMemory, SystemIO, and
-     * PCI_Config. This also means that no _REG methods need to be
-     * run for these address spaces. We need to have these handlers
-     * installed before any AML code can be executed, especially any
-     * module-level code (11/2015).
-     */
-    if (!AcpiGbl_GroupModuleLevelCode)
-    {
-        Status = AcpiEvInstallRegionHandlers ();
-        if (ACPI_FAILURE (Status))
-        {
-            ACPI_EXCEPTION ((AE_INFO, Status, "During Region initialization"));
-            return_ACPI_STATUS (Status);
-        }
-    }
-
 #if (!ACPI_REDUCED_HARDWARE)
 
     /* Enable ACPI mode */


### PR DESCRIPTION
After validation, I can see the correct behavior is to execute entire table rather than the current behavior.
And enabling this requires many tests and fixes in Linux environment.

This is the real module level execution enabling and those required fixes detected in the Linux environment.