### PR TITLE
compiler: disassembler: compile and disassemble externals in place

### DIFF
--- a/source/common/dmextern.c
+++ b/source/common/dmextern.c
@@ -1234,6 +1234,29 @@ AcpiDmEmitExternals (
     AcpiOsPrintf ("\n");
 }
 
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDmEmitExternal
+ *
+ * PARAMETERS:  Op                  External Parse Object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Emit an External() ASL statement for the current External
+ *              parse object
+ *
+ ******************************************************************************/
+
+void
+AcpiDmEmitExternal (
+    ACPI_PARSE_OBJECT       *NameOp,
+    ACPI_PARSE_OBJECT       *TypeOp)
+{
+    AcpiOsPrintf ("External (");
+    AcpiDmNamestring (NameOp->Common.Value.Name);
+    AcpiOsPrintf ("%s)\n",
+        AcpiDmGetObjectTypeName (TypeOp->Common.Value.Integer));
+}
 
 /*******************************************************************************
  *

--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -357,8 +357,17 @@ CmDoCompile (
     {
         Event = UtBeginEvent ("Resolve all Externals");
         DbgPrint (ASL_DEBUG_OUTPUT, "\nResolve Externals\n\n");
-        TrWalkParseTree (Gbl_ParseTreeRoot, ASL_WALK_VISIT_TWICE,
-            ExAmlExternalWalkBegin, ExAmlExternalWalkEnd, NULL);
+
+        if (Gbl_DoExternalsInPlace)
+        {
+            TrWalkParseTree (Gbl_ParseTreeRoot, ASL_WALK_VISIT_DOWNWARD,
+                ExAmlExternalWalkBegin, NULL, NULL);
+        }
+        else
+        {
+            TrWalkParseTree (Gbl_ParseTreeRoot, ASL_WALK_VISIT_TWICE,
+                ExAmlExternalWalkBegin, ExAmlExternalWalkEnd, NULL);
+        }
         UtEndEvent (Event);
     }
 

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -254,6 +254,7 @@ ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (Gbl_PruneParseTree, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (Gbl_DoTypechecking, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (Gbl_EnableReferenceTypechecking, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (Gbl_DoExternals, TRUE);
+ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (Gbl_DoExternalsInPlace, FALSE);
 
 
 #define HEX_OUTPUT_NONE             0

--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -647,6 +647,16 @@ AslDoOptions (
             AcpiGbl_DmEmitExternalOpcodes = TRUE;
             break;
 
+        case 'E':
+
+            /*
+             * iASL: keep External opcodes in place.
+             * No affect if Gbl_DoExternals is false.
+             */
+
+            Gbl_DoExternalsInPlace = TRUE;
+            break;
+
         case 'f':
 
             /* Disable folding on "normal" expressions */

--- a/source/components/disassembler/dmopcode.c
+++ b/source/components/disassembler/dmopcode.c
@@ -1078,14 +1078,12 @@ AcpiDmDisassembleOneOp (
 
         if (AcpiGbl_DmEmitExternalOpcodes)
         {
-            AcpiOsPrintf ("/* Opcode 0x15 */ ");
-
-            /* Fallthrough */
-        }
-        else
-        {
+            AcpiDmEmitExternal (AcpiPsGetArg(Op, 0),
+                AcpiPsGetArg(Op, 1));
             break;
         }
+
+        break;
 
     default:
 

--- a/source/components/disassembler/dmwalk.c
+++ b/source/components/disassembler/dmwalk.c
@@ -135,6 +135,14 @@ AcpiDmEmitExternals (
 {
     return;
 }
+
+void
+AcpiDmEmitExternal (
+    ACPI_PARSE_OBJECT       *NameOp,
+    ACPI_PARSE_OBJECT       *TypeOp)
+{
+    return;
+}
 #endif
 
 /* Local prototypes */
@@ -600,7 +608,11 @@ AcpiDmDescendingOp (
 
             /* Emit all External() declarations here */
 
-            AcpiDmEmitExternals ();
+            if (!AcpiGbl_DmEmitExternalOpcodes)
+            {
+                AcpiDmEmitExternals ();
+            }
+
             return (AE_OK);
         }
     }
@@ -677,6 +689,12 @@ AcpiDmDescendingOp (
         (Op->Common.AmlOpcode == AML_RETURN_OP))
     {
         Info->Level--;
+    }
+
+    if (Op->Common.AmlOpcode == AML_EXTERNAL_OP)
+    {
+        Op->Common.DisasmFlags |= ACPI_PARSEOP_IGNORE;
+        return (AE_CTRL_DEPTH);
     }
 
     /* Start the opcode argument list if necessary */

--- a/source/include/acdisasm.h
+++ b/source/include/acdisasm.h
@@ -875,6 +875,11 @@ AcpiDmEmitExternals (
     void);
 
 void
+AcpiDmEmitExternal (
+    ACPI_PARSE_OBJECT       *NameOp,
+    ACPI_PARSE_OBJECT       *TypeOp);
+
+void
 AcpiDmUnresolvedWarning (
     UINT8                   Type);
 


### PR DESCRIPTION
This patch adds an ACPICA testing feature that allows external
opcodes to be generated in place. This switch (-oE) doesn't place
an If (0) block around the opcodes. Use of this functions is for
compiler/disassembler testing only and is not intended to be
run through the interpreter. When this switch is used, the
disassembler will output the externals in the same location they
were at in the original ASL code and will not generate a separate
list of externals at the top of the file.

Signed-off-by: David E. Box <david.e.box@linux.intel.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>