### PR TITLE
acpixtract: support CRLF in input files

### DIFF
--- a/source/tools/acpixtract/acpixtract.c
+++ b/source/tools/acpixtract/acpixtract.c
@@ -159,7 +159,7 @@ AxExtractTables (
 
     /* Open input in text mode, output is in binary mode */
 
-    InputFile = fopen (InputPathname, "rt");
+    InputFile = fopen (InputPathname, "r");
     if (!InputFile)
     {
         printf ("Could not open input file %s\n", InputPathname);
@@ -358,7 +358,7 @@ AxExtractToMultiAmlFile (
 
     /* Open the input file in text mode */
 
-    InputFile = fopen (InputPathname, "rt");
+    InputFile = fopen (InputPathname, "r");
     if (!InputFile)
     {
         printf ("Could not open input file %s\n", InputPathname);
@@ -489,7 +489,7 @@ AxListTables (
 
     /* Open input in text mode, output is in binary mode */
 
-    InputFile = fopen (InputPathname, "rt");
+    InputFile = fopen (InputPathname, "r");
     if (!InputFile)
     {
         printf ("Could not open input file %s\n", InputPathname);

--- a/source/tools/acpixtract/axutils.c
+++ b/source/tools/acpixtract/axutils.c
@@ -334,7 +334,7 @@ AxCountTableInstances (
     unsigned int            Instances = 0;
 
 
-    InputFile = fopen (InputPathname, "rt");
+    InputFile = fopen (InputPathname, "r");
     if (!InputFile)
     {
         printf ("Could not open input file %s\n", InputPathname);

--- a/source/tools/acpixtract/axutils.c
+++ b/source/tools/acpixtract/axutils.c
@@ -172,9 +172,9 @@ AxIsEmptyLine (
         Buffer++;
     }
 
-    /* If end-of-line, this line is empty */
+    /* Line is empty when a Unix or DOS-style line terminator is found. */
 
-    if (*Buffer == '\n')
+    if ((*Buffer == '\r') || (*Buffer == '\n'))
     {
         return (1);
     }


### PR DESCRIPTION
Users copying the output of acpidump may accidentally replace LF by
CRLF which confused acpixtract, resulting in only one line.

That happens because `\r\n` is not considered an empty line. Then
AxListTables would continue trying to read a whole header (`\r\nSSDT @
0x...`) and discover that `\r\nSS` is not a valid signature and skip to
the next line. At that point however, the header is partially read and
cannot be matched anymore.

Signed-off-by: Peter Wu <peter@lekensteyn.nl>