### PR TITLE
Efi mem and I/O access services

### DIFF
--- a/source/include/platform/acefi.h
+++ b/source/include/platform/acefi.h
@@ -319,6 +319,7 @@ struct _ACPI_EFI_FILE_HANDLE;
 struct _ACPI_EFI_BOOT_SERVICES;
 struct _ACPI_EFI_SYSTEM_TABLE;
 struct _ACPI_EFI_PCI_IO;
+struct _ACPI_EFI_PCI_ROOT_BRIDGE_IO;
 
 extern struct _ACPI_EFI_SYSTEM_TABLE        *ST;
 extern struct _ACPI_EFI_BOOT_SERVICES       *BS;

--- a/source/include/platform/acefiex.h
+++ b/source/include/platform/acefiex.h
@@ -968,6 +968,61 @@ typedef struct _ACPI_EFI_PCI_IO {
     VOID                                *RomImage;
 } ACPI_EFI_PCI_IO;
 
+/*
+ * EFI PCI Root Bridge I/O Protocol
+ */
+#define ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL \
+  { 0x2f707ebb, 0x4a1a, 0x11d4, {0x9a, 0x38, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d} }
+
+typedef enum {
+    AcpiEfiPciWidthUint8,
+    AcpiEfiPciWidthUint16,
+    AcpiEfiPciWidthUint32,
+    AcpiEfiPciWidthUint64,
+    AcpiEfiPciWidthFifoUint8,
+    AcpiEfiPciWidthFifoUint16,
+    AcpiEfiPciWidthFifoUint32,
+    AcpiEfiPciWidthFifoUint64,
+    AcpiEfiPciWidthFillUint8,
+    AcpiEfiPciWidthFillUint16,
+    AcpiEfiPciWidthFillUint32,
+    AcpiEfiPciWidthFillUint64,
+    AcpiEfiPciWidthMaximum
+} ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_WIDTH;
+
+typedef
+ACPI_EFI_STATUS
+(ACPI_EFI_API *ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_IO_MEM)(
+    struct _ACPI_EFI_PCI_ROOT_BRIDGE_IO      *This,
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_WIDTH Width,
+    UINT64                              Address,
+    UINTN                               Count,
+    VOID                                *Buffer);
+
+typedef struct {
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_IO_MEM Read;
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_IO_MEM Write;
+} ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_ACCESS;
+
+typedef struct _ACPI_EFI_PCI_ROOT_BRIDGE_IO {
+    ACPI_EFI_HANDLE                     ParentHandle;
+    ACPI_EFI_UNKNOWN_INTERFACE          PollMem;
+    ACPI_EFI_UNKNOWN_INTERFACE          PollIo;
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_ACCESS Mem;
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_ACCESS Io;
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_ACCESS Pci;
+    ACPI_EFI_UNKNOWN_INTERFACE          CopyMem;
+    ACPI_EFI_UNKNOWN_INTERFACE          Map;
+    ACPI_EFI_UNKNOWN_INTERFACE          Unmap;
+    ACPI_EFI_UNKNOWN_INTERFACE          AllocateBuffer;
+    ACPI_EFI_UNKNOWN_INTERFACE          FreeBuffer;
+    ACPI_EFI_UNKNOWN_INTERFACE          Flush;
+    ACPI_EFI_UNKNOWN_INTERFACE          GetAttributes;
+    ACPI_EFI_UNKNOWN_INTERFACE          SetAttributes;
+    ACPI_EFI_UNKNOWN_INTERFACE          Configuration;
+    UINT32                              SegmentNumber;
+} ACPI_EFI_PCI_ROOT_BRIDGE_IO;
+
 /* GNU EFI definitions */
 
 #if defined(_GNU_EFI)

