### PR TITLE
Acpica aslts

### DIFF
--- a/tests/aslts.sh
+++ b/tests/aslts.sh
@@ -116,15 +116,13 @@ run_aslts() {
 	version=`$ASL | grep version | awk '{print $5}'`
 	rm -rf $ASLTSDIR/tmp/aml/$version
 
-	if [ "x$TEST_CASES" = "x" ]; then
-		# Compile all ASL test modules
-		Do 0 aslts $EXECONLY
-		if [ $? -ne 0 ]; then
-			echo "ASLTS Compile Failure"
-			exit 1
-		fi
-	else
-		Do 0 $TEST_CASES $EXECONLY
+	if [ "x$TEST_MODES" = "x" ]; then
+		TEST_MODES="n32 n64 o32 o64"
+	fi
+	Do 0 $TEST_MODES $TEST_CASES $EXECONLY
+	if [ $? -ne 0 ]; then
+		echo "ASLTS Compile Failure"
+		exit 1
 	fi
 
 	# Execute the test suite

--- a/tests/aslts/Makefile.def
+++ b/tests/aslts/Makefile.def
@@ -10,21 +10,6 @@
 #   AMLMOD - name of resulting AML module (DefinitionBlock->AMLFileName)
 #            without .aml extension.
 
-# Two level hierarchy of compilation:
-# optimization & (32/64 mode).
-#
-#  Directory |           Flags
-#            |---------------------------
-#            | optimization |  32/64 mode
-# ---------------------------------------
-#    opt/32  |              |  -r 1
-#    opt/64  |              |  -r 2
-#   nopt/32  |  -oa         |  -r 1
-#   nopt/64  |  -oa         |  -r 2
-
-SETOF_INDEXES= 0 1 2 3
-SETOF_AMLDIRS= nopt/32 nopt/64 opt/32 opt/64
-SETOF_ASLFAGS= "-oa -r 1" "-oa -r 2" "-r 1" "-r 2"
 COMMON_ASL_FLAGS= "-of -cr -vs -l -sc -sa -ic -ta -ts -so -lm -ln -ls -li"
 
 COMPILER_LOG="$(TOP)/tmp/aml/$(aslversion)/compile.txt"
@@ -44,123 +29,115 @@ empty_all:	FORCE
 # Rule to create directories located into aslts/tmp/aml;
 # aslversion is determined dynamically.
 
-${SETOF_AMLDIRS:%=$(TOP)/tmp/aml/$(aslversion)/%}:
+$(TOP)/tmp/aml/$(aslversion)/$(ASLTS_AMLDIR):
 	@$(INST.dir)
 
 # Make-install one particular Test Case for all modes
 
-install_all_modes_of_test_case:	${SETOF_AMLDIRS:%=$(TOP)/tmp/aml/$(aslversion)/%}
+install_all_modes_of_test_case:	$(TOP)/tmp/aml/$(aslversion)/$(ASLTS_AMLDIR)
 	@rval=0; \
 	if [ -f "$(ASL)" ]; then \
 		dd=`pwd`; \
 		echo "---- Test path: $$dd" >> $(COMPILER_LOG); \
 		echo "---- Test path: $$dd" >> $(COMPILER_ERROR_LOG); \
 		>&2 echo "Test path: $$dd"; \
-		for i in ${SETOF_INDEXES}; do \
-			set -- $(SETOF_AMLDIRS); \
-			shift $$i; \
-			CUR_AMLDIR=$$1; \
-			set -- $(SETOF_ASLFAGS); \
-			shift $$i; \
-			CUR_ASLFLAGS=$$1; \
-			echo "---- Test type: $$CUR_AMLDIR   (Flags $(COMMON_ASL_FLAGS) $$CUR_ASLFLAGS $(ADD_ASLFLAGS))" >> $(COMPILER_LOG); \
-			echo "---- Test type: $$CUR_AMLDIR   (Flags $(COMMON_ASL_FLAGS) $$CUR_ASLFLAGS $(ADD_ASLFLAGS))" >> $(COMPILER_ERROR_LOG); \
-			for j in ${AMLMOD}; do \
-				rm -f $$j.aml; \
-			done; \
-			for j in ${ASLMOD} $(ASLMODADD); do \
-				echo "---- Compile: $$j.asl" >> $(COMPILER_LOG); \
-				>&2 printf "%-18s" "    Type: $$CUR_AMLDIR "; \
-				>&2 printf  "Compile"; \
-				"$(ASL)" $$CUR_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS) $$j.asl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
-				ret=$$?; \
-				echo "" >> $(COMPILER_LOG); \
-				if [ $(OPT) -eq 0 ] && [ "x$(ADD_ASLFLAGS)" != "x-f" ]; then \
-					for k in ${AMLMOD}; do \
-						>&2 printf  " => Compile Ext in-place"; \
-						"$(ASL)" -p $$k-extInPlace -oE $$CUR_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS) $$j.asl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
-						if [ ! -f $$k-extInPlace.aml ]; then \
-							>&2 printf " [[ Error: disassembly failed of $$k.aml failed ]]\n"; \
-							>&2 printf "          Flags used: -p $$k-aslminus -oE -cr -vs $$CUR_ASLFLAGS $(ADD_ASLFLAGS) -od -dl\n\n"; \
+		echo "---- Test type: $$ASLTS_AMLDIR   (Flags $(COMMON_ASL_FLAGS) $$ASLTS_ASLFLAGS $(ADD_ASLFLAGS))" >> $(COMPILER_LOG); \
+		echo "---- Test type: $$ASLTS_AMLDIR   (Flags $(COMMON_ASL_FLAGS) $$ASLTS_ASLFLAGS $(ADD_ASLFLAGS))" >> $(COMPILER_ERROR_LOG); \
+		for j in ${AMLMOD}; do \
+			rm -f $$j.aml; \
+		done; \
+		for j in ${ASLMOD} $(ASLMODADD); do \
+			echo "---- Compile: $$j.asl" >> $(COMPILER_LOG); \
+			>&2 printf "%-18s" "    Type: $$ASLTS_AMLDIR "; \
+			>&2 printf  "Compile"; \
+			"$(ASL)" $$ASLTS_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS) $$j.asl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
+			ret=$$?; \
+			echo "" >> $(COMPILER_LOG); \
+			if [ $(OPT) -eq 0 ] && [ "x$(ADD_ASLFLAGS)" != "x-f" ]; then \
+				for k in ${AMLMOD}; do \
+					>&2 printf  " => Compile Ext in-place"; \
+					"$(ASL)" -p $$k-extInPlace -oE $$ASLTS_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS) $$j.asl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
+					if [ ! -f $$k-extInPlace.aml ]; then \
+						>&2 printf " [[ Error: disassembly failed of $$k.aml failed ]]\n"; \
+						>&2 printf "          Flags used: -p $$k-aslminus -oE -cr -vs $$ASLTS_ASLFLAGS $(ADD_ASLFLAGS) -od -dl\n\n"; \
+						#exit 1; \
+					fi; \
+					>&2 printf " => Disassemble"; \
+					echo "---- Diasassemble: $$k.aml" >> $(COMPILER_LOG); \
+					echo "---- Diasassemble: $$k.aml" >> $(COMPILER_ERROR_LOG); \
+					"$(ASL)" -p $$k-aslminus -oe -cr -vs $$ASLTS_ASLFLAGS $(ADD_ASLFLAGS) -od -dl $$k-extInPlace.aml >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
+					if [ ! -f $$k-aslminus.dsl ]; then \
+						>&2 printf " [[ Error: disassembly failed of $$k.aml failed ]]\n"; \
+						>&2 printf "          Flags used: -p $$k-aslminus -cr -vs $$ASLTS_ASLFLAGS $(ADD_ASLFLAGS) -od -dl\n\n"; \
+						#exit 1; \
+					fi; \
+					>&2 printf " => Recompile"; \
+					echo "---- Recompile: $$k.dsl" >> $(COMPILER_LOG); \
+					echo "---- Recompile: $$k.dsl" >> $(COMPILER_ERROR_LOG); \
+					"$(ASL)" $$ASLTS_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS) $$k-aslminus.dsl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
+					if [ ! -f $$k-aslminus.aml ]; then \
+						>&2 printf " [[ Error: re-compilation of $$k-aslminus.dsl failed]]\n"; \
+						>&2 printf "          Flags used: $$ASLTS_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS)\n\n"; \
+						#exit 1; \
+					fi; \
+					if [ $$ASLTS_AMLDIR = "nopt/32" ] || [ $$ASLTS_AMLDIR = "nopt/64" ]; then \
+						>&2 printf " => Binary compare"; \
+						rm -f comparison_output.txt; \
+						acpibin -c $$k.aml $$k-aslminus.aml >> comparison_output.txt; \
+						if [ $$? != 0 ]; then \
+							>&2 printf " [[ Error: comparison of $$k.aml and $$k-aslminus.aml do not match ]]"; \
+							cat comparison_output.txt | sed '1,/^Error/d' | sed 's/Error - Byte mismatch at offset     /         => /g' | sed -n 1,10p > comparison_output.txt;\
+							>&2 printf "\n"; \
+							cat comparison_output.txt >&2 ; \
+							>&2 printf "        "; \
 							#exit 1; \
