### PR TITLE
Fix deprecated functions when building for __APPLE__

### DIFF
--- a/source/include/platform/acmacosx.h
+++ b/source/include/platform/acmacosx.h
@@ -119,6 +119,7 @@
 #include "aclinux.h"
 
 #ifdef __APPLE__
+#undef sem_destroy
 #include <semaphore.h>
 #define sem_destroy         sem_close
 #define ACPI_USE_ALTERNATE_TIMEOUT

--- a/source/include/platform/acmacosx.h
+++ b/source/include/platform/acmacosx.h
@@ -119,6 +119,7 @@
 #include "aclinux.h"
 
 #ifdef __APPLE__
+#include <semaphore.h>
 #define sem_destroy         sem_close
 #define ACPI_USE_ALTERNATE_TIMEOUT
 #endif /* __APPLE__ */

--- a/source/os_specific/service_layers/osunixxf.c
+++ b/source/os_specific/service_layers/osunixxf.c
@@ -829,7 +829,7 @@ AcpiOsCreateSemaphore (
 
 #ifdef __APPLE__
     {
-        char            *SemaphoreName = tmpnam (NULL);
+        char            *SemaphoreName = mktemp (NULL);
 
         Sem = sem_open (SemaphoreName, O_EXCL|O_CREAT, 0755, InitialUnits);
         if (!Sem)


### PR DESCRIPTION
The current ACPICA code will not compile with gcc or clang if building under OS X as it currently stands.  It calls two deprecated functions, sem_destroy and tmpnam.  Tmpnam is very insecure and can be used quite easily as a vehicle for privilege escalation via interprocess attacks.  mktemp behaves identically, including the way in which it fails (returns -1 etc), but is not deprecated and is secure.  It can be used as a simple drop-in replacement.  It is also safely tucked away inside an #ifdef __APPLE__ code block, so the effect it has is perfectly scoped.  

The other problem is that in a header file specific to the __APPLE__ platform, a macro is already in place and is clearly an attempt to expand sem_destroy (which is deprecated to the point that it is not even actually implemented in OS X, it is an optional part of the POSIX standard) with a perfectly valid alternative, sem_close.  Unfortunately, this macro is defined in a header file that is always included well before <semaphore.h> is included, so the declaration of sem_destroy (which is also where it is explicitly marked as deprecated) in semaphore.h is, just like was defined, expanded to sem_close by the preprocessor.  This results in sem_close being declared as deprecated, and wholly incorrectly, and the end result is nothing is actually solved.  So I simply made sure any such define was removed directly before including semaphore .h, then reapplied after, so it would have the intended effect throughout the rest of the code without the macro expansion polluting the semaphore.h system header.  

Overall, this is almost on the level of a cosmetic change, and only effects OS X users, but it would be nice if typing `make` just worked for us too :).  

Thanks!