### PR TITLE
Use ; instead of , where appropriate.

### DIFF
--- a/source/compiler/aslopt.c
+++ b/source/compiler/aslopt.c
@@ -205,7 +205,7 @@ OptSearchToRoot (
      * not match, and we cannot use this optimization.
      */
     Path = &(((char *) TargetPath->Pointer)[
-        TargetPath->Length - ACPI_NAME_SIZE]),
+        TargetPath->Length - ACPI_NAME_SIZE]);
     ScopeInfo.Scope.Node = CurrentNode;
 
     /* Lookup the NameSeg using SEARCH_PARENT (search-to-root) */

--- a/source/components/disassembler/dmresrcl2.c
+++ b/source/components/disassembler/dmresrcl2.c
@@ -586,7 +586,7 @@ AcpiDmI2cSerialBusDescriptor (
     ResourceSourceOffset = sizeof (AML_RESOURCE_COMMON_SERIALBUS) +
         Resource->CommonSerialBus.TypeDataLength;
 
-    DeviceName = ACPI_ADD_PTR (char, Resource, ResourceSourceOffset),
+    DeviceName = ACPI_ADD_PTR (char, Resource, ResourceSourceOffset);
     AcpiUtPrintString (DeviceName, ACPI_UINT16_MAX);
 
     /* ResourceSourceIndex, ResourceUsage */
@@ -669,7 +669,7 @@ AcpiDmSpiSerialBusDescriptor (
     ResourceSourceOffset = sizeof (AML_RESOURCE_COMMON_SERIALBUS) +
         Resource->CommonSerialBus.TypeDataLength;
 
-    DeviceName = ACPI_ADD_PTR (char, Resource, ResourceSourceOffset),
+    DeviceName = ACPI_ADD_PTR (char, Resource, ResourceSourceOffset);
     AcpiUtPrintString (DeviceName, ACPI_UINT16_MAX);
 
     /* ResourceSourceIndex, ResourceUsage */
@@ -755,7 +755,7 @@ AcpiDmUartSerialBusDescriptor (
     ResourceSourceOffset = sizeof (AML_RESOURCE_COMMON_SERIALBUS) +
         Resource->CommonSerialBus.TypeDataLength;
 
-    DeviceName = ACPI_ADD_PTR (char, Resource, ResourceSourceOffset),
+    DeviceName = ACPI_ADD_PTR (char, Resource, ResourceSourceOffset);
     AcpiUtPrintString (DeviceName, ACPI_UINT16_MAX);
 
     /* ResourceSourceIndex, ResourceUsage */


### PR DESCRIPTION
The commas are legal but inadvisable here.