### PR TITLE
Revert "Update resource descriptor handling"

### DIFF
--- a/source/components/utilities/utresrc.c
+++ b/source/components/utilities/utresrc.c
@@ -303,11 +303,9 @@ AcpiUtWalkAmlResources (
     ACPI_FUNCTION_TRACE (UtWalkAmlResources);
 
 
-    /*
-     * The absolute minimum resource template is one EndTag descriptor.
-     * However, we will treat a lone EndTag as just a simple buffer.
-     */
-    if (AmlLength <= sizeof (AML_RESOURCE_END_TAG))
+    /* The absolute minimum resource template is one EndTag descriptor */
+
+    if (AmlLength < sizeof (AML_RESOURCE_END_TAG))
     {
         return_ACPI_STATUS (AE_AML_NO_RESOURCE_END_TAG);
     }
@@ -378,10 +376,8 @@ AcpiUtWalkAmlResources (
                 *Context = Aml;
             }
 
-            /*
-             * Normal exit. Note: We allow the buffer to be larger than
-             * the resource template, as long as the END_TAG exists.
-             */
+            /* Normal exit */
+
             return_ACPI_STATUS (AE_OK);
         }
 


### PR DESCRIPTION
This reverts commit c8eac10178b387f9eb1935694e509d4518da77bb resolves bz1391 and improves ASLTS results by decreasing failures and incrementing passes by 6.