### PR TITLE
Acpica tables

### DIFF
--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -1029,14 +1029,9 @@ AcpiTbLoadTable (
         AcpiEvUpdateGpes (OwnerId);
     }
 
-    /* Invoke table handler if present */
+    /* Invoke table handler */
 
-    if (AcpiGbl_TableHandler)
-    {
-        (void) AcpiGbl_TableHandler (ACPI_TABLE_EVENT_LOAD, Table,
-            AcpiGbl_TableHandlerContext);
-    }
-
+    AcpiTbNotifyTable (ACPI_TABLE_EVENT_LOAD, Table);
     return_ACPI_STATUS (Status);
 }
 
@@ -1117,16 +1112,12 @@ AcpiTbUnloadTable (
         return_ACPI_STATUS (AE_NOT_EXIST);
     }
 
-    /* Invoke table handler if present */
+    /* Invoke table handler */
 
-    if (AcpiGbl_TableHandler)
+    Status = AcpiGetTableByIndex (TableIndex, &Table);
+    if (ACPI_SUCCESS (Status))
     {
-        Status = AcpiGetTableByIndex (TableIndex, &Table);
-        if (ACPI_SUCCESS (Status))
-        {
-            (void) AcpiGbl_TableHandler (ACPI_TABLE_EVENT_UNLOAD, Table,
-                AcpiGbl_TableHandlerContext);
-        }
+        AcpiTbNotifyTable (ACPI_TABLE_EVENT_UNLOAD, Table);
     }
 
     /* Delete the portion of the namespace owned by this table */
