### PR TITLE
Acpica linuxize

### DIFF
--- a/generate/linux/gen-patch.sh
+++ b/generate/linux/gen-patch.sh
@@ -53,8 +53,8 @@ if [ "x${COMMIT}" = "x" ]; then
 	COMMIT=HEAD
 fi
 
-after=`git log -1 ${COMMIT} --format=%H | cut -c1-8`
-before=`git log -1 ${COMMIT}^1 --format=%H | cut -c1-8`
+after=`git log -1 ${COMMIT} --format=%H`
+before=`git log -1 ${COMMIT}^1 --format=%H`
 
 SCRIPT=`(cd \`dirname $0\`; pwd)`
 . $SCRIPT/libacpica.sh

--- a/generate/linux/gen-repo.sh
+++ b/generate/linux/gen-repo.sh
@@ -34,7 +34,7 @@ do
 done
 shift $(($OPTIND - 1))
 
-version=`git log -1 $1 --format=%H | cut -c1-8`
+version=`git log -1 $1 --format=%H`
 
 SCRIPT=`(cd \`dirname $0\`; pwd)`
 . $SCRIPT/libacpica.sh


### PR DESCRIPTION
Urgent fix that fixes breakage of Linuxize process.
SHA1 hash now has conflicts preventing linuxized patches from being generated.