### PR TITLE
Iasl external fix01

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -823,10 +823,15 @@ LdNamespace1Begin (
 
                 Status = AE_OK;
 
-                if (Node->OwnerId == WalkState->OwnerId)
+                if (Node->OwnerId == WalkState->OwnerId &&
+                    !(Node->Flags & IMPLICIT_EXTERNAL))
                 {
                     AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
                         Op->Asl.ExternalName);
+                }
+                if (Node->Flags & IMPLICIT_EXTERNAL)
+                {
+                    Node->Flags &= ~IMPLICIT_EXTERNAL;
                 }
             }
             else if (!(Node->Flags & ANOBJ_IS_EXTERNAL) &&

--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -764,6 +764,13 @@ AcpiNsLookup (
                     ThisNode = (ACPI_NAMESPACE_NODE *) ThisNode->Object;
                 }
             }
+#ifdef ACPI_ASL_COMPILER
+            if (!AcpiGbl_DisasmFlag &&
+                (ThisNode->Flags & ANOBJ_IS_EXTERNAL))
+            {
+                ThisNode->Flags |= IMPLICIT_EXTERNAL;
+            }
+#endif
         }
 
         /* Special handling for the last segment (NumSegments == 0) */

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -328,6 +328,7 @@ typedef struct acpi_namespace_node
 #define ANOBJ_EVALUATED                 0x20    /* Set on first evaluation of node */
 #define ANOBJ_ALLOCATED_BUFFER          0x40    /* Method AML buffer is dynamic (InstallMethod) */
 
+#define IMPLICIT_EXTERNAL               0x02    /* iASL only: This object created implicitly via External */
 #define ANOBJ_IS_EXTERNAL               0x08    /* iASL only: This object created via External() */
 #define ANOBJ_METHOD_NO_RETVAL          0x10    /* iASL only: Method has no return value */
 #define ANOBJ_METHOD_SOME_NO_RETVAL     0x20    /* iASL only: Method has at least one return value */

--- a/tests/aslts/src/runtime/collections/functional/external/MAIN.asl
+++ b/tests/aslts/src/runtime/collections/functional/external/MAIN.asl
@@ -89,3 +89,46 @@ DefinitionBlock(
 	CreateBitField(E003, 0, E014)
 }
 
+
+/*
+ * bz 1389 test case provided by racerrehabman@gmail.com
+ * This table should compile without error
+ */
+DefinitionBlock(
+	"external.aml",   // Output filename
+	"SSDT",     // Signature
+	0x02,       // DSDT Revision
+	"Intel",    // OEMID
+	"Many",     // TABLE ID
+	0x00000001  // OEM Revision
+	){
+
+	External(RMCF.XPEE, IntObj)
+	Device(RMCF)
+	{
+		Name(_ADR, 0)
+	}
+}
+
+/*
+ * This is a variation on the table above. This should compile.
+ */
+DefinitionBlock(
+	"external.aml",   // Output filename
+	"SSDT",     // Signature
+	0x02,       // DSDT Revision
+	"Intel",    // OEMID
+	"Many",     // TABLE ID
+	0x00000001  // OEM Revision
+	){
+
+	External(ABCD.XPEE, IntObj)
+	External(ABCD.XPED, IntObj)
+	Device(ABCD)
+	{
+		Name(_ADR, 0)
+		Name(XPEF, 0)
+	}
+	External(ABCD.XPEG, IntObj)
+}
+


### PR DESCRIPTION
This change resolves bz1389 and allows compilation of code like the following:

`DefinitionBlock (...)`
`{`
`    External (ABCD.EFGH)`
`    Device (ABCD) {Name (IJLK,0)}`
`}`