### PR TITLE
IORT: Update SMMU models for revision C

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -874,7 +874,7 @@ typedef struct acpi_ibft_target
  * IORT - IO Remapping Table
  *
  * Conforms to "IO Remapping Table System Software on ARM Platforms",
- * Document number: ARM DEN 0049B, October 2015
+ * Document number: ARM DEN 0049C, May 2017
  *
  ******************************************************************************/
 
@@ -1013,6 +1013,8 @@ typedef struct acpi_iort_smmu
 #define ACPI_IORT_SMMU_V2               0x00000001  /* Generic SMMUv2 */
 #define ACPI_IORT_SMMU_CORELINK_MMU400  0x00000002  /* ARM Corelink MMU-400 */
 #define ACPI_IORT_SMMU_CORELINK_MMU500  0x00000003  /* ARM Corelink MMU-500 */
+#define ACPI_IORT_SMMU_CORELINK_MMU401  0x00000004  /* ARM Corelink MMU-401 */
+#define ACPI_IORT_SMMU_CAVIUM_THUNDERX  0x00000005  /* Cavium ThunderX SMMUv2 */
 
 /* Masks for Flags field above */
 
@@ -1036,13 +1038,19 @@ typedef struct acpi_iort_smmu_v3
     UINT32                  Flags;
     UINT32                  Reserved;
     UINT64                  VatosAddress;
-    UINT32                  Model;                 /* O: generic SMMUv3 */
+    UINT32                  Model;
     UINT32                  EventGsiv;
     UINT32                  PriGsiv;
     UINT32                  GerrGsiv;
     UINT32                  SyncGsiv;
 
 } ACPI_IORT_SMMU_V3;
+
+/* Values for Model field above */
+
+#define ACPI_IORT_SMMU_V3_GENERIC           0x00000000  /* Generic SMMUv3 */
+#define ACPI_IORT_SMMU_V3_HISILICON_HI161X  0x00000001  /* HiSilicon Hi161x SMMUv3 */
+#define ACPI_IORT_SMMU_V3_CAVIUM_CN99XX     0x00000002  /* Cavium CN99xx SMMUv3 */
 
 /* Masks for Flags field above */
 


### PR DESCRIPTION
IORT revision C has been published with a number of new SMMU
implementation identifiers; define them.

Signed-off-by: Robin Murphy <robin.murphy@arm.com>