### PR TITLE
Optionally use designated initializers for function pointers

### DIFF
--- a/source/components/hardware/hwxfsleep.c
+++ b/source/components/hardware/hwxfsleep.c
@@ -184,9 +184,18 @@ AcpiHwSleepDispatch (
 
 static ACPI_SLEEP_FUNCTIONS         AcpiSleepDispatch[] =
 {
-    {ACPI_HW_OPTIONAL_FUNCTION (AcpiHwLegacySleep),    AcpiHwExtendedSleep},
-    {ACPI_HW_OPTIONAL_FUNCTION (AcpiHwLegacyWakePrep), AcpiHwExtendedWakePrep},
-    {ACPI_HW_OPTIONAL_FUNCTION (AcpiHwLegacyWake),     AcpiHwExtendedWake}
+    {ACPI_STRUCT_INIT (legacy_function,
+                       ACPI_HW_OPTIONAL_FUNCTION (AcpiHwLegacySleep)),
+     ACPI_STRUCT_INIT (extended_function,
+                       AcpiHwExtendedSleep) },
+    {ACPI_STRUCT_INIT (legacy_function,
+                       ACPI_HW_OPTIONAL_FUNCTION (AcpiHwLegacyWakePrep)),
+     ACPI_STRUCT_INIT (extended_function,
+                       AcpiHwExtendedWakePrep) },
+    {ACPI_STRUCT_INIT (legacy_function,
+                       ACPI_HW_OPTIONAL_FUNCTION (AcpiHwLegacyWake)),
+     ACPI_STRUCT_INIT (extended_function,
+                       AcpiHwExtendedWake) }
 };
 
 

--- a/source/include/platform/acenv.h
+++ b/source/include/platform/acenv.h
@@ -398,6 +398,11 @@
 #define ACPI_INLINE
 #endif
 
+/* Use ordered initialization if compiler doesn't support designated. */
+#ifndef ACPI_STRUCT_INIT
+#define ACPI_STRUCT_INIT(field, value)  value
+#endif
+
 /*
  * Configurable calling conventions:
  *

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -287,6 +287,11 @@
 #define ACPI_MSG_BIOS_ERROR     KERN_ERR "ACPI BIOS Error (bug): "
 #define ACPI_MSG_BIOS_WARNING   KERN_WARNING "ACPI BIOS Warning (bug): "
 
+/*
+ * Linux wants to use designated initializers for function pointer structs.
+ */
+#define ACPI_STRUCT_INIT(field, value)  .field = value
+
 #else /* !__KERNEL__ */
 
 #define ACPI_USE_STANDARD_HEADERS


### PR DESCRIPTION
The Linux kernel is going to soon be using a gcc plugin for automatically
randomizing structure layouts of structures that are entirely function
pointers. To support this, initializers need to use designated
initialization rather than ordered initialization. This provides a macro,
ACPI_STRUCT_INIT, to handle both cases, keeping ordered initialization
for non-Linux builds.