### PR TITLE
iASL: add option to expect specific compilation remarks/warnings/errors

### DIFF
--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -815,6 +815,7 @@ CmCleanupAndExit (
     BOOLEAN                 DeleteAmlFile = FALSE;
 
 
+    AslCheckExpectedExceptions ();
     AePrintErrorLog (ASL_FILE_STDERR);
     if (Gbl_DebugFlag)
     {

--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -413,12 +413,20 @@ AslError (
     ACPI_PARSE_OBJECT       *Op,
     char                    *ExtraMessage);
 
+void
+AslCheckExpectedExceptions (
+    void);
+
+ACPI_STATUS
+AslExpectException (
+    char                    *MessageIdString);
+
 ACPI_STATUS
 AslDisableException (
     char                    *MessageIdString);
 
 BOOLEAN
-AslIsExceptionDisabled (
+AslIsExceptionIgnored (
     UINT8                   Level,
     UINT16                  MessageId);
 

--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -160,6 +160,16 @@ static void
 AeAddToErrorLog (
     ASL_ERROR_MSG           *Enode);
 
+static BOOLEAN
+AslIsExceptionExpected (
+    UINT8                   Level,
+    UINT16                  MessageId);
+
+static BOOLEAN
+AslIsExceptionDisabled (
+    UINT8                   Level,
+    UINT16                  MessageId);
+
 
 /*******************************************************************************
  *
@@ -806,6 +816,115 @@ AslCommonError (
     return;
 }
 
+/*******************************************************************************
+ *
+ * FUNCTION:    AslIsExceptionIgnored
+ *
+ * PARAMETERS:  Level               - Seriousness (Warning/error, etc.)
+ *              MessageId           - Index into global message buffer
+ *
+ * RETURN:      BOOLEAN
+ *
+ * DESCRIPTION: Check if a particular exception is ignored. In this case it
+ *              means that the exception is (expected or disabled.
+ *
+ ******************************************************************************/
+
+BOOLEAN
+AslIsExceptionIgnored (
+    UINT8                   Level,
+    UINT16                  MessageId)
+{
+    BOOLEAN ExceptionIgnored;
+
+
+    /* Note: this allows exception to be disabled and expected */
+
+    ExceptionIgnored = AslIsExceptionDisabled (Level, MessageId);
+    ExceptionIgnored |= AslIsExceptionExpected (Level, MessageId);
+
+    return (Gbl_AllExceptionsDisabled || ExceptionIgnored);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AslCheckExpectException
+ *
+ * PARAMETERS:  none
+ *
+ * RETURN:      none
+ *
+ * DESCRIPTION: Check the global expected messages table and raise an error
+ *              for each message that has not been received.
+ *
+ ******************************************************************************/
+
+void
+AslCheckExpectedExceptions (
+    void)
+{
+    UINT8 i;
+
+    for (i = 0; i < Gbl_ExpectedMessagesIndex; ++i)
+    {
+        if (!Gbl_ExpectedMessages[i].MessageReceived)
+        {
+            AslError (ASL_ERROR, ASL_MSG_EXCEPTION_NOT_RECEIVED, NULL,
+                Gbl_ExpectedMessages[i].MessageIdStr);
+        }
+    }
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AslExpectException
+ *
+ * PARAMETERS:  MessageIdString     - ID of excepted exception during compile
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Enter a message ID into the global expected messages table
+ *              If these messages are not raised during the compilation, throw
+ *              an error.
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AslExpectException (
+    char                    *MessageIdString)
+{
+    UINT32                  MessageId;
+
+
+    /* Convert argument to an integer and validate it */
+
+    MessageId = (UINT32) strtoul (MessageIdString, NULL, 0);
+
+    if (MessageId > 6999)
+    {
+        printf ("\"%s\" is not a valid warning/remark/erro ID\n",
+            MessageIdString);
+        return (AE_BAD_PARAMETER);
+    }
+
+    /* Insert value into the global expected message array */
+
+    if (Gbl_ExpectedMessagesIndex >= ASL_MAX_EXPECTED_MESSAGES)
+    {
+        printf ("Too many messages have been registered as expected (max %u)\n",
+            ASL_MAX_DISABLED_MESSAGES);
+        return (AE_LIMIT);
+    }
+
+    Gbl_ExpectedMessages[Gbl_ExpectedMessagesIndex].MessageId = MessageId;
+    Gbl_ExpectedMessages[Gbl_ExpectedMessagesIndex].MessageIdStr = MessageIdString;
+    Gbl_ExpectedMessages[Gbl_ExpectedMessagesIndex].MessageReceived = FALSE;
+    Gbl_ExpectedMessagesIndex++;
+    return (AE_OK);
+}
+
 
 /*******************************************************************************
  *
@@ -866,7 +985,48 @@ AslDisableException (
  *
  ******************************************************************************/
 
-BOOLEAN
+static BOOLEAN
+AslIsExceptionExpected (
+    UINT8                   Level,
+    UINT16                  MessageId)
+{
+    UINT32                  EncodedMessageId;
+    UINT32                  i;
+
+
+    /*
+     * Mark this exception as received
+     */
+    EncodedMessageId = AeBuildFullExceptionCode (Level, MessageId);
+    for (i = 0; i < Gbl_ExpectedMessagesIndex; i++)
+    {
+        /* Simple implementation via fixed array */
+
+        if (EncodedMessageId == Gbl_ExpectedMessages[i].MessageId)
+        {
+            return (Gbl_ExpectedMessages[i].MessageReceived = TRUE);
+        }
+    }
+
+    return (FALSE);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AslIsExceptionDisabled
+ *
+ * PARAMETERS:  Level               - Seriousness (Warning/error, etc.)
+ *              MessageId           - Index into global message buffer
+ *
+ * RETURN:      TRUE if exception/message should be ignored
+ *
+ * DESCRIPTION: Check if the user has specified options such that this
+ *              exception should be ignored
+ *
+ ******************************************************************************/
+
+static BOOLEAN
 AslIsExceptionDisabled (
     UINT8                   Level,
     UINT16                  MessageId)
@@ -940,8 +1100,7 @@ AslError (
 
     /* Check if user wants to ignore this exception */
 
-    if (Gbl_AllExceptionsDisabled ||
-        AslIsExceptionDisabled (Level, MessageId))
+    if (AslIsExceptionIgnored (Level, MessageId))
     {
         return;
     }

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -252,6 +252,7 @@ extern int                  AslCompilerdebug;
 #define ASL_DEFAULT_LINE_BUFFER_SIZE    (1024 * 32) /* 32K */
 #define ASL_MSG_BUFFER_SIZE             (1024 * 32) /* 32k */
 #define ASL_MAX_DISABLED_MESSAGES       32
+#define ASL_MAX_EXPECTED_MESSAGES       32
 #define HEX_TABLE_LINE_SIZE             8
 #define HEX_LISTING_LINE_SIZE           8
 
@@ -396,6 +397,7 @@ ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_CurrentHexColumn, 0);
 ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_CurrentAmlOffset, 0);
 ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_CurrentLine, 0);
 ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_DisabledMessagesIndex, 0);
+ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_ExpectedMessagesIndex, 0);
 ASL_EXTERN UINT8                    ASL_INIT_GLOBAL (Gbl_HexBytesWereWritten, FALSE);
 ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_NumNamespaceObjects, 0);
 ASL_EXTERN UINT32                   ASL_INIT_GLOBAL (Gbl_ReservedMethods, 0);
@@ -438,6 +440,7 @@ ASL_EXTERN char                     MsgBuffer[ASL_MSG_BUFFER_SIZE];
 ASL_EXTERN char                     StringBuffer[ASL_MSG_BUFFER_SIZE];
 ASL_EXTERN char                     StringBuffer2[ASL_MSG_BUFFER_SIZE];
 ASL_EXTERN UINT32                   Gbl_DisabledMessages[ASL_MAX_DISABLED_MESSAGES];
+ASL_EXTERN ASL_EXPECTED_MESSAGE     Gbl_ExpectedMessages[ASL_MAX_EXPECTED_MESSAGES];
 
 
 #endif /* __ASLGLOBAL_H */

--- a/source/compiler/aslhelp.c
+++ b/source/compiler/aslhelp.c
@@ -205,6 +205,7 @@ Usage (
     ACPI_OPTION ("-vi",             "Less verbose errors and warnings for use with IDEs");
     ACPI_OPTION ("-vr",             "Disable remarks");
     ACPI_OPTION ("-vw <messageid>", "Disable specific warning or remark");
+    ACPI_OPTION ("-vx <messageid>", "Expect a specific warning, remark, or error");
     ACPI_OPTION ("-w <1|2|3>",      "Set warning reporting level");
     ACPI_OPTION ("-we",             "Report warnings as errors");
 

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -348,7 +348,8 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_ARG_AS_LOCAL_NOT_USED */      "Method Argument (as a local) is set but never used",
 /*    ASL_MSG_ARG_NOT_USED */               "Method Argument is never used",
 /*    ASL_MSG_CONSTANT_REQUIRED */          "Non-reducible expression",
-/*    ASL_MSG_CROSS_TABLE_SCOPE */          "Illegal open scope on external object from within DSDT"
+/*    ASL_MSG_CROSS_TABLE_SCOPE */          "Illegal open scope on external object from within DSDT",
+/*    ASL_MSG_EXCEPTION_NOT_RECEIVED */     "Expected remark, warning, or error did not occur. Message ID:"
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -351,6 +351,7 @@ typedef enum
     ASL_MSG_ARG_NOT_USED,
     ASL_MSG_CONSTANT_REQUIRED,
     ASL_MSG_CROSS_TABLE_SCOPE,
+    ASL_MSG_EXCEPTION_NOT_RECEIVED,
 
     /* These messages are used by the Data Table compiler only */
 

--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -954,6 +954,22 @@ AslDoOptions (
             }
             break;
 
+        case 'x':
+
+            /* Get the required argument */
+
+            if (AcpiGetoptArgument (argc, argv))
+            {
+                return (-1);
+            }
+
+            Status = AslExpectException (AcpiGbl_Optarg);
+            if (ACPI_FAILURE (Status))
+            {
+                return (-1);
+            }
+            break;
+
         default:
 
             printf ("Unknown option: -v%s\n", AcpiGbl_Optarg);

--- a/source/compiler/asltypes.h
+++ b/source/compiler/asltypes.h
@@ -355,6 +355,15 @@ typedef struct asl_error_msg
 
 } ASL_ERROR_MSG;
 
+/* An entry in the expected messages array */
+typedef struct asl_expected_message
+{
+    UINT32                       MessageId;
+    char                         *MessageIdStr;
+    BOOLEAN                      MessageReceived;
+
+} ASL_EXPECTED_MESSAGE;
+
 
 /* An entry in the listing file stack (for include files) */
 

--- a/source/compiler/dtutils.c
+++ b/source/compiler/dtutils.c
@@ -190,7 +190,7 @@ DtError (
 
     /* Check if user wants to ignore this exception */
 
-    if (AslIsExceptionDisabled (Level, MessageId))
+    if (AslIsExceptionIgnored (Level, MessageId))
     {
         return;
     }


### PR DESCRIPTION
The -vx [messageId] option, where the x stands for EXpect, allows the
compiler to expect that the compilation will result in an ASL exception
with a particular messageId. If this error is not raised. The
compilation will result in an error. This will help create a whole new
class of compilation tests in ASLTS.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>