+						else \
+							>&2 printf " => Success!"; \
+							rm comparison_output.txt; \
 						fi; \
-						>&2 printf " => Disassemble"; \
-						echo "---- Diasassemble: $$k.aml" >> $(COMPILER_LOG); \
-						echo "---- Diasassemble: $$k.aml" >> $(COMPILER_ERROR_LOG); \
-						"$(ASL)" -p $$k-aslminus -oe -cr -vs $$CUR_ASLFLAGS $(ADD_ASLFLAGS) -od -dl $$k-extInPlace.aml >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
-						if [ ! -f $$k-aslminus.dsl ]; then \
-							>&2 printf " [[ Error: disassembly failed of $$k.aml failed ]]\n"; \
-							>&2 printf "          Flags used: -p $$k-aslminus -cr -vs $$CUR_ASLFLAGS $(ADD_ASLFLAGS) -od -dl\n\n"; \
-							#exit 1; \
-						fi; \
-						>&2 printf " => Recompile"; \
-						echo "---- Recompile: $$k.dsl" >> $(COMPILER_LOG); \
-						echo "---- Recompile: $$k.dsl" >> $(COMPILER_ERROR_LOG); \
-						"$(ASL)" $$CUR_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS) $$k-aslminus.dsl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
-						if [ ! -f $$k-aslminus.aml ]; then \
-							>&2 printf " [[ Error: re-compilation of $$k-aslminus.dsl failed]]\n"; \
-							>&2 printf "          Flags used: $$CUR_ASLFLAGS "$(COMMON_ASL_FLAGS)" $(ADD_ASLFLAGS)\n\n"; \
-							#exit 1; \
-						fi; \
-						if [ $$CUR_AMLDIR = "nopt/32" ] || [ $$CUR_AMLDIR = "nopt/64" ]; then \
-							>&2 printf " => Binary compare"; \
-							rm -f comparison_output.txt; \
-							acpibin -c $$k.aml $$k-aslminus.aml >> comparison_output.txt; \
-							if [ $$? != 0 ]; then \
-								>&2 printf " [[ Error: comparison of $$k.aml and $$k-aslminus.aml do not match ]]"; \
-								cat comparison_output.txt | sed '1,/^Error/d' | sed 's/Error - Byte mismatch at offset     /         => /g' | sed -n 1,10p > comparison_output.txt;\
-								>&2 printf "\n"; \
-								cat comparison_output.txt >&2 ; \
-								>&2 printf "        "; \
-								#exit 1; \
-							else \
-								>&2 printf " => Success!"; \
-								rm comparison_output.txt; \
-							fi; \
-						fi; \
-						if [ ! -f comparison_output.txt ]; then \
-							>&2 printf " => Removing files"; \
-							rm $$k-aslminus.lst; \
-							rm $$k-aslminus.aml; \
-							rm $$k-aslminus.dsl; \
-						fi; \
-						for n in "$$k-aslminus" "$$k-extInPlace"; do \
-							rm $$n.i $$n.asm $$n.nsp; \
-							rm $$n.c $$n.hex $$n.map; \
-							rm $$n.h $$n.src $$n.offset.h; \
-						done; \
-						rm $$k-extInPlace.aml; \
-						rm $$k-extInPlace.lst; \
-						>&2 printf " => Done"; \
+					fi; \
+					if [ ! -f comparison_output.txt ]; then \
+						>&2 printf " => Removing files"; \
+						rm $$k-aslminus.lst; \
+						rm $$k-aslminus.aml; \
+						rm $$k-aslminus.dsl; \
+					fi; \
+					for n in "$$k-aslminus" "$$k-extInPlace"; do \
+						rm $$n.i $$n.asm $$n.nsp; \
+						rm $$n.c $$n.hex $$n.map; \
+						rm $$n.h $$n.src $$n.offset.h; \
 					done; \
