### PR TITLE
Disassembler: Do not unconditionally remove temporary names

### DIFF
--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -1009,9 +1009,10 @@ typedef union acpi_parse_value
 #define ACPI_DASM_LNOT_SUFFIX           0x09        /* End  of a LNotEqual (etc.) pair of opcodes */
 #define ACPI_DASM_HID_STRING            0x0A        /* String is a _HID or _CID */
 #define ACPI_DASM_IGNORE_SINGLE         0x0B        /* Ignore the opcode but not it's children */
-#define ACPI_DASM_SWITCH_PREDICATE      0x0C        /* Object is a predicate for a Switch or Case block */
-#define ACPI_DASM_CASE                  0x0D        /* If/Else is a Case in a Switch/Case block */
-#define ACPI_DASM_DEFAULT               0x0E        /* Else is a Default in a Switch/Case block */
+#define ACPI_DASM_SWITCH                0x0C        /* While is a Switch */
+#define ACPI_DASM_SWITCH_PREDICATE      0x0D        /* Object is a predicate for a Switch or Case block */
+#define ACPI_DASM_CASE                  0x0E        /* If/Else is a Case in a Switch/Case block */
+#define ACPI_DASM_DEFAULT               0x0F        /* Else is a Default in a Switch/Case block */
 
 /*
  * Generic operation (for example:  If, While, Store)


### PR DESCRIPTION
Change the Switch disassembly code to check if the conversion can be
done earlier before removing temporary (_T_x) names. Prevents invalid
disassembly of AML created by older compilers (circa 2005).

Link: https://bugs.acpica.org/show_bug.cgi?id=1358
Link: https://bugs.acpica.org/show_bug.cgi?id=1360
Reported-by: racerrehabman@gmail.com
Signed-off-by: David E. Box <david.e.box@linux.intel.com>