### PR TITLE
Improve compatibility with POSIX yacc.

### DIFF
--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -274,9 +274,11 @@ include ../Makefile.rules
 # Function to safely execute yacc
 #
 safe_yacc = \
-	_d=`mktemp -d $(OBJDIR)/$(1)XXXXXX` &&\
-	$(YACC) $(YFLAGS) -p$(1) -o$$_d/$(1).c -d $(2) &&\
-	mv $$_d/$(1)$(suffix $(3)) $(3);\
+	_d=`mktemp -d $(OBJDIR)/$(1).XXXXXX` &&\
+	cd $$_d &&\
+	$(YACC) $(YFLAGS) -d -p$(1) $(abspath $(2)) &&\
+	cd - &&\
+	mv $$_d/y.tab$(suffix $(3)) $(3);\
 	_r=$$?;\
 	rm -fr $$_d;\
 	exit $$_r

--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -274,12 +274,12 @@ include ../Makefile.rules
 # Function to safely execute yacc
 #
 safe_yacc = \
-	_f=`echo $(1) | tr '[:upper:]' '[:lower:]'` &&\
-	_d=`mktemp -d $(OBJDIR)/$$_f.XXXXXX` &&\
-	_t=`basename $(3)` &&\
-	$(YACC) $(YFLAGS) -p$(1) -o$$_d/$$_f.c -d $(2) &&\
-	mv $$_d/$$_f.$${_t\#\#*.} $(3);\
-	test -d $$_d && rm -fr $$_d
+	_d=`mktemp -d $(OBJDIR)/$(1)XXXXXX` &&\
+	$(YACC) $(YFLAGS) -p$(1) -o$$_d/$(1).c -d $(2) &&\
+	mv $$_d/$(1)$(suffix $(3)) $(3);\
+	_r=$$?;\
+	rm -fr $$_d;\
+	exit $$_r
 
 #
 # Macro processing for iASL .y files


### PR DESCRIPTION
- byacc has a bug in "-o" option parsing.  Prefix may not be set properly
if its argument contains ".c" somewhere before the actual output file name.
With "byacc -ofoo.cXXXXX/foo.c -d foo.y", for example, it generates "foo.h"
instead of "foo.cXXXXX/foo.h" because ".cXXXXX/foo.c" is replaced with ".h".
- Prefer a GNU make built-in function, suffix(), rather than a series of
complex variable substitutions, to improve readability.
- Exit with a meaningful exit status to make it more like a real function.