### PR TITLE
Iasl external fix02

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -316,7 +316,8 @@ LdLoadFieldElements (
                     return (Status);
                 }
                 else if (Status == AE_ALREADY_EXISTS &&
-                    (Node->Flags & ANOBJ_IS_EXTERNAL))
+                    (Node->Flags & ANOBJ_IS_EXTERNAL) &&
+                    Node->OwnerId != WalkState->OwnerId)
                 {
                     Node->Type = (UINT8) ACPI_TYPE_LOCAL_REGION_FIELD;
                 }

--- a/source/components/parser/psobject.c
+++ b/source/components/parser/psobject.c
@@ -487,6 +487,31 @@ AcpiPsCreateOp (
     {
         Status = AcpiPsBuildNamedOp (WalkState, AmlOpStart, Op, &NamedOp);
         AcpiPsFreeOp (Op);
+
+#ifdef ACPI_ASL_COMPILER
+        if (AcpiGbl_DisasmFlag && WalkState->Opcode == AML_EXTERNAL_OP &&
+            Status == AE_NOT_FOUND)
+        {
+            /*
+             * If parsing of AML_EXTERNAL_OP's name path fails, then skip
+             * past this opcode and keep parsing. This is a much better
+             * alternative than to abort the entire disassembler. At this
+             * point, the ParserState is at the end of the namepath of the
+             * external declaration opcode. Setting WalkState->Aml to
+             * WalkState->ParserState.Aml + 2 moves increments the
+             * WalkState->Aml past the object type and the paramcount of the
+             * external opcode. For the error message, only print the AML
+             * offset. We could attempt to print the name but this may cause
+             * a segmentation fault when printing the namepath because the
+             * AML may be incorrect.
+             */
+            AcpiOsPrintf (
+                "// Invalid external declaration at AML offset 0x%x.\n",
+                WalkState->Aml - WalkState->ParserState.AmlStart);
+            WalkState->Aml = WalkState->ParserState.Aml + 2;
+            return_ACPI_STATUS (AE_CTRL_PARSE_CONTINUE);
+        }
+#endif
         if (ACPI_FAILURE (Status))
         {
             return_ACPI_STATUS (Status);


### PR DESCRIPTION
this pull request resolves bz1397 by skipping incorrect external declarations in the AML during disassembly. Also, this pull request fixes field unit compilation so that iasl emits an error when there is a field unit declaration and an external declaration of the same in a definition block.