-				fi; \
-				>&2 printf " => Removing files"; \
-				rm $$j.asm; \
-				rm $$j.c; \
-				rm $$j.h; \
-				rm $$j.i; \
-				rm $$j.hex; \
-				rm $$j.lst; \
-				rm $$j.map; \
-				rm $$j.nsp; \
-				rm $$j.offset.h; \
-				rm $$j.src; \
-				>&2 printf " => Done"; \
-				if [ $$ret != 0 ]; then \
-					rval=1; \
-					>&2 echo "**** Unexpected iASL failure in $$dd/$$j.asl!"; \
-					exit 1; \
-				fi; \
-			done; \
-			>&2 echo ""; \
-			if [ $$ret != 0 ]; then break; fi; \
-			for j in ${AMLMOD}; do \
-				ls -l $$j.aml >> $(COMPILER_LOG); \
-				echo "---- Move: $$j.aml $(TOP)/tmp/aml/$(aslversion)/$$CUR_AMLDIR" >> $(COMPILER_LOG); \
-				mv $$j.aml $(TOP)/tmp/aml/$(aslversion)/$$CUR_AMLDIR; \
-				ret=$$?; \
-				if [ $$ret != 0 ]; then rval=2; echo "**** mv failed!" >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); break; fi; \
-			done; \
+					rm $$k-extInPlace.aml; \
+					rm $$k-extInPlace.lst; \
+					>&2 printf " => Done"; \
+				done; \
+			fi; \
+			>&2 printf " => Removing files"; \
+			rm $$j.asm; \
+			rm $$j.c; \
+			rm $$j.h; \
+			rm $$j.i; \
+			rm $$j.hex; \
+			rm $$j.lst; \
+			rm $$j.map; \
+			rm $$j.nsp; \
+			rm $$j.offset.h; \
+			rm $$j.src; \
+			>&2 printf " => Done"; \
+			if [ $$ret != 0 ]; then \
+				rval=1; \
+				>&2 echo "**** Unexpected iASL failure in $$dd/$$j.asl!"; \
+				exit 1; \
+			fi; \
+		done; \
+		>&2 echo ""; \
+		if [ $$ret != 0 ]; then break; fi; \
+		for j in ${AMLMOD}; do \
+			ls -l $$j.aml >> $(COMPILER_LOG); \
+			echo "---- Move: $$j.aml $(TOP)/tmp/aml/$(aslversion)/$$ASLTS_AMLDIR" >> $(COMPILER_LOG); \
+			mv $$j.aml $(TOP)/tmp/aml/$(aslversion)/$$ASLTS_AMLDIR; \
+			ret=$$?; \
+			if [ $$ret != 0 ]; then rval=2; echo "**** mv failed!" >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); break; fi; \
 		done; \
 	else \
 		echo "Bad iASL 0: <$(ASL)> does not exist"; \
