### PR TITLE
Fix acpidump.efi build

### DIFF
--- a/source/include/platform/acefi.h
+++ b/source/include/platform/acefi.h
@@ -332,6 +332,6 @@ extern struct _ACPI_EFI_BOOT_SERVICES       *BS;
 
 #define FILE                struct _ACPI_SIMPLE_TEXT_OUTPUT_INTERFACE
 #define stdout              ST->ConOut
-#define stderr              ST->ConOut
+#define stderr              ST->StdErr
 
 #endif /* __ACEFI_H__ */


### PR DESCRIPTION
Fix 'logical-op' warning generated by gcc 6.0 or above regarding conditionals
as "if (File == stdout || File == stderr)" since in that environment both
stdout and stderr were expanded to ST->ConOut.

Signed-off-by: Marcelo Ferreira <joaomarcelo@lesc.ufc.br>