### PR TITLE
Compiler: Remove "Argument never used" remark if ArgX is a Target

### DIFF
--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -562,20 +562,17 @@ XfNamespaceLocateBegin (
         RegisterNumber = Op->Asl.AmlOpcode - AML_ARG0; /* 0x68 through 0x6F */
         MethodArgs = Node->MethodArgs;
 
+        /* Mark this Arg as referenced */
+
+        MethodArgs[RegisterNumber].Flags |= ASL_ARG_REFERENCED;
+        MethodArgs[RegisterNumber].Op = Op;
+
         if (Op->Asl.CompileFlags & NODE_IS_TARGET)
         {
             /* Arg is being initialized */
 
             MethodArgs[RegisterNumber].Flags |= ASL_ARG_INITIALIZED;
-            MethodArgs[RegisterNumber].Op = Op;
-
-            return_ACPI_STATUS (AE_OK);
         }
-
-        /* Mark this Arg as referenced */
-
-        MethodArgs[RegisterNumber].Flags |= ASL_ARG_REFERENCED;
-        MethodArgs[RegisterNumber].Op = Op;
 
         return_ACPI_STATUS (AE_OK);
     }


### PR DESCRIPTION
Since iasl cannot detect if an argument passed to a method is being
used as a reference, it is incorrect for the compiler to assume that
the argument is never used. Do not display this remark when ArgX is
being assigned a value.

Link: https://bugs.acpica.org/show_bug.cgi?id=1332
Suggested-by: Jeffrey Hugo <jhugo@codeaurora.org>
Signed-off-by: David E. Box <david.e.box@linux.intel.com>