### PR TITLE
Acpica 64bit

### DIFF
--- a/source/components/events/evgpe.c
+++ b/source/components/events/evgpe.c
@@ -515,8 +515,8 @@ AcpiEvGpeDetect (
     ACPI_GPE_HANDLER_INFO   *GpeHandlerInfo;
     UINT32                  IntStatus = ACPI_INTERRUPT_NOT_HANDLED;
     UINT8                   EnabledStatusByte;
-    UINT32                  StatusReg;
-    UINT32                  EnableReg;
+    UINT64                  StatusReg;
+    UINT64                  EnableReg;
     ACPI_CPU_FLAGS          Flags;
     UINT32                  i;
     UINT32                  j;
@@ -593,7 +593,7 @@ AcpiEvGpeDetect (
                 "RunEnable=%02X, WakeEnable=%02X\n",
                 GpeRegisterInfo->BaseGpeNumber,
                 GpeRegisterInfo->BaseGpeNumber + (ACPI_GPE_REGISTER_WIDTH - 1),
-                StatusReg, EnableReg,
+                (UINT32) StatusReg, (UINT32) EnableReg,
                 GpeRegisterInfo->EnableForRun,
                 GpeRegisterInfo->EnableForWake));
 

--- a/source/components/hardware/hwgpe.c
+++ b/source/components/hardware/hwgpe.c
@@ -181,7 +181,7 @@ AcpiHwLowSetGpe (
 {
     ACPI_GPE_REGISTER_INFO  *GpeRegisterInfo;
     ACPI_STATUS             Status = AE_OK;
-    UINT32                  EnableMask;
+    UINT64                  EnableMask;
     UINT32                  RegisterBit;
 
 
@@ -306,7 +306,7 @@ AcpiHwGetGpeStatus (
     ACPI_GPE_EVENT_INFO     *GpeEventInfo,
     ACPI_EVENT_STATUS       *EventStatus)
 {
-    UINT32                  InByte;
+    UINT64                  InByte;
     UINT32                  RegisterBit;
     ACPI_GPE_REGISTER_INFO  *GpeRegisterInfo;
     ACPI_EVENT_STATUS       LocalEventStatus = 0;

--- a/source/components/hardware/hwregs.c
+++ b/source/components/hardware/hwregs.c
@@ -319,9 +319,8 @@ AcpiHwValidateRegister (
  *
  * RETURN:      Status
  *
- * DESCRIPTION: Read from either memory or IO space. This is a 32-bit max
- *              version of AcpiRead, used internally since the overhead of
- *              64-bit values is not needed.
+ * DESCRIPTION: Read from either memory or IO space. This is a 64-bit max
+ *              version of AcpiRead.
  *
  * LIMITATIONS: <These limitations also apply to AcpiHwWrite>
  *      SpaceID must be SystemMemory or SystemIO.
@@ -330,7 +329,7 @@ AcpiHwValidateRegister (
 
 ACPI_STATUS
 AcpiHwRead (
-    UINT32                  *Value,
+    UINT64                  *Value,
     ACPI_GENERIC_ADDRESS    *Reg)
 {
     UINT64                  Address;
@@ -348,18 +347,18 @@ AcpiHwRead (
 
     /* Validate contents of the GAS register */
 
-    Status = AcpiHwValidateRegister (Reg, 32, &Address);
+    Status = AcpiHwValidateRegister (Reg, 64, &Address);
     if (ACPI_FAILURE (Status))
     {
         return (Status);
     }
 
     /*
-     * Initialize entire 32-bit return value to zero, convert AccessWidth
+     * Initialize entire 64-bit return value to zero, convert AccessWidth
      * into number of bits based
      */
     *Value = 0;
-    AccessWidth = AcpiHwGetAccessBitWidth (Address, Reg, 32);
+    AccessWidth = AcpiHwGetAccessBitWidth (Address, Reg, 64);
     BitWidth = Reg->BitOffset + Reg->BitWidth;
     BitOffset = Reg->BitOffset;
 
@@ -372,7 +371,7 @@ AcpiHwRead (
     {
         if (BitOffset >= AccessWidth)
         {
-            Value32 = 0;
+            Value64 = 0;
             BitOffset -= AccessWidth;
         }
         else
@@ -382,31 +381,31 @@ AcpiHwRead (
                 Status = AcpiOsReadMemory ((ACPI_PHYSICAL_ADDRESS)
                     Address + Index * ACPI_DIV_8 (AccessWidth),
                     &Value64, AccessWidth);
-                Value32 = (UINT32) Value64;
             }
             else /* ACPI_ADR_SPACE_SYSTEM_IO, validated earlier */
             {
                 Status = AcpiHwReadPort ((ACPI_IO_ADDRESS)
                     Address + Index * ACPI_DIV_8 (AccessWidth),
                     &Value32, AccessWidth);
+                Value64 = (UINT64) Value32;
             }
         }
 
         /*
          * Use offset style bit writes because "Index * AccessWidth" is
-         * ensured to be less than 32-bits by AcpiHwValidateRegister().
+         * ensured to be less than 64-bits by AcpiHwValidateRegister().
          */
         ACPI_SET_BITS (Value, Index * AccessWidth,
-            ACPI_MASK_BITS_ABOVE_32 (AccessWidth), Value32);
+            ACPI_MASK_BITS_ABOVE_64 (AccessWidth), Value64);
 
         BitWidth -= BitWidth > AccessWidth ? AccessWidth : BitWidth;
         Index++;
     }
 
     ACPI_DEBUG_PRINT ((ACPI_DB_IO,
-        "Read:  %8.8X width %2d from %8.8X%8.8X (%s)\n",
-        *Value, AccessWidth, ACPI_FORMAT_UINT64 (Address),
-        AcpiUtGetRegionName (Reg->SpaceId)));
+        "Read:  %8.8X%8.8X width %2d from %8.8X%8.8X (%s)\n",
+        ACPI_FORMAT_UINT64 (*Value), AccessWidth,
+        ACPI_FORMAT_UINT64 (Address), AcpiUtGetRegionName (Reg->SpaceId)));
 
     return (Status);
 }
@@ -421,15 +420,14 @@ AcpiHwRead (
  *
  * RETURN:      Status
  *
- * DESCRIPTION: Write to either memory or IO space. This is a 32-bit max
- *              version of AcpiWrite, used internally since the overhead of
- *              64-bit values is not needed.
+ * DESCRIPTION: Write to either memory or IO space. This is a 64-bit max
+ *              version of AcpiWrite.
  *
  ******************************************************************************/
 
 ACPI_STATUS
 AcpiHwWrite (
-    UINT32                  Value,
+    UINT64                  Value,
     ACPI_GENERIC_ADDRESS    *Reg)
 {
     UINT64                  Address;
@@ -437,7 +435,6 @@ AcpiHwWrite (
     UINT32                  BitWidth;
     UINT8                   BitOffset;
     UINT64                  Value64;
-    UINT32                  Value32;
     UINT8                   Index;
     ACPI_STATUS             Status;
 
@@ -447,7 +444,7 @@ AcpiHwWrite (
 
     /* Validate contents of the GAS register */
 
-    Status = AcpiHwValidateRegister (Reg, 32, &Address);
+    Status = AcpiHwValidateRegister (Reg, 64, &Address);
     if (ACPI_FAILURE (Status))
     {
         return (Status);
@@ -455,7 +452,7 @@ AcpiHwWrite (
 
     /* Convert AccessWidth into number of bits based */
 
-    AccessWidth = AcpiHwGetAccessBitWidth (Address, Reg, 32);
+    AccessWidth = AcpiHwGetAccessBitWidth (Address, Reg, 64);
     BitWidth = Reg->BitOffset + Reg->BitWidth;
     BitOffset = Reg->BitOffset;
 
@@ -468,10 +465,10 @@ AcpiHwWrite (
     {
         /*
          * Use offset style bit reads because "Index * AccessWidth" is
-         * ensured to be less than 32-bits by AcpiHwValidateRegister().
+         * ensured to be less than 64-bits by AcpiHwValidateRegister().
          */
-        Value32 = ACPI_GET_BITS (&Value, Index * AccessWidth,
-            ACPI_MASK_BITS_ABOVE_32 (AccessWidth));
+        Value64 = ACPI_GET_BITS (&Value, Index * AccessWidth,
+            ACPI_MASK_BITS_ABOVE_64 (AccessWidth));
 
         if (BitOffset >= AccessWidth)
         {
@@ -481,7 +478,6 @@ AcpiHwWrite (
         {
             if (Reg->SpaceId == ACPI_ADR_SPACE_SYSTEM_MEMORY)
             {
-                Value64 = (UINT64) Value32;
                 Status = AcpiOsWriteMemory ((ACPI_PHYSICAL_ADDRESS)
                     Address + Index * ACPI_DIV_8 (AccessWidth),
                     Value64, AccessWidth);
@@ -490,7 +486,7 @@ AcpiHwWrite (
             {
                 Status = AcpiHwWritePort ((ACPI_IO_ADDRESS)
                     Address + Index * ACPI_DIV_8 (AccessWidth),
-                    Value32, AccessWidth);
+                    (UINT32) Value64, AccessWidth);
             }
         }
 
@@ -503,9 +499,9 @@ AcpiHwWrite (
     }
 
     ACPI_DEBUG_PRINT ((ACPI_DB_IO,
-        "Wrote: %8.8X width %2d   to %8.8X%8.8X (%s)\n",
-        Value, AccessWidth, ACPI_FORMAT_UINT64 (Address),
-        AcpiUtGetRegionName (Reg->SpaceId)));
+        "Wrote: %8.8X%8.8X width %2d   to %8.8X%8.8X (%s)\n",
+        ACPI_FORMAT_UINT64 (Value), AccessWidth,
+        ACPI_FORMAT_UINT64 (Address), AcpiUtGetRegionName (Reg->SpaceId)));
 
     return (Status);
 }
@@ -652,6 +648,7 @@ AcpiHwRegisterRead (
     UINT32                  *ReturnValue)
 {
     UINT32                  Value = 0;
+    UINT64                  Value64;
     ACPI_STATUS             Status;
 
 
@@ -690,12 +687,14 @@ AcpiHwRegisterRead (
 
     case ACPI_REGISTER_PM2_CONTROL:          /* 8-bit access */
 
-        Status = AcpiHwRead (&Value, &AcpiGbl_FADT.XPm2ControlBlock);
+        Status = AcpiHwRead (&Value64, &AcpiGbl_FADT.XPm2ControlBlock);
+        Value = (UINT32) Value64;
         break;
 
     case ACPI_REGISTER_PM_TIMER:             /* 32-bit access */
 
-        Status = AcpiHwRead (&Value, &AcpiGbl_FADT.XPmTimerBlock);
+        Status = AcpiHwRead (&Value64, &AcpiGbl_FADT.XPmTimerBlock);
+        Value = (UINT32) Value64;
         break;
 
     case ACPI_REGISTER_SMI_COMMAND_BLOCK:    /* 8-bit access */
@@ -713,7 +712,7 @@ AcpiHwRegisterRead (
 
     if (ACPI_SUCCESS (Status))
     {
-        *ReturnValue = Value;
+        *ReturnValue = (UINT32) Value;
     }
 
     return_ACPI_STATUS (Status);
@@ -753,6 +752,7 @@ AcpiHwRegisterWrite (
 {
     ACPI_STATUS             Status;
     UINT32                  ReadValue;
+    UINT64                  ReadValue64;
 
 
     ACPI_FUNCTION_TRACE (HwRegisterWrite);
@@ -814,11 +814,12 @@ AcpiHwRegisterWrite (
          * For control registers, all reserved bits must be preserved,
          * as per the ACPI spec.
          */
-        Status = AcpiHwRead (&ReadValue, &AcpiGbl_FADT.XPm2ControlBlock);
+        Status = AcpiHwRead (&ReadValue64, &AcpiGbl_FADT.XPm2ControlBlock);
         if (ACPI_FAILURE (Status))
         {
             goto Exit;
         }
+        ReadValue = (UINT32) ReadValue64;
 
         /* Insert the bits to be preserved */
 
@@ -874,26 +875,29 @@ AcpiHwReadMultiple (
 {
     UINT32                  ValueA = 0;
     UINT32                  ValueB = 0;
+    UINT64                  Value64;
     ACPI_STATUS             Status;
 
 
     /* The first register is always required */
 
-    Status = AcpiHwRead (&ValueA, RegisterA);
+    Status = AcpiHwRead (&Value64, RegisterA);
     if (ACPI_FAILURE (Status))
     {
         return (Status);
     }
+    ValueA = (UINT32) Value64;
 
     /* Second register is optional */
 
     if (RegisterB->Address)
     {
-        Status = AcpiHwRead (&ValueB, RegisterB);
+        Status = AcpiHwRead (&Value64, RegisterB);
         if (ACPI_FAILURE (Status))
         {
             return (Status);
         }
+        ValueB = (UINT32) Value64;
     }
 
     /*

--- a/source/components/hardware/hwxface.c
+++ b/source/components/hardware/hwxface.c
@@ -211,84 +211,14 @@ AcpiRead (
     UINT64                  *ReturnValue,
     ACPI_GENERIC_ADDRESS    *Reg)
 {
-    UINT32                  ValueLo;
-    UINT32                  ValueHi;
-    UINT32                  Width;
-    UINT64                  Address;
     ACPI_STATUS             Status;
 
 
     ACPI_FUNCTION_NAME (AcpiRead);
 
 
-    if (!ReturnValue)
-    {
-        return (AE_BAD_PARAMETER);
-    }
-
-    /* Validate contents of the GAS register. Allow 64-bit transfers */
-
-    Status = AcpiHwValidateRegister (Reg, 64, &Address);
-    if (ACPI_FAILURE (Status))
-    {
-        return (Status);
-    }
-
-    /*
-     * Two address spaces supported: Memory or I/O. PCI_Config is
-     * not supported here because the GAS structure is insufficient
-     */
-    if (Reg->SpaceId == ACPI_ADR_SPACE_SYSTEM_MEMORY)
-    {
-        Status = AcpiOsReadMemory ((ACPI_PHYSICAL_ADDRESS)
-            Address, ReturnValue, Reg->BitWidth);
-        if (ACPI_FAILURE (Status))
-        {
-            return (Status);
-        }
-    }
-    else /* ACPI_ADR_SPACE_SYSTEM_IO, validated earlier */
-    {
-        ValueLo = 0;
-        ValueHi = 0;
-
-        Width = Reg->BitWidth;
-        if (Width == 64)
-        {
-            Width = 32; /* Break into two 32-bit transfers */
-        }
-
-        Status = AcpiHwReadPort ((ACPI_IO_ADDRESS)
-            Address, &ValueLo, Width);
-        if (ACPI_FAILURE (Status))
-        {
-            return (Status);
-        }
-
-        if (Reg->BitWidth == 64)
-        {
-            /* Read the top 32 bits */
-
-            Status = AcpiHwReadPort ((ACPI_IO_ADDRESS)
-                (Address + 4), &ValueHi, 32);
-            if (ACPI_FAILURE (Status))
-            {
-                return (Status);
-            }
-        }
-
-        /* Set the return value only if status is AE_OK */
-
-        *ReturnValue = (ValueLo | ((UINT64) ValueHi << 32));
-    }
-
-    ACPI_DEBUG_PRINT ((ACPI_DB_IO,
-        "Read:  %8.8X%8.8X width %2d from %8.8X%8.8X (%s)\n",
-        ACPI_FORMAT_UINT64 (*ReturnValue), Reg->BitWidth,
-        ACPI_FORMAT_UINT64 (Address),
-        AcpiUtGetRegionName (Reg->SpaceId)));
-
-    return (AE_OK);
+    Status = AcpiHwRead (ReturnValue, Reg);
+    return (Status);
 }
 
 ACPI_EXPORT_SYMBOL (AcpiRead)
@@ -312,67 +242,13 @@ AcpiWrite (
     UINT64                  Value,
     ACPI_GENERIC_ADDRESS    *Reg)
 {
-    UINT32                  Width;
-    UINT64                  Address;
     ACPI_STATUS             Status;
 
 
     ACPI_FUNCTION_NAME (AcpiWrite);
 
 
-    /* Validate contents of the GAS register. Allow 64-bit transfers */
-
-    Status = AcpiHwValidateRegister (Reg, 64, &Address);
-    if (ACPI_FAILURE (Status))
-    {
-        return (Status);
-    }
-
-    /*
-     * Two address spaces supported: Memory or IO. PCI_Config is
-     * not supported here because the GAS structure is insufficient
-     */
-    if (Reg->SpaceId == ACPI_ADR_SPACE_SYSTEM_MEMORY)
-    {
-        Status = AcpiOsWriteMemory ((ACPI_PHYSICAL_ADDRESS)
-            Address, Value, Reg->BitWidth);
-        if (ACPI_FAILURE (Status))
-        {
-            return (Status);
-        }
-    }
-    else /* ACPI_ADR_SPACE_SYSTEM_IO, validated earlier */
-    {
-        Width = Reg->BitWidth;
-        if (Width == 64)
-        {
-            Width = 32; /* Break into two 32-bit transfers */
-        }
-
-        Status = AcpiHwWritePort ((ACPI_IO_ADDRESS)
-            Address, ACPI_LODWORD (Value), Width);
-        if (ACPI_FAILURE (Status))
-        {
-            return (Status);
-        }
-
-        if (Reg->BitWidth == 64)
-        {
-            Status = AcpiHwWritePort ((ACPI_IO_ADDRESS)
-                (Address + 4), ACPI_HIDWORD (Value), 32);
-            if (ACPI_FAILURE (Status))
-            {
-                return (Status);
-            }
-        }
-    }
-
-    ACPI_DEBUG_PRINT ((ACPI_DB_IO,
-        "Wrote: %8.8X%8.8X width %2d   to %8.8X%8.8X (%s)\n",
-        ACPI_FORMAT_UINT64 (Value), Reg->BitWidth,
-        ACPI_FORMAT_UINT64 (Address),
-        AcpiUtGetRegionName (Reg->SpaceId)));
-
+    Status = AcpiHwWrite (Value, Reg);
     return (Status);
 }
 

--- a/source/include/achware.h
+++ b/source/include/achware.h
@@ -149,12 +149,12 @@ AcpiHwValidateRegister (
 
 ACPI_STATUS
 AcpiHwRead (
-    UINT32                  *Value,
+    UINT64                  *Value,
     ACPI_GENERIC_ADDRESS    *Reg);
 
 ACPI_STATUS
 AcpiHwWrite (
-    UINT32                  Value,
+    UINT64                  Value,
     ACPI_GENERIC_ADDRESS    *Reg);
 
 ACPI_BIT_REGISTER_INFO *


### PR DESCRIPTION
BZ 1287.
Contains 64-bit support of internal GAS.
External API then can invoke internal ones to reduce code redundancy.