### PR TITLE
Acpica access

### DIFF
--- a/source/components/hardware/hwregs.c
+++ b/source/components/hardware/hwregs.c
@@ -272,7 +272,7 @@ AcpiHwRead (
     *Value = 0;
     AccessWidth = Reg->AccessWidth ? Reg->AccessWidth : 1;
     AccessWidth = 1 << (AccessWidth + 2);
-    BitWidth = ACPI_ROUND_UP (Reg->BitOffset + Reg->BitWidth, AccessWidth);
+    BitWidth = Reg->BitOffset + Reg->BitWidth;
     BitOffset = Reg->BitOffset;
 
     /*
@@ -375,7 +375,7 @@ AcpiHwWrite (
 
     AccessWidth = Reg->AccessWidth ? Reg->AccessWidth : 1;
     AccessWidth = 1 << (AccessWidth + 2);
-    BitWidth = ACPI_ROUND_UP (Reg->BitOffset + Reg->BitWidth, AccessWidth);
+    BitWidth = Reg->BitOffset + Reg->BitWidth;
     BitOffset = Reg->BitOffset;
 
     /*

--- a/source/components/hardware/hwregs.c
+++ b/source/components/hardware/hwregs.c
@@ -315,7 +315,7 @@ AcpiHwRead (
         }
 
         ACPI_SET_BITS (Value, Index * AccessWidth,
-            ((1 << AccessWidth) - 1), Value32);
+            (1 << AccessWidth) - 1, Value32);
 
         BitWidth -= BitWidth > AccessWidth ? AccessWidth : BitWidth;
         Index++;
@@ -385,8 +385,8 @@ AcpiHwWrite (
     Index = 0;
     while (BitWidth)
     {
-        NewValue32 = ACPI_GET_BITS (&Value, (Index * AccessWidth),
-            ((1 << AccessWidth) - 1));
+        NewValue32 = ACPI_GET_BITS (&Value, Index * AccessWidth,
+            (1 << AccessWidth) - 1);
 
         if (BitOffset > AccessWidth)
         {

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -363,10 +363,10 @@
 /* Generic bitfield macros and masks */
 
 #define ACPI_GET_BITS(SourcePtr, Position, Mask) \
-    ((*SourcePtr >> Position) & Mask)
+    ((*(SourcePtr) >> (Position)) & (Mask))
 
 #define ACPI_SET_BITS(TargetPtr, Position, Mask, Value) \
-    (*TargetPtr |= ((Value & Mask) << Position))
+    (*(TargetPtr) |= (((Value) & (Mask)) << (Position)))
 
 #define ACPI_1BIT_MASK      0x00000001
 #define ACPI_2BIT_MASK      0x00000003


### PR DESCRIPTION
The build issue should be fixed in the macro definition, not the caller side.
Going to add a fix to remove wrong ACPI_ROUND_UP() from AcpiHwRead()/AcpiHwWrite(). This was erroneously introduced by the previous BitOffset fix.