### PR TITLE
Acpica gcc

### DIFF
--- a/source/include/platform/acgcc.h
+++ b/source/include/platform/acgcc.h
@@ -156,7 +156,17 @@
  * Use compiler specific <stdarg.h> is a good practice for even when
  * -nostdinc is specified (i.e., ACPI_USE_STANDARD_HEADERS undefined.
  */
+#ifndef va_arg
+#ifdef ACPI_USE_BUILTIN_STDARG
+typedef __builtin_va_list       va_list;
+#define va_start(v, l)          __builtin_va_start(v, l)
+#define va_end(v)               __builtin_va_end(v)
+#define va_arg(v, l)            __builtin_va_arg(v, l)
+#define va_copy(d, s)           __builtin_va_copy(d, s)
+#else
 #include <stdarg.h>
+#endif
+#endif
 
 #define ACPI_INLINE             __inline__
 

--- a/source/include/platform/acintel.h
+++ b/source/include/platform/acintel.h
@@ -156,7 +156,9 @@
  * Use compiler specific <stdarg.h> is a good practice for even when
  * -nostdinc is specified (i.e., ACPI_USE_STANDARD_HEADERS undefined.
  */
+#ifndef va_arg
 #include <stdarg.h>
+#endif
 
 /* Configuration specific to Intel 64-bit C compiler */
 


### PR DESCRIPTION
Facilities to allow excluding gcc's stdarg.h.
Tested in efi builds by adding -DACPI_USE_BUILTIN_STDARG in Makefiles.