### PR TITLE
iASL: Ensure that the target node is valid in AcpiExCreateAlias

### DIFF
--- a/source/components/executer/excreate.c
+++ b/source/components/executer/excreate.c
@@ -203,6 +203,12 @@ AcpiExCreateAlias (
         TargetNode = ACPI_CAST_PTR (ACPI_NAMESPACE_NODE, TargetNode->Object);
     }
 
+    /* Ensure that the target node is valid */
+    if (!TargetNode)
+    {
+        return_ACPI_STATUS (AE_NULL_OBJECT);
+    }
+
     /*
      * For objects that can never change (i.e., the NS node will
      * permanently point to the same object), we can simply attach


### PR DESCRIPTION
The following ACPI table contains an invalid target node within the
Alias operator:

```
DefinitionBlock ("", "SSDT", 1, "Bug", "BugTable", 0x00001000)
{
    Scope (_SB)
    {
        Device (DEV0)
        {
            Name (_ADR, 1)

            Device (DEV1)
            {
                Alias (_ADR, _ADR)
            }
        }
    }
}
```

If an ACPI table contains such an invalid target node in an Alias
operator, a segmentation fault will occur when the target node is
dereferenced within AcpiExCreateAlias. Add a check for such an invalid
target node in AcpiExCreateAlias.

Signed-off-by: Alex James <theracermaster@gmail.com>