### PR TITLE
iasl: only convert // comments to /* during conversion

### DIFF
--- a/source/compiler/aslsupport.l
+++ b/source/compiler/aslsupport.l
@@ -697,14 +697,18 @@ AslDoCommentType2 (
 
 
     AslInsertLineBuffer ('/');
-    AslInsertLineBuffer ('*');
 
     if (Gbl_CaptureComments && CurrentState.CaptureComments)
     {
+        AslInsertLineBuffer ('*');
         *StringBuffer = '/';
         ++StringBuffer;
         *StringBuffer = '*';
         ++StringBuffer;
+    }
+    else
+    {
+        AslInsertLineBuffer ('/');
     }
 
     while (((c = input ()) != '\n') && (c != EOF))

--- a/source/compiler/cvdisasm.c
+++ b/source/compiler/cvdisasm.c
@@ -522,7 +522,7 @@ CvSwitchFiles(
            Current->Parent &&
            AcpiUtStricmp (Current->Filename, AcpiGbl_CurrentFilename))
     {
-        CvPrintInclude (FNode, Level);
+        CvPrintInclude (Current, Level);
         Current = Current->Parent;
     }
 


### PR DESCRIPTION
This solves the issue with /* comments appearing in place of // comments within listing files and fixes generation of include statements.
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>