### PR TITLE
Acpica gas

### DIFF
--- a/source/components/executer/exfldio.c
+++ b/source/components/executer/exfldio.c
@@ -1018,20 +1018,9 @@ AcpiExInsertIntoField (
 
     AccessBitWidth = ACPI_MUL_8 (ObjDesc->CommonField.AccessByteWidth);
 
-    /*
-     * Create the bitmasks used for bit insertion.
-     * Note: This if/else is used to bypass compiler differences with the
-     * shift operator
-     */
-    if (AccessBitWidth == ACPI_INTEGER_BIT_SIZE)
-    {
-        WidthMask = ACPI_UINT64_MAX;
-    }
-    else
-    {
-        WidthMask = ACPI_MASK_BITS_ABOVE (AccessBitWidth);
-    }
+    /* Create the bitmasks used for bit insertion */
 
+    WidthMask = ACPI_MASK_BITS_ABOVE_64 (AccessBitWidth);
     Mask = WidthMask &
         ACPI_MASK_BITS_BELOW (ObjDesc->CommonField.StartFieldBitOffset);
 

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -346,9 +346,21 @@
  * Bit positions start at zero.
  * MASK_BITS_ABOVE creates a mask starting AT the position and above
  * MASK_BITS_BELOW creates a mask starting one bit BELOW the position
+ * MASK_BITS_ABOVE/BELOW accpets a bit offset to create a mask
+ * MASK_BITS_ABOVE/BELOW_32/64 accpets a bit width to create a mask
+ * Note: The ACPI_INTEGER_BIT_SIZE check is used to bypass compiler
+ * differences with the shift operator
  */
 #define ACPI_MASK_BITS_ABOVE(position)      (~((ACPI_UINT64_MAX) << ((UINT32) (position))))
 #define ACPI_MASK_BITS_BELOW(position)      ((ACPI_UINT64_MAX) << ((UINT32) (position)))
+#define ACPI_MASK_BITS_ABOVE_32(width)      ((UINT32) ACPI_MASK_BITS_ABOVE(width))
+#define ACPI_MASK_BITS_BELOW_32(width)      ((UINT32) ACPI_MASK_BITS_BELOW(width))
+#define ACPI_MASK_BITS_ABOVE_64(width)      ((width) == ACPI_INTEGER_BIT_SIZE ? \
+                                                ACPI_UINT64_MAX : \
+                                                ACPI_MASK_BITS_ABOVE(width))
+#define ACPI_MASK_BITS_BELOW_64(width)      ((width) == ACPI_INTEGER_BIT_SIZE ? \
+                                                (UINT64) 0 : \
+                                                ACPI_MASK_BITS_BELOW(width))
 
 /* Bitfields within ACPI registers */
 

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -336,6 +336,11 @@
 
 #define ACPI_IS_MISALIGNED(value)           (((ACPI_SIZE) value) & (sizeof(ACPI_SIZE)-1))
 
+/* Generic (power-of-two) rounding */
+
+#define ACPI_IS_ALIGNED(a, s)               (((a) & ((s) - 1)) == 0)
+#define ACPI_IS_POWER_OF_TWO(a)             ACPI_IS_ALIGNED(a, a)
+
 /*
  * Bitmask creation
  * Bit positions start at zero.

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -338,6 +338,66 @@
 
 /* Generic (power-of-two) rounding */
 
