### PR TITLE
Acpica 1706

### DIFF
--- a/source/components/hardware/hwregs.c
+++ b/source/components/hardware/hwregs.c
@@ -228,7 +228,7 @@ AcpiHwGetAccessBitWidth (
     }
     else if (Reg->AccessWidth)
     {
-        AccessBitWidth = (1 << (Reg->AccessWidth + 2));
+        AccessBitWidth = ACPI_ACCESS_BIT_WIDTH (Reg->AccessWidth);
     }
     else
     {

--- a/source/components/utilities/utresrc.c
+++ b/source/components/utilities/utresrc.c
@@ -359,16 +359,6 @@ AcpiUtWalkAmlResources (
                 return_ACPI_STATUS (AE_AML_NO_RESOURCE_END_TAG);
             }
 
-            /*
-             * The EndTag opcode must be followed by a zero byte.
-             * Although this byte is technically defined to be a checksum,
-             * in practice, all ASL compilers set this byte to zero.
-             */
-            if (*(Aml + 1) != 0)
-            {
-                return_ACPI_STATUS (AE_AML_NO_RESOURCE_END_TAG);
-            }
-
             /* Return the pointer to the EndTag if requested */
 
             if (!UserFunction)

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -675,6 +675,13 @@ typedef UINT64                          ACPI_INTEGER;
 #define ACPI_VALIDATE_RSDP_SIG(a)       (!strncmp (ACPI_CAST_PTR (char, (a)), ACPI_SIG_RSDP, 8))
 #define ACPI_MAKE_RSDP_SIG(dest)        (memcpy (ACPI_CAST_PTR (char, (dest)), ACPI_SIG_RSDP, 8))
 
+/*
+ * Algorithm to obtain access bit width.
+ * Can be used with AccessWidth of ACPI_GENERIC_ADDRESS and AccessSize of
+ * ACPI_RESOURCE_GENERIC_REGISTER.
+ */
+#define ACPI_ACCESS_BIT_WIDTH(size)     (1 << ((size) + 2))
+
 
 /*******************************************************************************
  *


### PR DESCRIPTION
ACPICA 201700629 release materials.
No significant divergences can be seen except 2 small changes. They are there because Linux side merged 2 urgent fixes and thus the fixes were not in ACPICA upstream.

This series back ports the ACPICA parts of the 2 commits.