### PR TITLE
Executer: adapt buffer length for Field Attrib Raw Process in Ops Region

### DIFF
--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -553,6 +553,15 @@ AcpiExWriteDataToField (
              *     Data[x-1]: (Bytes 2-x of the arbitrary length data buffer)
              */
             Length += 2;
+
+            /*
+             * When using AttribRawProcessBytes, it seems the access length
+             * is always specified by the user.
+             * So just take the incoming buffer length as the reference.
+             */
+            if (AccessorType == AML_FIELD_ATTRIB_RAW_PROCESS)
+                Length = SourceDesc->Buffer.Length;
+
             Function = ACPI_WRITE | (AccessorType << 16);
         }
         else /* IPMI */


### PR DESCRIPTION
Detected on the Surface 3:
The MSHW0011 driver uses Field Attrib Raw Process to return information
for the ACPI Battery. The DSDT declares a parameter of 2 though
functions like _BST or _BIX require a much bigger out buffer.

It looks like the incoming buffer has the requested size and we can
work around the issue by using this input size as the output and
parameters size.

As metioned by Stephen Just on the kernel bugzilla (comment 44):
"Lv, after reading through 5.5.2.4.5.3 of the ACPI spec several times,
it appears that AccessLength is ignored for AttribRawProcessBytes
accesses - the access length is always specified by the user - and
in fact, the example omits the AccessLength argument entirely.

More specifically, comparing 5.5.2.4.5.3.9 and 5.5.2.4.5.3.10, it
appears that the only difference between AttribRawProcessBytes and
AttribRawBytes is that AttribRawProcessBytes does not seem to pay
attention to AccessLength, and lets the driver deal with it."

Link: https://bugzilla.kernel.org/show_bug.cgi?id=106231

Signed-off-by: Benjamin Tissoires <benjamin.tissoires@redhat.com>