### PR TITLE
dmtbdump: remove redundant assigment to Length

### DIFF
--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -1873,7 +1873,6 @@ AcpiDmDumpHmat (
 
             /* Attempt to continue */
 
-            Length = HmatStruct->Length;
             goto NextSubTable;
         }
 


### PR DESCRIPTION
The assignment to Length is redundant as the stored value is
overwritten again before it is read. Issue detected by
CoverityScan CID#163885 ("Unused Value")

Signed-off-by: Colin Ian King <colin.king@canonical.com>