### PR TITLE
Acpiexec test

### DIFF
--- a/source/components/tables/tbxface.c
+++ b/source/components/tables/tbxface.c
@@ -300,10 +300,13 @@ AcpiReallocateRootTable (
 
 
     /*
-     * Only reallocate the root table if the host provided a static buffer
-     * for the table array in the call to AcpiInitializeTables.
+     * If there are tables unverified, it is required to reallocate the
+     * root table list to clean up invalid table entries. Otherwise only
+     * reallocate the root table list if the host provided a static buffer
+     * for the table array in the call to AcpiInitializeTables().
      */
-    if (AcpiGbl_RootTableList.Flags & ACPI_ROOT_ORIGIN_ALLOCATED)
+    if ((AcpiGbl_RootTableList.Flags & ACPI_ROOT_ORIGIN_ALLOCATED) &&
+        AcpiGbl_EnableTableValidation)
     {
         return_ACPI_STATUS (AE_SUPPORT);
     }

--- a/source/tools/acpiexec/aetables.c
+++ b/source/tools/acpiexec/aetables.c
@@ -598,6 +598,14 @@ AeInstallTables (
     Status = AcpiInitializeTables (NULL, ACPI_MAX_INIT_TABLES, TRUE);
     ACPI_CHECK_OK (AcpiInitializeTables, Status);
 
+    /*
+     * The following code is prepared to test the deferred table
+     * verification mechanism. When AcpiGbl_EnableTableValidation is set
+     * to FALSE by default, AcpiReallocateRootTable() sets it back to TRUE
+     * and triggers the deferred table verification mechanism accordingly.
+     */
+    (void) AcpiReallocateRootTable ();
+
     if (AcpiGbl_LoadTestTables)
     {
         /* Test multiple table/UEFI support. First, get the headers */


### PR DESCRIPTION
My local test code for the new deferred table verification mechanism. I enhanced it so that it could be upstreamed.

This commit is not urgent but it will nicer to have it in the upstream as:
1. The enhanced sanity check in AcpiReallocateRootTable() makes the condition of the check a necessary and sufficient condition.
2. OSPMs now can freely change the allocation style of the global root table list while still be able to enable the deferred table verification feature when AcpiReallocateRootTable() is invoked.