### PR TITLE
Remove redefinition of YY_BUFFER_STATE.

### DIFF
--- a/source/compiler/asltypes.h
+++ b/source/compiler/asltypes.h
@@ -416,12 +416,11 @@ typedef struct asl_xref_info
 } ASL_XREF_INFO;
 
 
-typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef struct asl_file_node
 {
     FILE                    *File;
     UINT32                  CurrentLineNumber;
-    YY_BUFFER_STATE         State;
+    void                    *State;
     char                    *Filename;
     struct asl_file_node    *Next;
 


### PR DESCRIPTION
This works around an unnecessary redefinition of typedef `YY_BUFFER_STATE`.