+#ifndef ACPI_USE_NATIVE_BIT_FINDER
+
+#define __ACPI_FIND_LAST_BIT_2(a, r)        ((((UINT8)  (a)) & 0x02) ? (r)+1 : (r))
+#define __ACPI_FIND_LAST_BIT_4(a, r)        ((((UINT8)  (a)) & 0x0C) ? \
+                                             __ACPI_FIND_LAST_BIT_2  ((a)>>2,  (r)+2) : \
+                                             __ACPI_FIND_LAST_BIT_2  ((a), (r)))
+#define __ACPI_FIND_LAST_BIT_8(a, r)        ((((UINT8)  (a)) & 0xF0) ? \
+                                             __ACPI_FIND_LAST_BIT_4  ((a)>>4,  (r)+4) : \
+                                             __ACPI_FIND_LAST_BIT_4  ((a), (r)))
+#define __ACPI_FIND_LAST_BIT_16(a, r)       ((((UINT16) (a)) & 0xFF00) ? \
+                                             __ACPI_FIND_LAST_BIT_8  ((a)>>8,  (r)+8) : \
+                                             __ACPI_FIND_LAST_BIT_8  ((a), (r)))
+#define __ACPI_FIND_LAST_BIT_32(a, r)       ((((UINT32) (a)) & 0xFFFF0000) ? \
+                                             __ACPI_FIND_LAST_BIT_16 ((a)>>16, (r)+16) : \
+                                             __ACPI_FIND_LAST_BIT_16 ((a), (r)))
+#define __ACPI_FIND_LAST_BIT_64(a, r)       ((((UINT64) (a)) & 0xFFFFFFFF00000000) ? \
+                                             __ACPI_FIND_LAST_BIT_32 ((a)>>32, (r)+32) : \
+                                             __ACPI_FIND_LAST_BIT_32 ((a), (r)))
+
+#define ACPI_FIND_LAST_BIT_8(a)             ((a) ? __ACPI_FIND_LAST_BIT_8 (a, 1) : 0)
+#define ACPI_FIND_LAST_BIT_16(a)            ((a) ? __ACPI_FIND_LAST_BIT_16 (a, 1) : 0)
+#define ACPI_FIND_LAST_BIT_32(a)            ((a) ? __ACPI_FIND_LAST_BIT_32 (a, 1) : 0)
+#define ACPI_FIND_LAST_BIT_64(a)            ((a) ? __ACPI_FIND_LAST_BIT_64 (a, 1) : 0)
+
+#define __ACPI_FIND_FIRST_BIT_2(a, r)       ((((UINT8) (a)) & 0x01) ? (r) : (r)+1)
+#define __ACPI_FIND_FIRST_BIT_4(a, r)       ((((UINT8) (a)) & 0x03) ? \
+                                             __ACPI_FIND_FIRST_BIT_2  ((a), (r)) : \
+                                             __ACPI_FIND_FIRST_BIT_2  ((a)>>2, (r)+2))
+#define __ACPI_FIND_FIRST_BIT_8(a, r)       ((((UINT8) (a)) & 0x0F) ? \
+                                             __ACPI_FIND_FIRST_BIT_4  ((a), (r)) : \
+                                             __ACPI_FIND_FIRST_BIT_4  ((a)>>4, (r)+4))
+#define __ACPI_FIND_FIRST_BIT_16(a, r)      ((((UINT16) (a)) & 0x00FF) ? \
+                                             __ACPI_FIND_FIRST_BIT_8  ((a), (r)) : \
+                                             __ACPI_FIND_FIRST_BIT_8  ((a)>>8, (r)+8))
+#define __ACPI_FIND_FIRST_BIT_32(a, r)      ((((UINT32) (a)) & 0x0000FFFF) ? \
+                                             __ACPI_FIND_FIRST_BIT_16 ((a), (r)) : \
+                                             __ACPI_FIND_FIRST_BIT_16 ((a)>>16, (r)+16))
+#define __ACPI_FIND_FIRST_BIT_64(a, r)      ((((UINT64) (a)) & 0x00000000FFFFFFFF) ? \
+                                             __ACPI_FIND_FIRST_BIT_32 ((a), (r)) : \
+                                             __ACPI_FIND_FIRST_BIT_32 ((a)>>32, (r)+32))
+
+#define ACPI_FIND_FIRST_BIT_8(a)            ((a) ? __ACPI_FIND_FIRST_BIT_8 (a, 1) : 0)
+#define ACPI_FIND_FIRST_BIT_16(a)           ((a) ? __ACPI_FIND_FIRST_BIT_16 (a, 1) : 0)
+#define ACPI_FIND_FIRST_BIT_32(a)           ((a) ? __ACPI_FIND_FIRST_BIT_32 (a, 1) : 0)
+#define ACPI_FIND_FIRST_BIT_64(a)           ((a) ? __ACPI_FIND_FIRST_BIT_64 (a, 1) : 0)
+
+#endif /* ACPI_USE_NATIVE_BIT_FINDER */
+
+#define ACPI_ROUND_UP_POWER_OF_TWO_8(a)     ((UINT8) \
+                                            (((UINT16) 1) <<  ACPI_FIND_LAST_BIT_8  ((a)  - 1)))
+#define ACPI_ROUND_DOWN_POWER_OF_TWO_8(a)   ((UINT8) \
+                                            (((UINT16) 1) << (ACPI_FIND_LAST_BIT_8  ((a)) - 1)))
+#define ACPI_ROUND_UP_POWER_OF_TWO_16(a)    ((UINT16) \
+                                            (((UINT32) 1) <<  ACPI_FIND_LAST_BIT_16 ((a)  - 1)))
+#define ACPI_ROUND_DOWN_POWER_OF_TWO_16(a)  ((UINT16) \
+                                            (((UINT32) 1) << (ACPI_FIND_LAST_BIT_16 ((a)) - 1)))
+#define ACPI_ROUND_UP_POWER_OF_TWO_32(a)    ((UINT32) \
+                                            (((UINT64) 1) <<  ACPI_FIND_LAST_BIT_32 ((a)  - 1)))
+#define ACPI_ROUND_DOWN_POWER_OF_TWO_32(a)  ((UINT32) \
+                                            (((UINT64) 1) << (ACPI_FIND_LAST_BIT_32 ((a)) - 1)))
 #define ACPI_IS_ALIGNED(a, s)               (((a) & ((s) - 1)) == 0)
 #define ACPI_IS_POWER_OF_TWO(a)             ACPI_IS_ALIGNED(a, a)
 


### PR DESCRIPTION
Current GAS code in Linux upstream.
AcpiHwWrite() support is not included because of issue related to the predefined FADT register length.
However AcpiHwRead() won't be affected.
So it is tested in Linux upstream for months and is proven to be safe.

Our new GAS improvement will be based on this.

Thanks
