### PR TITLE
Windows: add support for dumping SSDT tables

### DIFF
--- a/source/os_specific/service_layers/oswintbl.c
+++ b/source/os_specific/service_layers/oswintbl.c
@@ -143,8 +143,8 @@ static char             KeyBuffer[LOCAL_BUFFER_SIZE];
 static char             ErrorBuffer[LOCAL_BUFFER_SIZE];
 
 /*
- * Tables supported in the Windows registry. SSDTs are not placed into
- * the registry, a limitation.
+ * Tables supported in the Windows registry. Zero or more SSDTs are assumed to
+ * follow these tables.
  */
 static char             *SupportedTables[] =
 {
@@ -154,9 +154,9 @@ static char             *SupportedTables[] =
     "FACP"
 };
 
-/* Max index for table above */
+/* Number of table names for the table above. */
 
-#define ACPI_OS_MAX_TABLE_INDEX     3
+#define ACPI_OS_NUM_TABLE_ENTRIES   4
 
 
 /******************************************************************************
@@ -243,14 +243,32 @@ AcpiOsGetTableByIndex (
     ACPI_PHYSICAL_ADDRESS   *Address)
 {
     ACPI_STATUS             Status;
+    char                    *Signature;
 
 
-    if (Index > ACPI_OS_MAX_TABLE_INDEX)
+    if (Index < ACPI_OS_NUM_TABLE_ENTRIES)
     {
-        return (AE_LIMIT);
+        Signature = SupportedTables[Index];
+        Index = 0;
+    }
+    else
+    {
+        Signature = ACPI_SIG_SSDT;
+        Index -= ACPI_OS_NUM_TABLE_ENTRIES;
     }
 
-    Status = AcpiOsGetTableByName (SupportedTables[Index], 0, Table, Address);
+    Status = AcpiOsGetTableByName (Signature, Index, Table, Address);
+
+    if (ACPI_SUCCESS (Status))
+    {
+        *Instance = Index;
+    }
+    else if (Status == AE_NOT_FOUND && ACPI_COMPARE_NAME (Signature, ACPI_SIG_SSDT))
+    {
+        /* Treat SSDTs that are not found as invalid index. */
+        Status = (AE_LIMIT);
+    }
+
     return (Status);
 }
 
@@ -297,11 +315,9 @@ AcpiOsGetTableByName (
     ACPI_STATUS             Status = AE_OK;
 
 
-    /*
-     * Windows has no SSDTs in the registry, so multiple instances are
-     * not supported.
-     */
-    if (Instance > 0)
+    /* Multiple instances are only supported for SSDT tables. */
+
+    if (Instance > 0 && !ACPI_COMPARE_NAME (Signature, ACPI_SIG_SSDT))
     {
         return (AE_LIMIT);
     }
@@ -314,6 +330,28 @@ AcpiOsGetTableByName (
         if (AcpiUtSafeStrcat (KeyBuffer, sizeof (KeyBuffer), Signature))
         {
             return (AE_BUFFER_OVERFLOW);
+        }
+
+        /*
+         * Windows stores SSDT at SSDT, SSD1, ..., SSD9, SSDA, ..., SSDS, SSDT,
+         * SSDU, ..., SSDY. If the first (0th) and the 29th tables have the same
+         * OEM ID, Table ID and Revision, then the 29th entry will overwrite the
+         * first entry... Let's hope that we do not have that many entries.
+         */
+        if (Instance > 0 && ACPI_COMPARE_NAME (Signature, ACPI_SIG_SSDT))
+        {
+            if (Instance < 10)
+            {
+                KeyBuffer[strlen (KeyBuffer) - 1] = '0' + (char) Instance;
+            }
+            else if (Instance < 29)
+            {
+                KeyBuffer[strlen (KeyBuffer) - 1] = 'A' + (char) (Instance - 10);
+            }
+            else
+            {
+                return (AE_LIMIT);
+            }
         }
 
         WinStatus = RegOpenKeyEx (HKEY_LOCAL_MACHINE, KeyBuffer,
@@ -336,6 +374,12 @@ AcpiOsGetTableByName (
             else if (ACPI_COMPARE_NAME (Signature, "XSDT"))
             {
                 Signature = "RSDT";
+            }
+            else if (ACPI_COMPARE_NAME (Signature, ACPI_SIG_SSDT))
+            {
+                /* SSDT may not be present on older Windows versions, but it is
+                 * also possible that the index is not found. */
+                return (AE_NOT_FOUND);
             }
             else
             {


### PR DESCRIPTION
Newer Windows versions expose SSDT tables via the registry. Make sure
that AcpiDump is able to query for these tables.

Tested with 'acpidump' and 'acpidump -s' on Windows 7 (registry entries
not present, nothing to dump), Windows 8.1 and 10 (29 SSDT tables). The
number of ACPI tables was be varied using QEMU system emulation.

Reference: https://bugs.acpica.org/show_bug.cgi?id=1282
Signed-off-by: Peter Wu <peter@lekensteyn.nl>