### PR TITLE
Explicitly cast 1 to UINT32.

### DIFF
--- a/source/components/utilities/utownerid.c
+++ b/source/components/utilities/utownerid.c
@@ -225,14 +225,14 @@ AcpiUtAllocateOwnerId (
                 break;
             }
 
-            if (!(AcpiGbl_OwnerIdMask[j] & (1 << k)))
+            if (!(AcpiGbl_OwnerIdMask[j] & ((UINT32) 1 << k)))
             {
                 /*
                  * Found a free ID. The actual ID is the bit index plus one,
                  * making zero an invalid Owner ID. Save this as the last ID
                  * allocated and update the global ID mask.
                  */
-                AcpiGbl_OwnerIdMask[j] |= (1 << k);
+                AcpiGbl_OwnerIdMask[j] |= ((UINT32) 1 << k);
 
                 AcpiGbl_LastOwnerIdIndex = (UINT8) j;
                 AcpiGbl_NextOwnerIdOffset = (UINT8) (k + 1);
@@ -328,7 +328,7 @@ AcpiUtReleaseOwnerId (
     /* Decode ID to index/offset pair */
 
     Index = ACPI_DIV_32 (OwnerId);
-    Bit = 1 << ACPI_MOD_32 (OwnerId);
+    Bit = (UINT32) 1 << ACPI_MOD_32 (OwnerId);
 
     /* Free the owner ID only if it is valid */
 


### PR DESCRIPTION
The runtime errors caused when acpica tools are compiled with
-fsanitize=shift imply that these 1s are stored in integers.
This cast insures that 1 is stored in unsigned integers.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>