@@ -1140,4 +1131,32 @@ AcpiTbUnloadTable (
     (void) AcpiTbReleaseOwnerId (TableIndex);
     AcpiTbSetTableLoadedFlag (TableIndex, FALSE);
     return_ACPI_STATUS (Status);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiTbNotifyTable
+ *
+ * PARAMETERS:  Event               - Table event
+ *              Table               - Validated table pointer
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Notify a table event to the users.
+ *
+ ******************************************************************************/
+
+void
+AcpiTbNotifyTable (
+    UINT32                          Event,
+    void                            *Table)
+{
+    /* Invoke table handler if present */
+
+    if (AcpiGbl_TableHandler)
+    {
+        (void) AcpiGbl_TableHandler (Event, Table,
+            AcpiGbl_TableHandlerContext);
+    }
 }

--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -1070,24 +1070,19 @@ AcpiTbInstallAndLoadTable (
     ACPI_FUNCTION_TRACE (TbInstallAndLoadTable);
 
 
-    (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
-
     /* Install the table and load it into the namespace */
 
     Status = AcpiTbInstallStandardTable (Address, Flags, TRUE,
         Override, &i);
     if (ACPI_FAILURE (Status))
     {
-        goto UnlockAndExit;
+        goto Exit;
     }
 
-    (void) AcpiUtReleaseMutex (ACPI_MTX_TABLES);
     Status = AcpiTbLoadTable (i, AcpiGbl_RootNode);
-    (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
 
-UnlockAndExit:
+Exit:
     *TableIndex = i;
-    (void) AcpiUtReleaseMutex (ACPI_MTX_TABLES);
     return_ACPI_STATUS (Status);
 }
 

--- a/source/components/tables/tbdata.c
+++ b/source/components/tables/tbdata.c
@@ -477,7 +477,7 @@ AcpiTbValidateTempTable (
     ACPI_TABLE_DESC         *TableDesc)
 {
 
-    if (!TableDesc->Pointer && !AcpiGbl_VerifyTableChecksum)
+    if (!TableDesc->Pointer && !AcpiGbl_EnableTableValidation)
     {
         /*
          * Only validates the header of the table.
@@ -542,7 +542,7 @@ AcpiTbVerifyTempTable (
 
     /* Verify the checksum */
 
-    if (AcpiGbl_VerifyTableChecksum)
+    if (AcpiGbl_EnableTableValidation)
     {
         Status = AcpiTbVerifyChecksum (TableDesc->Pointer, TableDesc->Length);
         if (ACPI_FAILURE (Status))

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -434,14 +434,10 @@ AcpiTbInstallStandardTable (
 
     AcpiTbInstallTableWithOverride (&NewTableDesc, Override, TableIndex);
 
-    /* Invoke table handler if present */
+    /* Invoke table handler */
 
     (void) AcpiUtReleaseMutex (ACPI_MTX_TABLES);
-    if (AcpiGbl_TableHandler)
-    {
-        (void) AcpiGbl_TableHandler (ACPI_TABLE_EVENT_INSTALL,
-            NewTableDesc.Pointer, AcpiGbl_TableHandlerContext);
-    }
+    AcpiTbNotifyTable (ACPI_TABLE_EVENT_INSTALL, NewTableDesc.Pointer);
     (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
 
 UnlockAndExit:

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -351,32 +351,6 @@ AcpiTbInstallStandardTable (
 
     if (Reload)
     {
-        /*
-         * Validate the incoming table signature.
-         *
-         * 1) Originally, we checked the table signature for "SSDT" or "PSDT".
-         * 2) We added support for OEMx tables, signature "OEM".
-         * 3) Valid tables were encountered with a null signature, so we just
-         *    gave up on validating the signature, (05/2008).
-         * 4) We encountered non-AML tables such as the MADT, which caused
-         *    interpreter errors and kernel faults. So now, we once again allow
-         *    only "SSDT", "OEMx", and now, also a null signature. (05/2011).
-         */
-        if ((NewTableDesc.Signature.Ascii[0] != 0x00) &&
-           (!ACPI_COMPARE_NAME (&NewTableDesc.Signature, ACPI_SIG_SSDT)) &&
-           (strncmp (NewTableDesc.Signature.Ascii, "OEM", 3)))
-        {
-            ACPI_BIOS_ERROR ((AE_INFO,
-                "Table has invalid signature [%4.4s] (0x%8.8X), "
-                "must be SSDT or OEMx",
-                AcpiUtValidNameseg (NewTableDesc.Signature.Ascii) ?
-                    NewTableDesc.Signature.Ascii : "????",
-                NewTableDesc.Signature.Integer));
-
-            Status = AE_BAD_SIGNATURE;
-            goto UnlockAndExit;
-        }
-
         /* Check if table is already registered */
 
         for (i = 0; i < AcpiGbl_RootTableList.CurrentTableCount; ++i)

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -349,7 +349,7 @@ AcpiTbInstallStandardTable (
 
     (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
 
-    if (Reload)
+    if (AcpiGbl_EnableTableValidation)
     {
         /* Check if table is already registered */
 

--- a/source/components/tables/tbutils.c
+++ b/source/components/tables/tbutils.c
@@ -562,11 +562,7 @@ AcpiTbGetTable (
     TableDesc->ValidationCount++;
     if (TableDesc->ValidationCount == 0)
     {
-        ACPI_ERROR ((AE_INFO,
-            "Table %p, Validation count is zero after increment\n",
-            TableDesc));
         TableDesc->ValidationCount--;
-        return_ACPI_STATUS (AE_LIMIT);
     }
 
     *OutTable = TableDesc->Pointer;

--- a/source/components/tables/tbxface.c
+++ b/source/components/tables/tbxface.c
@@ -292,6 +292,7 @@ AcpiReallocateRootTable (
     void)
 {
     ACPI_STATUS             Status;
+    ACPI_TABLE_DESC         *TableDesc;
     UINT32                  i;
 
 
@@ -307,6 +308,8 @@ AcpiReallocateRootTable (
         return_ACPI_STATUS (AE_SUPPORT);
     }
 
+    (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
+
     /*
      * Ensure OS early boot logic, which is required by some hosts. If the
      * table state is reported to be wrong, developers should fix the
@@ -315,11 +318,12 @@ AcpiReallocateRootTable (
      */
     for (i = 0; i < AcpiGbl_RootTableList.CurrentTableCount; ++i)
     {
-        if (AcpiGbl_RootTableList.Tables[i].Pointer)
+        TableDesc = &AcpiGbl_RootTableList.Tables[i];
+        if (TableDesc->Pointer)
         {
             ACPI_ERROR ((AE_INFO,
                 "Table [%4.4s] is not invalidated during early boot stage",
-                AcpiGbl_RootTableList.Tables[i].Signature.Ascii));
+                TableDesc->Signature.Ascii));
         }
     }
 
@@ -330,11 +334,25 @@ AcpiReallocateRootTable (
          * table initilization here once the flag is set.
          */
         AcpiGbl_EnableTableValidation = TRUE;
+        for (i = 0; i < AcpiGbl_RootTableList.CurrentTableCount; ++i)
+        {
+            TableDesc = &AcpiGbl_RootTableList.Tables[i];
+            if (!(TableDesc->Flags & ACPI_TABLE_IS_VERIFIED))
+            {
+                Status = AcpiTbVerifyTempTable (TableDesc, NULL, NULL);
+                if (ACPI_FAILURE (Status))
+                {
+                    AcpiTbUninstallTable (TableDesc);
+                }
+            }
+        }
     }
 
     AcpiGbl_RootTableList.Flags |= ACPI_ROOT_ALLOW_RESIZE;
-
     Status = AcpiTbResizeRootTableList ();
+    AcpiGbl_RootTableList.Flags |= ACPI_ROOT_ORIGIN_ALLOCATED;
+
+    (void) AcpiUtReleaseMutex (ACPI_MTX_TABLES);
     return_ACPI_STATUS (Status);
 }
 

--- a/source/components/tables/tbxface.c
+++ b/source/components/tables/tbxface.c
@@ -323,6 +323,15 @@ AcpiReallocateRootTable (
         }
     }
 
+    if (!AcpiGbl_EnableTableValidation)
+    {
+        /*
+         * Now it's safe to do full table validation. We can do deferred
+         * table initilization here once the flag is set.
+         */
+        AcpiGbl_EnableTableValidation = TRUE;
+    }
+
     AcpiGbl_RootTableList.Flags |= ACPI_ROOT_ALLOW_RESIZE;
 
     Status = AcpiTbResizeRootTableList ();

--- a/source/components/tables/tbxface.c
+++ b/source/components/tables/tbxface.c
@@ -522,6 +522,11 @@ AcpiPutTable (
     ACPI_FUNCTION_TRACE (AcpiPutTable);
 
 
+    if (!Table)
+    {
+        return_VOID;
+    }
+
     (void) AcpiUtAcquireMutex (ACPI_MTX_TABLES);
 
     /* Walk the root table list */

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -336,11 +336,11 @@ AcpiTbLoadNamespace (
     {
         Table = &AcpiGbl_RootTableList.Tables[i];
 
-        if (!AcpiGbl_RootTableList.Tables[i].Address ||
+        if (!Table->Address ||
             (!ACPI_COMPARE_NAME (Table->Signature.Ascii, ACPI_SIG_SSDT) &&
              !ACPI_COMPARE_NAME (Table->Signature.Ascii, ACPI_SIG_PSDT) &&
              !ACPI_COMPARE_NAME (Table->Signature.Ascii, ACPI_SIG_OSDT)) ||
-             ACPI_FAILURE (AcpiTbValidateTable (Table)))
+            ACPI_FAILURE (AcpiTbValidateTable (Table)))
         {
             continue;
         }

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -270,13 +270,14 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_CreateOsiMethod, TRUE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_UseDefaultRegisterWidths, TRUE);
 
 /*
- * Whether or not to verify the table checksum before installation. Set
- * this to TRUE to verify the table checksum before install it to the table
- * manager. Note that enabling this option causes errors to happen in some
- * OSPMs during early initialization stages. Default behavior is to do such
- * verification.
+ * Whether or not to validate (map) an entire table to verify
+ * checksum/duplication in early stage before install. Set this to TRUE to
+ * allow early table validation before install it to the table manager.
+ * Note that enabling this option causes errors to happen in some OSPMs
+ * during early initialization stages. Default behavior is to allow such
+ * validation.
  */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_VerifyTableChecksum, TRUE);
+ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_EnableTableValidation, TRUE);
 
 /*
  * Optionally enable output from the AML Debug Object.

--- a/source/include/actables.h
+++ b/source/include/actables.h
@@ -303,6 +303,11 @@ AcpiTbUnloadTable (
     UINT32                  TableIndex);
 
 void
+AcpiTbNotifyTable (
+    UINT32                          Event,
+    void                            *Table);
+
+void
 AcpiTbTerminate (
     void);
 

--- a/source/include/actables.h
+++ b/source/include/actables.h
@@ -206,7 +206,8 @@ AcpiTbValidateTempTable (
 ACPI_STATUS
 AcpiTbVerifyTempTable (
     ACPI_TABLE_DESC         *TableDesc,
-    char                    *Signature);
+    char                    *Signature,
+    UINT32                  *TableIndex);
 
 BOOLEAN
 AcpiTbIsTableLoaded (

--- a/source/include/actbl.h
+++ b/source/include/actbl.h
@@ -517,6 +517,20 @@ typedef struct acpi_table_desc
 
 } ACPI_TABLE_DESC;
 
+/*
+ * Maximum value of the ValidationCount field in ACPI_TABLE_DESC.
+ * When reached, ValidationCount cannot be changed any more and the table will
+ * be permanently regarded as validated.
+ *
+ * This is to prevent situations in which unbalanced table get/put operations
+ * may cause premature table unmapping in the OS to happen.
+ *
+ * The maximum validation count can be defined to any value, but should be
+ * greater than the maximum number of OS early stage mapping slots to avoid
+ * leaking early stage table mappings to the late stage.
+ */
+#define ACPI_MAX_TABLE_VALIDATIONS          ACPI_UINT16_MAX
+
 /* Masks for Flags field above */
 
 #define ACPI_TABLE_ORIGIN_EXTERNAL_VIRTUAL  (0) /* Virtual address, external maintained */

--- a/source/include/actbl.h
+++ b/source/include/actbl.h
@@ -537,6 +537,7 @@ typedef struct acpi_table_desc
 #define ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL (1) /* Physical address, internally mapped */
 #define ACPI_TABLE_ORIGIN_INTERNAL_VIRTUAL  (2) /* Virtual address, internallly allocated */
 #define ACPI_TABLE_ORIGIN_MASK              (3)
+#define ACPI_TABLE_IS_VERIFIED              (4)
 #define ACPI_TABLE_IS_LOADED                (8)
 
 

--- a/tests/aslts/src/runtime/collections/functional/table/load.asl
+++ b/tests/aslts/src/runtime/collections/functional/table/load.asl
@@ -1472,7 +1472,7 @@ Device(DTM0) {
 		return (0)
 	}
 
-	// Exceptions when the table contained in an OpRegion
+	// No exception when the table contained in an OpRegion
 	// (Field) is not an SSDT
 	Method(tstd, 1, Serialized)
 	{
@@ -1513,12 +1513,18 @@ Device(DTM0) {
 
 		// Load operator execution, OpRegion Field case
 		Load(RFU0, HI0)
-		CH04(arg0, 0, 37, z174, 0x086, 0, 0)	// AE_BAD_SIGNATURE
+		CH03(arg0, z174, 0x086, 0, 0) // No exception
 
 		if (CondRefof(\SSS0, Local0)) {
+		} else {
 			err(arg0, z174, 0x087, 0, 0, "\\SSS0", 1)
 		}
 
+		// CleanUp
+		UnLoad(HI0)
+		if (CH03(arg0, z174, 0x088, 0, 0)) {
+			return (1)
+		}
 		return (0)
 	}
 


### PR DESCRIPTION
New table materials, generated to fix AcpiGetTable()/AcpiPutTable() regressions.

The first 2 patches are Linux materials, and the follow-ups are based on the Linux upstream code base as the feature is requested by Linux kernel developers, they need them to be able to apply on top of current code base.

Reported by Hans de Geode from redhat
Fixed by Lv Zheng