### PR TITLE
debugger: fix memory leak on Pathname

### DIFF
--- a/source/components/debugger/dbmethod.c
+++ b/source/components/debugger/dbmethod.c
@@ -551,6 +551,7 @@ AcpiDbWalkForExecute (
     Status = AcpiGetObjectInfo (ObjHandle, &ObjInfo);
     if (ACPI_FAILURE (Status))
     {
+        ACPI_FREE (Pathname);
         return (Status);
     }
 


### PR DESCRIPTION
On the error return path when AcpiGetObjectInfo fails the allocated
pathname is not free'd leading to a memory leak.  Free pathname
to fix this.

Signed-off-by: Colin Ian King <colin.king@canonical.com>