--- a/source/os_specific/efi/osefixf.c
+++ b/source/os_specific/efi/osefixf.c
@@ -672,6 +672,138 @@ AcpiEfiGetPciDev (
 
 /******************************************************************************
  *
+ * FUNCTION:    AcpiOsReadPort
+ *
+ * PARAMETERS:  Address             - Address of I/O port/register to read
+ *              Value               - Where value is placed
+ *              Width               - Number of bits
+ *
+ * RETURN:      Value read from port
+ *
+ * DESCRIPTION: Read data from an I/O port or register
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsReadPort (
+    ACPI_IO_ADDRESS         Address,
+    UINT32                  *Value64,
+    UINT32                  Width)
+{
+    ACPI_EFI_STATUS         EfiStatus;
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO *PciRootBridge = NULL;
+    ACPI_EFI_GUID           AcpiEfiPciRootBridgeIoProtocol = ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL;
+    UINT8                   Value8;
+    UINT16                  Value16;
+    UINT32                  Value32;
+
+    EfiStatus = uefi_call_wrapper (BS->LocateProtocol, 3, &AcpiEfiPciRootBridgeIoProtocol, NULL, (VOID **) &PciRootBridge);
+    if (ACPI_EFI_ERROR (EfiStatus))
+    {
+        return (AE_NOT_FOUND);
+    }
+
+    switch (Width)
+    {
+    case 8:
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Read, 5, PciRootBridge,
+            AcpiEfiPciWidthUint8, Address, 1, (VOID *) &Value8);
+        *Value64 = Value8;
+        break;
+
+    case 16:
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Read, 5, PciRootBridge,
+            AcpiEfiPciWidthUint16, Address, 1, (VOID *) &Value16);
+        *Value64 = Value16;
+        break;
+
+    case 32:
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Read, 5, PciRootBridge,
+            AcpiEfiPciWidthUint32, Address, 1, (VOID *) &Value32);
+        *Value64 = Value32;
+        break;
+
+    case 64:
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Read, 5, PciRootBridge,
+            AcpiEfiPciWidthUint64, Address, 1, (VOID *) Value64);
+        break;
+
+    default:
+        return (AE_BAD_PARAMETER);
+    }
+
+    return (ACPI_EFI_ERROR (EfiStatus)) ? (AE_ERROR) : (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsWritePort
+ *
+ * PARAMETERS:  Address             - Address of I/O port/register to write
+ *              Value               - Value to write
+ *              Width               - Number of bits
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Write data to an I/O port or register
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsWritePort (
+    ACPI_IO_ADDRESS         Address,
+    UINT32                  Value64,
+    UINT32                  Width)
+{
+    ACPI_EFI_STATUS         EfiStatus;
+    ACPI_EFI_PCI_ROOT_BRIDGE_IO *PciRootBridge = NULL;
+    ACPI_EFI_GUID           AcpiEfiPciRootBridgeIoProtocol = ACPI_EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL;
+    UINT8                   Value8;
+    UINT16                  Value16;
+    UINT32                  Value32;
+
+    EfiStatus = uefi_call_wrapper (BS->LocateProtocol, 3, &AcpiEfiPciRootBridgeIoProtocol, NULL, (VOID **) &PciRootBridge);
+    if (ACPI_EFI_ERROR (EfiStatus))
+    {
+        return (AE_NOT_FOUND);
+    }
+
+    switch (Width)
+    {
+    case 8:
+        Value8 = (UINT8) Value64;
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Write, 5, PciRootBridge,
+            AcpiEfiPciWidthUint8, Address, 1, (VOID *) &Value8);
+        break;
+
+    case 16:
+        Value16 = (UINT16) Value64;
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Write, 5, PciRootBridge,
+            AcpiEfiPciWidthUint16, Address, 1, (VOID *) &Value16);
+        break;
+
+    case 32:
+        Value32 = (UINT32) Value64;
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Write, 5, PciRootBridge,
+            AcpiEfiPciWidthUint32, Address, 1, (VOID *) &Value32);
+        break;
+
+    case 64:
+        EfiStatus = uefi_call_wrapper (PciRootBridge->Io.Write, 5, PciRootBridge,
+            AcpiEfiPciWidthUint64, Address, 1, (VOID *) &Value64);
+        break;
+
+    default:
+        return (AE_BAD_PARAMETER);
+    }
+
+    return (ACPI_EFI_ERROR (EfiStatus)) ? (AE_ERROR) : (AE_OK);
+}
+
+
+/******************************************************************************
+ *
  * FUNCTION:    AcpiOsReadMemory
  *
  * PARAMETERS:  Address             - Physical Memory Address to read
@@ -694,25 +826,26 @@ AcpiOsReadMemory (
 
     switch (Width)
     {
-        case 8:
-            *Value = *(UINT8 *) Address;
-            break;
+    case 8:
+        *Value = *(UINT8 *) Address;
+        break;
 
-        case 16:
-            *Value = *(UINT16 *) Address;
-            break;
+    case 16:
+        *Value = *(UINT16 *) Address;
+        break;
 
-        case 32:
-            *Value = *(UINT32 *) Address;
-            break;
+    case 32:
+        *Value = *(UINT32 *) Address;
+        break;
 
-        case 64:
-            *Value = *(UINT64 *) Address;
-            break;
+    case 64:
+        *Value = *(UINT64 *) Address;
+        break;
 
-        default:
-            return (AE_BAD_PARAMETER);
+    default:
+        return (AE_BAD_PARAMETER);
     }
+
     return (AE_OK);
 }
 
@@ -740,24 +873,25 @@ AcpiOsWriteMemory (
 
     switch (Width)
     {
-        case 8:
-            *(UINT8 *) Address = (UINT8) Value;
-            break;
+    case 8:
+        *(UINT8 *) Address = (UINT8) Value;
+        break;
 
-        case 16:
-            *(UINT16 *) Address = (UINT16) Value;
-            break;
+    case 16:
+        *(UINT16 *) Address = (UINT16) Value;
+        break;
 
-        case 32:
-            *(UINT32 *) Address = (UINT32) Value;
-            break;
+    case 32:
+        *(UINT32 *) Address = (UINT32) Value;
+        break;
 
-        case 64:
-            *(UINT64 *) Address = Value;
-            break;
+    case 64:
+        *(UINT64 *) Address = Value;
+        break;
 
-        default:
-            return (AE_BAD_PARAMETER);
+    default:
+        return (AE_BAD_PARAMETER);
     }
+
     return (AE_OK);
 }

--- a/source/os_specific/efi/osefixf.c
+++ b/source/os_specific/efi/osefixf.c
@@ -668,3 +668,96 @@ AcpiEfiGetPciDev (
     uefi_call_wrapper (BS->FreePool, 1, Handles);
     return (NULL);
 }
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsReadMemory
+ *
+ * PARAMETERS:  Address             - Physical Memory Address to read
+ *              Value               - Where value is placed
+ *              Width               - Number of bits (8,16,32, or 64)
+ *
+ * RETURN:      Value read from physical memory address. Always returned
+ *              as a 64-bit integer, regardless of the read width.
+ *
+ * DESCRIPTION: Read data from a physical memory address
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsReadMemory (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    UINT64                  *Value,
+    UINT32                  Width)
+{
+
+    switch (Width)
+    {
+        case 8:
+            *Value = *(UINT8 *) Address;
+            break;
+
+        case 16:
+            *Value = *(UINT16 *) Address;
+            break;
+
+        case 32:
+            *Value = *(UINT32 *) Address;
+            break;
+
+        case 64:
+            *Value = *(UINT64 *) Address;
+            break;
+
+        default:
+            return (AE_BAD_PARAMETER);
+    }
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsWriteMemory
+ *
+ * PARAMETERS:  Address             - Physical Memory Address to write
+ *              Value               - Value to write
+ *              Width               - Number of bits (8,16,32, or 64)
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Write data to a physical memory address
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsWriteMemory (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    UINT64                  Value,
+    UINT32                  Width)
+{
+
+    switch (Width)
+    {
+        case 8:
+            *(UINT8 *) Address = (UINT8) Value;
+            break;
+
+        case 16:
+            *(UINT16 *) Address = (UINT16) Value;
+            break;
+
+        case 32:
+            *(UINT32 *) Address = (UINT32) Value;
+            break;
+
+        case 64:
+            *(UINT64 *) Address = Value;
+            break;
+
+        default:
+            return (AE_BAD_PARAMETER);
+    }
+    return (AE_OK);
+}


### PR DESCRIPTION
Implementation of OS services to access physical memory and I/O on uefi environment.

Memory access is made directly (no virtual address translation needed) and ports are considered memory-mapped.

Marcelo