@@ -238,18 +215,10 @@ compile_test_case:
 	echo "Compile_test_case"
 
 	if [ -f "$(ASL)" ]; then \
-		for i in ${SETOF_INDEXES}; do \
-			set -- $(SETOF_AMLDIRS); \
-			shift $$i; \
-			CUR_AMLDIR=$$1; \
-			set -- $(SETOF_ASLFAGS); \
-			shift $$i; \
-			CUR_ASLFLAGS=$$1; \
-			for j in ${ASLMOD} $(ASLMODADD); do \
-				"$(ASL)" $$CUR_ASLFLAGS $(ADD_ASLFLAGS) $$j.asl; \
-				ret=$$?; \
-				if [ $$ret != 0 ]; then rval=1; echo "**** Unexpected iASL failure!"; exit 1; fi; \
-			done; \
+		for j in ${ASLMOD} $(ASLMODADD); do \
+			"$(ASL)" $$ASLTS_ASLFLAGS $(ADD_ASLFLAGS) $$j.asl; \
+			ret=$$?; \
+			if [ $$ret != 0 ]; then rval=1; echo "**** Unexpected iASL failure!"; exit 1; fi; \
 		done; \
 	else \
 		echo "Bad iASL 4: <$(ASL)> does not exist"; \

--- a/tests/aslts/Makefile.switch
+++ b/tests/aslts/Makefile.switch
@@ -1,10 +1,24 @@
 # common switch make
