### PR TITLE
Makefile: enable compilation of ACPICA tools as 32-bit programs

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -148,6 +148,15 @@ ACPICA_HEADERS = \
 OPT_CFLAGS ?= $(CWARNINGFLAGS)
 
 #
+# Common compiler flags
+# The _GNU_SOURCE symbol is required for many hosts.
+#
+ifeq ($(M32),TRUE)
+CFLAGS +=-m32
+LDFLAGS +=-m32
+endif
+
+#
 # Optionally disable optimizations. Optimization causes problems on
 # some compilers such as gcc 4.4
 #


### PR DESCRIPTION
This is to facilitate compiling ACPICA tools as 32-bit programs on 64-bit machines.

To build as 32 bit programs, set the M32 variable to true when running make

Example: make M32=TRUE

Note: if the above results in a compilation error, there is a possibility
that 32-bit libraries may not be installed. If this is the case, run the
following command (on Ubuntu compiling with gcc)

    sudo apt-get install g++-multilib libc6-dev-i386

and run make again.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>