### PR TITLE
Fix acpidump.efi binary

### DIFF
--- a/generate/efi/Makefile.config
+++ b/generate/efi/Makefile.config
@@ -27,15 +27,6 @@
 # OPT_CFLAGS Optimization CFLAGS can be overridden on the make command
 #            line by adding the followings to the invocation:
 #            OPT_CFLAGS="..."
-# SHARED     Testing build to check if symbols are not implemented.
-#            GCC won't complain missing of symbols as our programs are
-#            compiled with -shared. This can be overridden on the make
-#            command line by adding the followings to the invocation:
-#            SHARED=false
-#            Link failures should only be seen for the _start and
-#            DivU64x32.  They are the only 2 GNU EFI functions we are
-#            using in order not to introduce architecture specific code
-#            into ACPICA.
 #
 # Notes:
 #   gcc should be version 4 or greater, otherwise some of the options
@@ -50,7 +41,6 @@
 PROGS =  acpidump
 HOST =   $(shell uname -m | sed s,i[3456789]86,ia32,)
 TARGET = $(shell uname -m | sed s,i[3456789]86,ia32,)
-SHARED ?= true
 OBJDIR = obj
 BINDIR = bin
 
@@ -108,14 +98,9 @@ CFLAGS  = \
 LDFLAGS	= \
 	-nostdlib\
 	-znocombreloc\
-	-Bsymbolic
-ifeq ($(strip $(SHARED)), true)
-LDFLAGS	+= \
+	-Bsymbolic\
 	-shared\
 	--no-undefined
-endif
-LIBS    = \
-	$(shell $(CC) -print-libgcc-file-name)
 OBJCOPYFLAGS = \
 	-j .text\
 	-j .sdata\
@@ -221,9 +206,10 @@ LDFLAGS	+= \
 	-T $(EFILIB)/elf_$(TARGET)_efi.lds\
 	-L$(EFILIB)\
 	$(EFILIB)/crt0-efi-$(TARGET).o
-LIBS += \
+LIBS = \
 	-lefi\
 	-lgnuefi\
+	$(shell $(CC) -print-libgcc-file-name)
 
 #
 # Bison/Flex configuration

--- a/generate/efi/Makefile.config
+++ b/generate/efi/Makefile.config
@@ -111,7 +111,8 @@ LDFLAGS	= \
 	-Bsymbolic
 ifeq ($(strip $(SHARED)), true)
 LDFLAGS	+= \
-	-shared
+	-shared\
+	--no-undefined
 endif
 LIBS    = \
 	$(shell $(CC) -print-libgcc-file-name)
@@ -167,7 +168,8 @@ CWARNINGFLAGS = \
 	-Wlogical-op\
 	-Wmissing-parameter-type\
 	-Wold-style-declaration\
-	-Wtype-limits
+	-Wtype-limits\
+	-Wno-error=logical-op
 #
 # Extra warning flags (for possible future use)
 #

--- a/generate/efi/acpidump/Makefile
+++ b/generate/efi/acpidump/Makefile
@@ -44,7 +44,9 @@ OBJECTS = \
 	$(OBJDIR)/utmath.o\
 	$(OBJDIR)/utprint.o\
 	$(OBJDIR)/utstring.o\
-	$(OBJDIR)/utxferror.o
+	$(OBJDIR)/utxferror.o\
+	${OBJDIR}/utnonansi.o\
+	${OBJDIR}/utascii.o
 
 #
 # Flags specific to acpidump


### PR DESCRIPTION
Fix build by ignoring 'logical-op' warning (ACPI_FILE_OUT and ACPI_FILE_ERR are
the same on uefi).
Fix final binary by linking missing objects and adding linker flag to warn in
case of undefined references.