### PR TITLE
Change path's type from UINT8* to char*

### DIFF
--- a/source/common/adwalk.c
+++ b/source/common/adwalk.c
@@ -754,7 +754,7 @@ AcpiDmLoadDescendingOp (
     {
         /* For all named operators, get the new name */
 
-        Path = (char *) Op->Named.Path;
+        Path = Op->Named.Path;
 
         if (!Path && Op->Common.AmlOpcode == AML_INT_NAMEDFIELD_OP)
         {
@@ -926,7 +926,7 @@ AcpiDmXrefDescendingOp (
         }
         else if (Op->Common.AmlOpcode == AML_SCOPE_OP)
         {
-            Path = (char *) Op->Named.Path;
+            Path = Op->Named.Path;
         }
     }
     else if (OpInfo->Flags & AML_CREATE)

--- a/source/components/disassembler/dmwalk.c
+++ b/source/components/disassembler/dmwalk.c
@@ -782,7 +782,7 @@ AcpiDmDescendingOp (
                 Name = AcpiPsGetName (Op);
                 if (Op->Named.Path)
                 {
-                    AcpiDmNamestring ((char *) Op->Named.Path);
+                    AcpiDmNamestring (Op->Named.Path);
                 }
                 else
                 {

--- a/source/components/dispatcher/dswload.c
+++ b/source/components/dispatcher/dswload.c
@@ -518,7 +518,7 @@ AcpiDsLoad1BeginOp (
     /* Initialize the op */
 
 #if (defined (ACPI_NO_METHOD_EXECUTION) || defined (ACPI_CONSTANT_EVAL_ONLY))
-    Op->Named.Path = ACPI_CAST_PTR (UINT8, Path);
+    Op->Named.Path = Path;
 #endif
 
     if (Node)

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -1136,7 +1136,7 @@ typedef struct acpi_parse_obj_common
 typedef struct acpi_parse_obj_named
 {
     ACPI_PARSE_COMMON
-    UINT8                           *Path;
+    char                            *Path;
     UINT8                           *Data;          /* AML body or bytelist data */
     UINT32                          Length;         /* AML length */
     UINT32                          Name;           /* 4-byte name or zero if no name */


### PR DESCRIPTION
All instances using a named parseOp's path field has a type
cast from UINT8* to char*. Changing path's type from UINT8*
to char* eliminates type casting and retains the previous
behavior.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>