### PR TITLE
Fix deconstification warnings with '-Wcast-qual'

### DIFF
--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -188,8 +188,8 @@ AcpiNsRootInitialize (
             continue;
         }
 
-        Status = AcpiNsLookup (NULL, (char *) InitVal->Name, InitVal->Type,
-            ACPI_IMODE_LOAD_PASS2, ACPI_NS_NO_UPSEARCH,
+        Status = AcpiNsLookup (NULL, ACPI_CAST_PTR (char, InitVal->Name),
+            InitVal->Type, ACPI_IMODE_LOAD_PASS2, ACPI_NS_NO_UPSEARCH,
             NULL, &NewNode);
         if (ACPI_FAILURE (Status))
         {

--- a/source/components/utilities/utdebug.c
+++ b/source/components/utilities/utdebug.c
@@ -704,6 +704,48 @@ AcpiUtPtrExit (
 
 /*******************************************************************************
  *
+ * FUNCTION:    AcpiUtStrExit
+ *
+ * PARAMETERS:  LineNumber          - Caller's line number
+ *              FunctionName        - Caller's procedure name
+ *              ModuleName          - Caller's module name
+ *              ComponentId         - Caller's component ID
+ *              String              - String to display
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Function exit trace. Prints only if TRACE_FUNCTIONS bit is
+ *              set in DebugLevel. Prints exit value also.
+ *
+ ******************************************************************************/
+
+void
+AcpiUtStrExit (
+    UINT32                  LineNumber,
+    const char              *FunctionName,
+    const char              *ModuleName,
+    UINT32                  ComponentId,
+    const char              *String)
+{
+
+    /* Check if enabled up-front for performance */
+
+    if (ACPI_IS_DEBUG_ENABLED (ACPI_LV_FUNCTIONS, ComponentId))
+    {
+        AcpiDebugPrint (ACPI_LV_FUNCTIONS,
+            LineNumber, FunctionName, ModuleName, ComponentId,
+            "%s %s\n", AcpiGbl_FunctionExitPrefix, String);
+    }
+
+    if (AcpiGbl_NestingLevel)
+    {
+        AcpiGbl_NestingLevel--;
+    }
+}
+
+
+/*******************************************************************************
+ *
  * FUNCTION:    AcpiTracePoint
  *
  * PARAMETERS:  Type                - Trace event type

--- a/source/components/utilities/utdecode.c
+++ b/source/components/utilities/utdecode.c
@@ -356,7 +356,7 @@ AcpiUtGetObjectTypeName (
         return_PTR ("Invalid object");
     }
 
-    return_PTR (AcpiUtGetTypeName (ObjDesc->Common.Type));
+    return_STR (AcpiUtGetTypeName (ObjDesc->Common.Type));
 }
 
 

--- a/source/include/acoutput.h
+++ b/source/include/acoutput.h
@@ -444,7 +444,7 @@
     ACPI_TRACE_ENTRY (Name, AcpiUtTraceU32, UINT32, Value)
 
 #define ACPI_FUNCTION_TRACE_STR(Name, String) \
-    ACPI_TRACE_ENTRY (Name, AcpiUtTraceStr, char *, String)
+    ACPI_TRACE_ENTRY (Name, AcpiUtTraceStr, const char *, String)
 
 #define ACPI_FUNCTION_ENTRY() \
     AcpiUtTrackStackPtr()
@@ -503,6 +503,9 @@
 
 #define return_PTR(Pointer) \
     ACPI_TRACE_EXIT (AcpiUtPtrExit, void *, Pointer)
+
+#define return_STR(String) \
+    ACPI_TRACE_EXIT (AcpiUtStrExit, const char *, String)
 
 #define return_VALUE(Value) \
     ACPI_TRACE_EXIT (AcpiUtValueExit, UINT64, Value)

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -488,6 +488,14 @@ AcpiUtPtrExit (
     UINT8                   *Ptr);
 
 void
+AcpiUtStrExit (
+    UINT32                  LineNumber,
+    const char              *FunctionName,
+    const char              *ModuleName,
+    UINT32                  ComponentId,
+    const char              *String);
+
+void
 AcpiUtDebugDumpBuffer (
     UINT8                   *Buffer,
     UINT32                  Count,


### PR DESCRIPTION
These changes fixes casting `const char *` to `char *` and `void *` warnings.  It is critical for FreeBSD kernel.