### PR TITLE
Acpica order

### DIFF
--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -623,58 +623,6 @@ AcpiEvAttachRegion (
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiEvAssociateRegMethod
- *
- * PARAMETERS:  RegionObj           - Region object
- *
- * RETURN:      Status
- *
- * DESCRIPTION: Find and associate _REG method to a region
- *
- ******************************************************************************/
-
-void
-AcpiEvAssociateRegMethod (
-    ACPI_OPERAND_OBJECT     *RegionObj)
-{
-    const ACPI_NAME         *RegNamePtr = ACPI_CAST_PTR (ACPI_NAME, METHOD_NAME__REG);
-    ACPI_NAMESPACE_NODE     *MethodNode;
-    ACPI_NAMESPACE_NODE     *Node;
-    ACPI_OPERAND_OBJECT     *RegionObj2;
-    ACPI_STATUS             Status;
-
-
-    ACPI_FUNCTION_TRACE (EvAssociateRegMethod);
-
-
-    RegionObj2 = AcpiNsGetSecondaryObject (RegionObj);
-    if (!RegionObj2)
-    {
-        return_VOID;
-    }
-
-    Node = RegionObj->Region.Node->Parent;
-
-    /* Find any "_REG" method associated with this region definition */
-
-    Status = AcpiNsSearchOneScope (
-        *RegNamePtr, Node, ACPI_TYPE_METHOD, &MethodNode);
-    if (ACPI_SUCCESS (Status))
-    {
-        /*
-         * The _REG method is optional and there can be only one per region
-         * definition. This will be executed when the handler is attached
-         * or removed
-         */
-        RegionObj2->Extra.Method_REG = MethodNode;
-    }
-
-    return_VOID;
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    AcpiEvExecuteRegMethod
  *
  * PARAMETERS:  RegionObj           - Region object
@@ -694,11 +642,20 @@ AcpiEvExecuteRegMethod (
     ACPI_EVALUATE_INFO      *Info;
     ACPI_OPERAND_OBJECT     *Args[3];
     ACPI_OPERAND_OBJECT     *RegionObj2;
+    const ACPI_NAME         *RegNamePtr = ACPI_CAST_PTR (ACPI_NAME, METHOD_NAME__REG);
+    ACPI_NAMESPACE_NODE     *MethodNode;
+    ACPI_NAMESPACE_NODE     *Node;
     ACPI_STATUS             Status;
 
 
     ACPI_FUNCTION_TRACE (EvExecuteRegMethod);
 
+
+    if (!AcpiGbl_NamespaceInitialized ||
+        RegionObj->Region.Handler == NULL)
+    {
+        return_ACPI_STATUS (AE_OK);
+    }
 
     RegionObj2 = AcpiNsGetSecondaryObject (RegionObj);
     if (!RegionObj2)
@@ -706,9 +663,24 @@ AcpiEvExecuteRegMethod (
         return_ACPI_STATUS (AE_NOT_EXIST);
     }
 
-    if (RegionObj2->Extra.Method_REG == NULL ||
-        RegionObj->Region.Handler == NULL ||
-        !AcpiGbl_NamespaceInitialized)
+    /*
+     * Find any "_REG" method associated with this region definition.
+     * The method should always be updated as this function may be
+     * invoked after a namespace change.
+     */
+    Node = RegionObj->Region.Node->Parent;
+    Status = AcpiNsSearchOneScope (
+        *RegNamePtr, Node, ACPI_TYPE_METHOD, &MethodNode);
+    if (ACPI_SUCCESS (Status))
+    {
+        /*
+         * The _REG method is optional and there can be only one per
+         * region definition. This will be executed when the handler is
+         * attached or removed.
+         */
+        RegionObj2->Extra.Method_REG = MethodNode;
+    }
+    if (RegionObj2->Extra.Method_REG == NULL)
     {
         return_ACPI_STATUS (AE_OK);
     }

--- a/source/components/events/evrgnini.c
+++ b/source/components/events/evrgnini.c
@@ -654,7 +654,6 @@ AcpiEvInitializeRegion (
         return_ACPI_STATUS (AE_OK);
     }
 
-    AcpiEvAssociateRegMethod (RegionObj);
     RegionObj->Common.Flags |= AOPOBJ_OBJECT_INITIALIZED;
 
     Node = RegionObj->Region.Node->Parent;

--- a/source/components/namespace/nsinit.c
+++ b/source/components/namespace/nsinit.c
@@ -230,6 +230,7 @@ AcpiNsInitializeDevices (
 {
     ACPI_STATUS             Status = AE_OK;
     ACPI_DEVICE_WALK_INFO   Info;
+    ACPI_HANDLE             Handle;
 
 
     ACPI_FUNCTION_TRACE (NsInitializeDevices);
@@ -283,6 +284,27 @@ AcpiNsInitializeDevices (
         {
             Info.Num_INI++;
         }
+
+        /*
+         * Execute \_SB._INI.
+	 * There appears to be a strict order requirement for \_SB._INI,
+         * which should be evaluated before any _REG evaluations.
+         */
+        Status = AcpiGetHandle (NULL, "\\_SB", &Handle);
+        if (ACPI_SUCCESS (Status))
+        {
+            memset (Info.EvaluateInfo, 0, sizeof (ACPI_EVALUATE_INFO));
+            Info.EvaluateInfo->PrefixNode = Handle;
+            Info.EvaluateInfo->RelativePathname = METHOD_NAME__INI;
+            Info.EvaluateInfo->Parameters = NULL;
+            Info.EvaluateInfo->Flags = ACPI_IGNORE_RETURN_VALUE;
+
+            Status = AcpiNsEvaluate (Info.EvaluateInfo);
+            if (ACPI_SUCCESS (Status))
+            {
+                Info.Num_INI++;
+            }
+        }
     }
 
     /*
@@ -291,6 +313,12 @@ AcpiNsInitializeDevices (
      * Note: Any objects accessed by the _REG methods will be automatically
      * initialized, even if they contain executable AML (see the call to
      * AcpiNsInitializeObjects below).
+     *
+     * Note: According to the ACPI specification, we actually needn't execute
+     * _REG for SystemMemory/SystemIo operation regions, but for PCI_Config
+     * operation regions, it is required to evaluate _REG for those on a PCI
+     * root bus that doesn't contain _BBN object. So this code is kept here
+     * in order not to break things.
      */
     if (!(Flags & ACPI_NO_ADDRESS_SPACE_INIT))
     {
@@ -714,33 +742,37 @@ AcpiNsInitOneDevice (
      * Note: We know there is an _INI within this subtree, but it may not be
      * under this particular device, it may be lower in the branch.
      */
-    ACPI_DEBUG_EXEC (AcpiUtDisplayInitPathname (
-        ACPI_TYPE_METHOD, DeviceNode, METHOD_NAME__INI));
-
-    memset (Info, 0, sizeof (ACPI_EVALUATE_INFO));
-    Info->PrefixNode = DeviceNode;
-    Info->RelativePathname = METHOD_NAME__INI;
-    Info->Parameters = NULL;
-    Info->Flags = ACPI_IGNORE_RETURN_VALUE;
-
-    Status = AcpiNsEvaluate (Info);
-    if (ACPI_SUCCESS (Status))
+    if (!ACPI_COMPARE_NAME (DeviceNode->Name.Ascii, "_SB_") ||
+        DeviceNode->Parent != AcpiGbl_RootNode)
     {
-        WalkInfo->Num_INI++;
-    }
+        ACPI_DEBUG_EXEC (AcpiUtDisplayInitPathname (
+            ACPI_TYPE_METHOD, DeviceNode, METHOD_NAME__INI));
+
+        memset (Info, 0, sizeof (ACPI_EVALUATE_INFO));
+        Info->PrefixNode = DeviceNode;
+        Info->RelativePathname = METHOD_NAME__INI;
+        Info->Parameters = NULL;
+        Info->Flags = ACPI_IGNORE_RETURN_VALUE;
+
+        Status = AcpiNsEvaluate (Info);
+        if (ACPI_SUCCESS (Status))
+        {
+            WalkInfo->Num_INI++;
+        }
 
 #ifdef ACPI_DEBUG_OUTPUT
-    else if (Status != AE_NOT_FOUND)
-    {
-        /* Ignore error and move on to next device */
+        else if (Status != AE_NOT_FOUND)
+        {
+            /* Ignore error and move on to next device */
 
-        char *ScopeName = AcpiNsGetNormalizedPathname (DeviceNode, TRUE);
+            char *ScopeName = AcpiNsGetNormalizedPathname (DeviceNode, TRUE);
 
-        ACPI_EXCEPTION ((AE_INFO, Status, "during %s._INI execution",
-            ScopeName));
-        ACPI_FREE (ScopeName);
-    }
+            ACPI_EXCEPTION ((AE_INFO, Status, "during %s._INI execution",
+                ScopeName));
+            ACPI_FREE (ScopeName);
+        }
 #endif
+    }
 
     /* Ignore errors from above */
 

--- a/source/include/acevents.h
+++ b/source/include/acevents.h
@@ -345,10 +345,6 @@ AcpiEvDetachRegion (
     BOOLEAN                 AcpiNsIsLocked);
 
 void
-AcpiEvAssociateRegMethod (
-    ACPI_OPERAND_OBJECT     *RegionObj);
-
-void
 AcpiEvExecuteRegMethods (
     ACPI_NAMESPACE_NODE     *Node,
     ACPI_ADR_SPACE_TYPE     SpaceId,


### PR DESCRIPTION
This pull request contains required fixes for enabling "AcpiGbl_GroupModuleLevelCode = FALSE".

- _REG association issue:
In Linux, EC is supported in 2 ways:
During early stage, Linux will install EC operation region handler without _REG executed using ECDT EC settings. This allows EC read/write transactions to happen during the table loading.
During late stage, Linux will uninstall EC operation region handler and re-install EC operation region handler with _REG executed using DSDT EC settings. This allows EC read/write transactions and query event handling to happen after the table loading.
Then it seems _REG association will fail in the first step as the namespace hasn't been fully initialized at that time and the association cannot be recovered in the second step.
This patch fixes this issue by letting _REG to be always associated before executing _REG so that _REG can be correctly associated again and executed in the second step.
This looks like the root cause of current strange Linux ECDT support and ACPICA MLC support.
Without this fix, Linux will fail to notify AML table of the "EC operation region handler connected" event, and no EC accesses can happen even in the late stage.
Tested at: https://bugzilla.kernel.org/show_bug.cgi?id=112911

- \_SB._INI order issue:
When ECDT order issue is fixed in Linux, strict \_SB._INI evaluation order is required.
Some BIOS tables allow ECDT EC to be used in the entire device enumeration process, and thus initialize ECDT in \_SB._INI.
According to the validation, \_SB._INI is the first control method evaluated by the Windows.
But it is not in ACPICA, we need to introduce special logic to ensure this before fixing ECDT.