+# Two level hierarchy of compilation:
+# optimization & (32/64 mode).
+#
+#  Directory |           Flags
+#            |---------------------------
+#            | optimization |  32/64 mode
+# ---------------------------------------
+#    opt/32  |              |  -r 1
+#    opt/64  |              |  -r 2
+#   nopt/32  |  -oa         |  -r 1
+#   nopt/64  |  -oa         |  -r 2
 
 all:	${MDIRS}
 ${MDIRS}: FORCE
-	@cd $@; pwd; make
+	@cd $@; pwd; make all ASLTS_ASLFLAGS="-oa -r 1"
+	@cd $@; pwd; make all ASLTS_ASLFLAGS="-oa -r 2"
+	@cd $@; pwd; make all ASLTS_ASLFLAGS="-r 1"
+	@cd $@; pwd; make all ASLTS_ASLFLAGS="-r 2"
 
-install:	FORCE
+__install:	FORCE
 		@r=0; set -e; for d in ${MDIRS}; do \
 			(cd $$d; \
 			if [ $$? -ne 0 ]; then \
@@ -12,7 +26,7 @@ install:	FORCE
 			else \
 				pwd; \
 				>&2 echo "Begin compiling test package: [$$d]"; \
-				if ($(MAKE) install); then \
+				if ($(MAKE) __install); then \
 					:; \
 				else \
 					r=1; \
@@ -24,6 +38,17 @@ install:	FORCE
 		fi; \
 		>&2 echo "Compiled test package: [$$d]"; \
 		done
+
+install_n32:
+	$(MAKE) __install ASLTS_AMLDIR=nopt/32 ASLTS_ASLFLAGS="-oa -r 1"
+install_n64:
+	$(MAKE) __install ASLTS_AMLDIR=nopt/64 ASLTS_ASLFLAGS="-oa -r 2"
+install_s32:
+	$(MAKE) __install ASLTS_AMLDIR=opt/32 ASLTS_ASLFLAGS="-r 1"
+install_s64:
+	$(MAKE) __install ASLTS_AMLDIR=opt/64 ASLTS_ASLFLAGS="-r 2"
+
+install:	install_n32 install_n64 install_s32 install_s64
 
 clean:	FORCE
 		@for d in ${MDIRS}; do \

--- a/tests/aslts/bin/Do
+++ b/tests/aslts/bin/Do
@@ -320,7 +320,43 @@ make_target()
 
 make_install()
 {
-	make_target install "$1" "$2"
+	local res=0 nres=0
+
+	echo $1 $2 $ENABLENORM32
+	if [ $ENABLENORM32 != 0 ]; then
+		echo "Make n32"
+		make_target install_n32 "$1" "$2"
+		nres=$?
+		if [ $nres -ne 0 ]; then
+			res=$nres
+		fi
+	fi
+	if [ $ENABLENORM64 != 0 ]; then
+		echo "Make n64"
+		make_target install_n64 "$1" "$2"
+		nres=$?
+		if [ $nres -ne 0 ]; then
+			res=$nres
+		fi
+	fi
+	if [ $ENABLEOPT32 != 0 ]; then
+		echo "Make s32"
+		make_target install_s32 "$1" "$2"
+		nres=$?
+		if [ $nres -ne 0 ]; then
+			res=$nres
+		fi
+	fi
+	if [ $ENABLEOPT64 != 0 ]; then
+		echo "Make s64"
+		make_target install_s64 "$1" "$2"
+		nres=$?
+		if [ $nres -ne 0 ]; then
+			res=$nres
+		fi
+	fi
+
+	return $res
 }
 
 # Make-install all the provided test cases
@@ -458,6 +494,16 @@ run_asl_compiler()
 {
 	local nparam=$2 list="$3" execonly=$4
 	local action=100
+
+	# It's better to split this function into a special 'asltscomp'
+	# script. For now, still uses it as an inline function.
+	RESET_SETTINGS
+	INIT_ALL_AVAILABLE_CASES
+	INIT_ALL_AVAILABLE_MODES
+	INIT_SET_OF_TEST_CASES
+	INIT_SET_OF_TEST_MODES
+	INIT_LOG_RESULTS
+	INIT_MEM_STAT
 
 	if [ $nparam -le 1 ]; then
 		usage

--- a/tests/aslts/bin/Do
+++ b/tests/aslts/bin/Do
@@ -295,31 +295,43 @@ do_bdemo_table()
 	bdemostabs "$DIR0" "$DIR1" "$ALLBUGS" "$KBSUM" "$LBSUM" "$BUG_STATE_DIR"
 }
 
+make_target()
+{
+	local dir restore_dir
+
+	restore_dir=$PWD
+	target=$1
+	dir="$2"
+	execonly=$3
+
+	cd "$dir"
+
+	echo "Running make $target from $dir"
+	if [ "$execonly" = "yes" ]; then
+		make $target OPT=1 > /dev/null
+	else
+		make $target OPT=0 > /dev/null
+	fi
+	res=$?
+
+	cd "$restore_dir"
+	return $res
+}
+
+make_install()
+{
+	make_target install "$1" "$2"
+}
 
 # Make-install all the provided test cases
 # (make install from aslts directory)
 # arg1 - root directory of aslts
 make_install_1()
 {
-	local dir restore_dir diasm
-
-	restore_dir=$PWD
-	dir="$1"
-	execonly=$2
-
-	cd "$dir"
-
-	echo "Running make install from $dir"
-	if [ "$execonly" = "yes" ]; then
-		make install OPT=1 > /dev/null
-	else
-		make install OPT=0 > /dev/null
-	fi
-
+	make_install "$1" "$2"
 	if [ $? -ne 0 ]; then
 		do_exit 1 "make install error"
 	fi
-	cd "$restore_dir"
 }
 
 # Check parameters to be the names of test
@@ -347,13 +359,7 @@ do_test_cases_make_install()
 		check_dir "$dir"
 
 		if [ $3 != 0 ]; then
-			cd "$dir"
-			if [ "x$execonly" = "xyes" ]; then
-				make install OPT=1 > /dev/null
-			else
-				make install OPT=0 > /dev/null
-			fi
-
+			make_install "$dir" "$execonly"
 			if [ $? -ne 0 ]; then
 				errors=1
 			fi
@@ -361,8 +367,6 @@ do_test_cases_make_install()
 	done
 
 	cd "$restore_dir"
-
-	return $errors
 }
 
 # Make-install a list of specified test cases
