### PR TITLE
Unix makefiles: Add OPT_LDFLAGS and edit NOOPT parsing

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -43,7 +43,7 @@ CC =    gcc
 OBJDIR =     obj
 BINDIR =     bin
 COMPILEOBJ = $(CC) -c $(CFLAGS) $(OPT_CFLAGS) -o $@ $<
-LINKPROG =   $(CC) $(OBJECTS) -o $(PROG) $(LDFLAGS)
+LINKPROG =   $(CC) $(OBJECTS) -o $(PROG) $(LDFLAGS) $(OPT_LDFLAGS)
 PREFIX ?=    /usr
 INSTALLDIR = $(PREFIX)/bin
 UNAME_S := $(shell uname -s)
@@ -162,6 +162,8 @@ endif
 #
 ifneq ($(NOOPT),TRUE)
 OPT_CFLAGS += -O2
+else
+OPT_CFLAGS += -O0
 endif
 
 #
@@ -176,14 +178,14 @@ CFLAGS += \
     -D$(HOST)\
     -D_GNU_SOURCE\
     -I$(ACPICA_INCLUDE)
-    
+
 #
 # QNX requires __EXT to enable most functions in its C library, analogous
 # to _GNU_SOURCE.
 #
 ifeq ($(HOST), _QNX)
     CFLAGS+=-D__EXT
-endif  
+endif
 
 #
 # Common compiler warning flags. The warning flags in addition


### PR DESCRIPTION
Add OPT_LDFLAGS to be specified during compilation for custom linker
flags. Disable optimization (adding -O0) when NOOPT is set to true.


Signed-off-by: Alex James <theracermaster@gmail.com>