### PR TITLE
Acpica lock

### DIFF
--- a/source/components/namespace/nsload.c
+++ b/source/components/namespace/nsload.c
@@ -161,21 +161,6 @@ AcpiNsLoadTable (
     ACPI_FUNCTION_TRACE (NsLoadTable);
 
 
-    /*
-     * Parse the table and load the namespace with all named
-     * objects found within. Control methods are NOT parsed
-     * at this time. In fact, the control methods cannot be
-     * parsed until the entire namespace is loaded, because
-     * if a control method makes a forward reference (call)
-     * to another control method, we can't continue parsing
-     * because we don't know how many arguments to parse next!
-     */
-    Status = AcpiUtAcquireMutex (ACPI_MTX_NAMESPACE);
-    if (ACPI_FAILURE (Status))
-    {
-        return_ACPI_STATUS (Status);
-    }
-
     /* If table already loaded into namespace, just return */
 
     if (AcpiTbIsTableLoaded (TableIndex))
@@ -193,6 +178,15 @@ AcpiNsLoadTable (
         goto Unlock;
     }
 
+    /*
+     * Parse the table and load the namespace with all named
+     * objects found within. Control methods are NOT parsed
+     * at this time. In fact, the control methods cannot be
+     * parsed until the entire namespace is loaded, because
+     * if a control method makes a forward reference (call)
+     * to another control method, we can't continue parsing
+     * because we don't know how many arguments to parse next!
+     */
     Status = AcpiNsParseTable (TableIndex, Node);
     if (ACPI_SUCCESS (Status))
     {
@@ -209,7 +203,6 @@ AcpiNsLoadTable (
          * exist. This target of Scope must already exist in the
          * namespace, as per the ACPI specification.
          */
-        (void) AcpiUtReleaseMutex (ACPI_MTX_NAMESPACE);
         AcpiNsDeleteNamespaceByOwner (
             AcpiGbl_RootTableList.Tables[TableIndex].OwnerId);
 
@@ -218,8 +211,6 @@ AcpiNsLoadTable (
     }
 
 Unlock:
-    (void) AcpiUtReleaseMutex (ACPI_MTX_NAMESPACE);
-
     if (ACPI_FAILURE (Status))
     {
         return_ACPI_STATUS (Status);

--- a/source/components/namespace/nsparse.c
+++ b/source/components/namespace/nsparse.c
@@ -215,9 +215,7 @@ AcpiNsExecuteTable (
         goto Cleanup;
     }
 
-    (void) AcpiUtReleaseMutex (ACPI_MTX_NAMESPACE);
     Status = AcpiPsExecuteTable (Info);
-    (void) AcpiUtAcquireMutex (ACPI_MTX_NAMESPACE);
 
 Cleanup:
     if (Info)


### PR DESCRIPTION
Lock order is wrong.
During boot, it is namespace -> interpreter.
While we should always ensure interpreter -> namespace.
Linux doesn't trigger this because this happens in boot stage, there is no parallel running threads invoking ACPICA at that time.

Thanks
-Lv