### PR TITLE
Fix a redundant check.

### DIFF
--- a/source/compiler/asltree.c
+++ b/source/compiler/asltree.c
@@ -259,7 +259,7 @@ TrAllocateNode (
         }
 
         Gbl_CommentState.Latest_Parse_Node = Op;
-        if (Gbl_CommentState.Latest_Parse_Node->Asl.ParseOpName)
+        if (Gbl_CommentState.Latest_Parse_Node->Asl.ParseOpName[0])
         {
             CvDbgPrint ("trallocatenode=Set latest parse node to this node.\n");
             CvDbgPrint ("           Op->Asl.ParseOpName = %s\n",

--- a/source/compiler/asltypes.h
+++ b/source/compiler/asltypes.h
@@ -416,12 +416,11 @@ typedef struct asl_xref_info
 } ASL_XREF_INFO;
 
 
-typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef struct asl_file_node
 {
     FILE                    *File;
     UINT32                  CurrentLineNumber;
-    YY_BUFFER_STATE         State;
+    void                    *State;
     char                    *Filename;
     struct asl_file_node    *Next;
 


### PR DESCRIPTION
- `Gbl_CommentState.Latest_Parse_Node->Asl.ParseOpName` can never be null as it is an array, not a pointer.
- asltypes.h redefines YY_BUFFER_STATE.  It is a C11 feature and it may break build on certain platforms.  For example,

```
cc -c -O2 -pipe  -fstack-protector -fno-strict-aliasing -D_FreeBSD -D_GNU_SOURCE -I../../../source/include -D_FreeBSD -D_GNU_SOURCE -I../../../source/include -DACPI_ASL_COMPILER -I../../../source/compiler -Iobj -Wall -Werror -oobj/aslcompilerlex.o obj/aslcompilerlex.c
In file included from ../../../source/compiler/aslcompiler.l:45:
In file included from ../../../source/compiler/aslcompiler.h:72:
./../../source/compiler/asltypes.h:347:33: error: redefinition of typedef 'YY_BUFFER_STATE' is a C11 feature [-Werror,-Wtypedef-redefinition]
typedef struct yy_buffer_state *YY_BUFFER_STATE;
                                ^
obj/aslcompilerlex.c:184:33: note: previous definition is here
typedef struct yy_buffer_state *YY_BUFFER_STATE;
                                ^
1 error generated.
```