### PR TITLE
External op refactor02

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -477,7 +477,7 @@ LdNamespace1Begin (
         if (ACPI_FAILURE (Status))
         {
             AslCoreSubsystemError (Op, Status,
-                "Failure to allocate ownder ID to this definition block.", FALSE);
+                "Failure to allocate owner ID to this definition block.", FALSE);
             return_ACPI_STATUS (Status);
         }
     }

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -474,7 +474,6 @@ LdNamespace1Begin (
          */
         Status = AcpiUtAllocateOwnerId (&OwnerId);
         WalkState->OwnerId = OwnerId;
-
         if (ACPI_FAILURE (Status))
         {
             AslCoreSubsystemError (Op, Status,
@@ -801,21 +800,22 @@ LdNamespace1Begin (
                  * Node->OwnerId are found in different tables (meaning that
                  * they have differnt OwnerIds).
                  */
-                    Node->Flags &= ~ANOBJ_IS_EXTERNAL;
-                    Node->Type = (UINT8) ObjectType;
+                Node->Flags &= ~ANOBJ_IS_EXTERNAL;
+                Node->Type = (UINT8) ObjectType;
 
-                    /* Just retyped a node, probably will need to open a scope */
+                /* Just retyped a node, probably will need to open a scope */
 
-                    if (AcpiNsOpensScope (ObjectType))
+                if (AcpiNsOpensScope (ObjectType))
+                {
+                    Status = AcpiDsScopeStackPush (Node, ObjectType, WalkState);
+                    if (ACPI_FAILURE (Status))
                     {
-                        Status = AcpiDsScopeStackPush (Node, ObjectType, WalkState);
-                        if (ACPI_FAILURE (Status))
-                        {
-                            return_ACPI_STATUS (Status);
-                        }
+                        return_ACPI_STATUS (Status);
                     }
+                }
 
-                    Status = AE_OK;
+                Status = AE_OK;
+
                 if (Node->OwnerId == WalkState->OwnerId)
                 {
                     AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -844,7 +844,36 @@ LdNamespace1Begin (
                      (Op->Asl.ParseOpcode == PARSEOP_EXTERNAL) &&
                      (ObjectType == ACPI_TYPE_ANY))
             {
-                /* Allow update of externals of unknown type. */
+                /*
+                 * Allow update of externals of unknown type.
+                 * In the case that multiple definition blocks are being
+                 * parsed, updating the OwnerId allows enables subsequent calls
+                 * of this method to understand which table the most recent
+                 * external declaration was seen. Without this OwnerId update,
+                 * code like the following is allowed to compile:
+                 *
+                 * DefinitionBlock("externtest.aml", "DSDT", 0x02, "Intel", "Many", 0x00000001)
+                 * {
+                 *     External(ERRS,methodobj)
+                 *     Method (MAIN)
+                 *     {
+                 *         Name(NUM2, 0)
+                 *         ERRS(1,2,3)
+                 *     }
+                 * }
+                 *
+                 * DefinitionBlock("externtest.aml", "SSDT", 0x02, "Intel", "Many", 0x00000001)
+                 * {
+                 *     if (0)
+                 *     {
+                 *         External(ERRS,methodobj)
+                 *     }
+                 *     Method (ERRS,3)
+                 *     {}
+                 *
+                 * }
+                 */
+                Node->OwnerId = WalkState->OwnerId;
 
                 if (AcpiNsOpensScope (ActualObjectType))
                 {

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -458,11 +458,30 @@ LdNamespace1Begin (
     ACPI_PARSE_OBJECT       *Arg;
     UINT32                  i;
     BOOLEAN                 ForceNewScope = FALSE;
+    ACPI_OWNER_ID           OwnerId = 0;
 
 
     ACPI_FUNCTION_NAME (LdNamespace1Begin);
     ACPI_DEBUG_PRINT ((ACPI_DB_DISPATCH, "Op %p [%s]\n",
         Op, Op->Asl.ParseOpName));
+
+    if (Op->Asl.ParseOpcode == PARSEOP_DEFINITION_BLOCK)
+    {
+        /*
+         * Allocate an OwnerId for this block. This helps identify the owners
+         * of each namespace node. This is used in determining whether if
+         * certain external declarations cause redefinition errors.
+         */
+        Status = AcpiUtAllocateOwnerId (&OwnerId);
+        WalkState->OwnerId = OwnerId;
+
+        if (ACPI_FAILURE (Status))
+        {
+            AslCoreSubsystemError (Op, Status,
+                "Failure to allocate ownder ID to this definition block.", FALSE);
+            return_ACPI_STATUS (Status);
+        }
+    }
 
     /*
      * We are only interested in opcodes that have an associated name

--- a/tests/aslts/src/runtime/cntl/ehandle.asl
+++ b/tests/aslts/src/runtime/cntl/ehandle.asl
@@ -26,8 +26,6 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-External (_ERR, MethodObj)
-
 /*
  * Exceptional conditions support
  */


### PR DESCRIPTION
This pull request changes the compiler behavior when there are externals and named objects with the same name. If these externals and named objects appear in different definition blocks, the externals are references to the named object. This case is considered a valid use case and passes compilation. If these externals and named objects appear in the same definition block, this is considered a redefinition of that named object or external and results in an error. With this new change in behavior, the external(_ERR, MethodObj) declaration in ehandle.asl within ASLTS has to be deleted to avoid redefinition of _ERR.