### PR TITLE
Acpica module

### DIFF
--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -623,58 +623,6 @@ AcpiEvAttachRegion (
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiEvAssociateRegMethod
- *
- * PARAMETERS:  RegionObj           - Region object
- *
- * RETURN:      Status
- *
- * DESCRIPTION: Find and associate _REG method to a region
- *
- ******************************************************************************/
-
-void
-AcpiEvAssociateRegMethod (
-    ACPI_OPERAND_OBJECT     *RegionObj)
-{
-    const ACPI_NAME         *RegNamePtr = ACPI_CAST_PTR (ACPI_NAME, METHOD_NAME__REG);
-    ACPI_NAMESPACE_NODE     *MethodNode;
-    ACPI_NAMESPACE_NODE     *Node;
-    ACPI_OPERAND_OBJECT     *RegionObj2;
-    ACPI_STATUS             Status;
-
-
-    ACPI_FUNCTION_TRACE (EvAssociateRegMethod);
-
-
-    RegionObj2 = AcpiNsGetSecondaryObject (RegionObj);
-    if (!RegionObj2)
-    {
-        return_VOID;
-    }
-
-    Node = RegionObj->Region.Node->Parent;
-
-    /* Find any "_REG" method associated with this region definition */
-
-    Status = AcpiNsSearchOneScope (
-        *RegNamePtr, Node, ACPI_TYPE_METHOD, &MethodNode);
-    if (ACPI_SUCCESS (Status))
-    {
-        /*
-         * The _REG method is optional and there can be only one per region
-         * definition. This will be executed when the handler is attached
-         * or removed
-         */
-        RegionObj2->Extra.Method_REG = MethodNode;
-    }
-
-    return_VOID;
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    AcpiEvExecuteRegMethod
  *
  * PARAMETERS:  RegionObj           - Region object
@@ -694,11 +642,20 @@ AcpiEvExecuteRegMethod (
     ACPI_EVALUATE_INFO      *Info;
     ACPI_OPERAND_OBJECT     *Args[3];
     ACPI_OPERAND_OBJECT     *RegionObj2;
+    const ACPI_NAME         *RegNamePtr = ACPI_CAST_PTR (ACPI_NAME, METHOD_NAME__REG);
+    ACPI_NAMESPACE_NODE     *MethodNode;
+    ACPI_NAMESPACE_NODE     *Node;
     ACPI_STATUS             Status;
 
 
     ACPI_FUNCTION_TRACE (EvExecuteRegMethod);
 
+
+    if (!AcpiGbl_NamespaceInitialized ||
+        RegionObj->Region.Handler == NULL)
+    {
+        return_ACPI_STATUS (AE_OK);
+    }
 
     RegionObj2 = AcpiNsGetSecondaryObject (RegionObj);
     if (!RegionObj2)
@@ -706,9 +663,24 @@ AcpiEvExecuteRegMethod (
         return_ACPI_STATUS (AE_NOT_EXIST);
     }
 
-    if (RegionObj2->Extra.Method_REG == NULL ||
-        RegionObj->Region.Handler == NULL ||
-        !AcpiGbl_NamespaceInitialized)
+    /*
+     * Find any "_REG" method associated with this region definition.
+     * The method should always be updated as this function may be
+     * invoked after a namespace change.
+     */
+    Node = RegionObj->Region.Node->Parent;
+    Status = AcpiNsSearchOneScope (
+        *RegNamePtr, Node, ACPI_TYPE_METHOD, &MethodNode);
+    if (ACPI_SUCCESS (Status))
+    {
+        /*
+         * The _REG method is optional and there can be only one per
+         * region definition. This will be executed when the handler is
+         * attached or removed.
+         */
+        RegionObj2->Extra.Method_REG = MethodNode;
+    }
+    if (RegionObj2->Extra.Method_REG == NULL)
     {
         return_ACPI_STATUS (AE_OK);
     }

--- a/source/components/events/evrgnini.c
+++ b/source/components/events/evrgnini.c
@@ -654,7 +654,6 @@ AcpiEvInitializeRegion (
         return_ACPI_STATUS (AE_OK);
     }
 
-    AcpiEvAssociateRegMethod (RegionObj);
     RegionObj->Common.Flags |= AOPOBJ_OBJECT_INITIALIZED;
 
     Node = RegionObj->Region.Node->Parent;

--- a/source/include/acevents.h
+++ b/source/include/acevents.h
@@ -345,10 +345,6 @@ AcpiEvDetachRegion (
     BOOLEAN                 AcpiNsIsLocked);
 
 void
-AcpiEvAssociateRegMethod (
-    ACPI_OPERAND_OBJECT     *RegionObj);
-
-void
 AcpiEvExecuteRegMethods (
     ACPI_NAMESPACE_NODE     *Node,
     ACPI_ADR_SPACE_TYPE     SpaceId,


### PR DESCRIPTION
A required fix for enabling "AcpiGbl_GroupModuleLevelCode = FALSE".

In Linux, EC is supported in 2 ways:
During early stage, Linux will install EC operation region handler without _REG executed using ECDT EC settings. This allows EC read/write transactions to happen during the table loading.
During late stage, Linux will uninstall EC operation region handler and re-install EC operation region handler with _REG executed using DSDT EC settings. This allows EC read/write transactions and query event handling to happen after the table loading.

Then it seems _REG association will fail in the first step as the namespace hasn't been fully initialized at that time and the association cannot be recovered in the second step.
This patch fixes this issue by letting _REG to be always associated before executing _REG so that _REG can be correctly associated again and executed in the second step.

This looks like the root cause of current strange Linux ECDT support and ACPICA MLC support.

Without this fix, Linux will fail to notify AML table of the "EC operation region handler connected" event, and no EC accesses can happen even in the late stage. Thus this is required before enabling AcpiGbl_GroupModuleLevelCode = FALSE support.

Tested at: https://bugzilla.kernel.org/show_bug.cgi?id=112911