@@ -404,12 +408,7 @@ do_collections_make_install()
 		check_dir "$dir"
 
 		if [ $3 != 0 ]; then
-			cd "$dir"
-			if [ "$execonly" = "yes" ]; then
-				make install OPT=1 > /dev/null
-			else
-				make install OPT=0 > /dev/null
-			fi
+			make_install "$dir" "$execonly"
 			if [ $? -ne 0 ]; then
 				errors=1
 			fi

--- a/tests/aslts/bin/Do
+++ b/tests/aslts/bin/Do
@@ -456,21 +456,20 @@ make_install_3()
 # arg3 - all parameters passed to Do utility
 run_asl_compiler()
 {
-	local lexem list nparam=$2 action=100 execonly=$4
-
-	lexem=`echo "$3" | awk '{ print $2}'`
+	local nparam=$2 list="$3" execonly=$4
+	local action=100
 
 	if [ $nparam -le 1 ]; then
 		usage
 		do_exit 1 "Bad parameters 0"
-	elif [ $lexem == ASLTS -o $lexem == aslts ]; then
+	elif [ $list == ASLTS -o $list == aslts ]; then
 		if [ $nparam != 3 ]; then
 			usage
 			do_exit 1 "Bad parameters 1"
 		else
 			action=1
 		fi
-	elif [ $lexem == ALL -o $lexem == all ]; then
+	elif [ $list == ALL -o $list == all ]; then
 		if [ $nparam -le 3 ]; then
 			usage
 			do_exit 1 "Bad parameters 2"
@@ -480,12 +479,10 @@ run_asl_compiler()
 		fi
 	else
 		action=2
-		list=`echo "$3" | cut -c 3-`
 	fi
 
-	# cut the last item from the list. It's a yes or no from execonly.
-	list=`echo $list | rev | cut -c 4- | rev `
-	>&2 echo "list of testcases: $list"
+	echo "list of testcases: $list"
+
 	if [ $action == 1 ]; then
 		echo "Make-install all the provided test cases"
 		make_install_1 "$1" "$execonly"
@@ -618,7 +615,44 @@ if [ $CMD == $ASLCOMPILE ]; then
 		do_exit 1 "Undefined ASL variable! Set it to pathname of ASL compiler."
 	fi
 
-	x="$@"
+	shift 1
+	ENABLED_TMODES=
+	while :
+	do
+		check_mode_id $1
+		if [ $? -eq 1 ]; then
+			break
+		fi
+		ENABLED_TMODES="$1 $ENABLED_TMODES"
+		shift 1
+		# Sort NPARAM
+		# NPARAM=$(($NPARAM - 1))
+	done
+	export ENABLED_TMODES
+
+	ENABLED_TCASES=
+	while :
+	do
+		get_collection_opcode $1
+		if [ $? -eq $COLLS_NUM ]; then
+			break
+		fi
+		ENABLED_TCASES="$1 $ENABLED_TCASES"
+		shift 1
+		# Sort NPARAM
+		# NPARAM=$(($NPARAM - 1))
+	done
+	export ENABLED_TCASES
+
+	if [ "x$ENABLED_TCASES" == "x" ]; then
+		x=aslts
+	else
+		x="$ENABLED_TCASES"
+	fi
+	# Sort NPARAM
+	# NPARAM=$(($NPARAM + 1))
+
+	EXECONLY=$1
 	>&2 echo "disassemble: $EXECONLY"
 	run_asl_compiler "$ASLTSDIR" $NPARAM "$x" "$EXECONLY"
 

--- a/tests/aslts/bin/common
+++ b/tests/aslts/bin/common
@@ -212,42 +212,46 @@ get_collection_opcode()
 {
 	local rval=0
 
-	echo $FUNC_COLL | grep $1 > /dev/null
+	if [ -z $1 ]; then
+		return $COLLS_NUM
+	fi
+
+	echo $FUNC_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $FUNC_COLL_OP
 	fi
 
-	echo $CPLX_COLL | grep $1 > /dev/null
+	echo $CPLX_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $CPLX_COLL_OP
 	fi
 
-	echo $EXCP_COLL | grep $1 > /dev/null
+	echo $EXCP_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $EXCP_COLL_OP
 	fi
 
-	echo $BDEMO_COLL | grep $1 > /dev/null
+	echo $BDEMO_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $BDEMO_COLL_OP
 	fi
 
-	echo $SERV_COLL | grep $1 > /dev/null
+	echo $SERV_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $SERV_COLL_OP
 	fi
 
-	echo $MT_COLL | grep $1 > /dev/null
+	echo $MT_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $MT_COLL_OP
 	fi
 
-	echo $MS_IDENT_COLL | grep $1 > /dev/null
+	echo $MS_IDENT_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $MS_IDENT_COLL_OP
 	fi
 
-	echo $IMPL_COLL | grep $1 > /dev/null
+	echo $IMPL_COLL | grep -w $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		return $IMPL_COLL_OP
 	fi

--- a/tests/aslts/src/runtime/collections/Makefile.install
+++ b/tests/aslts/src/runtime/collections/Makefile.install
@@ -1,7 +1,7 @@
 
 all:		compile_test_case
 
-install:	install_test_case
+__install:	install_test_case
 
 clean:	clobber
 


### PR DESCRIPTION
Some ASLTS case is not written in a Windows compliant way.
This patchset fixes such problems.
By converting in-package NameString into the following style:

Store(RefOf(name), Index(pkg, ...))

And find correct position to add DerefOf to extract the element.