### PR TITLE
Fix efi build with gcc 6.0+

### DIFF
--- a/source/include/platform/acefi.h
+++ b/source/include/platform/acefi.h
@@ -331,7 +331,8 @@ extern struct _ACPI_EFI_SYSTEM_TABLE        *ST;
 extern struct _ACPI_EFI_BOOT_SERVICES       *BS;
 
 #define FILE                struct _ACPI_SIMPLE_TEXT_OUTPUT_INTERFACE
-#define stdout              ST->ConOut
-#define stderr              ST->ConOut
+
+extern FILE                 *stdout;
+extern FILE                 *stderr;
 
 #endif /* __ACEFI_H__ */

--- a/source/os_specific/efi/oseficlib.c
+++ b/source/os_specific/efi/oseficlib.c
@@ -153,6 +153,8 @@ AcpiEfiFlushFile (
 
 /* Local variables */
 
+FILE                        *stdout = NULL;
+FILE                        *stderr = NULL;
 static ACPI_EFI_FILE_HANDLE AcpiGbl_EfiCurrentVolume = NULL;
 ACPI_EFI_GUID               AcpiGbl_LoadedImageProtocol = ACPI_EFI_LOADED_IMAGE_PROTOCOL;
 ACPI_EFI_GUID               AcpiGbl_TextInProtocol = ACPI_SIMPLE_TEXT_INPUT_PROTOCOL;
@@ -827,6 +829,8 @@ efi_main (
 
     ST = SystemTab;
     BS = SystemTab->BootServices;
+    stdout = SystemTab->ConOut;
+    stderr = SystemTab->ConOut;
 
     /* Retrieve image information */
 


### PR DESCRIPTION
Avoid 'logical-op' warning caused by stdout and stderr (both defined as ST->ConOut).
This patch replaces the stdout and stderr defines by global variables (both initialized to point to ST->ConOut).
