### PR TITLE
Acpica Gpe

### DIFF
--- a/source/components/events/evgpe.c
+++ b/source/components/events/evgpe.c
@@ -226,7 +226,7 @@ AcpiEvUpdateGpeEnableMask (
  *
  * RETURN:      Status
  *
- * DESCRIPTION: Clear a GPE of stale events and enable it.
+ * DESCRIPTION: Enable a GPE.
  *
  ******************************************************************************/
 
@@ -239,14 +239,6 @@ AcpiEvEnableGpe (
 
     ACPI_FUNCTION_TRACE (EvEnableGpe);
 
-
-    /* Clear the GPE (of stale events) */
-
-    Status = AcpiHwClearGpe (GpeEventInfo);
-    if (ACPI_FAILURE (Status))
-    {
-        return_ACPI_STATUS (Status);
-    }
 
     /* Enable the requested GPE */
 

--- a/source/components/events/evgpe.c
+++ b/source/components/events/evgpe.c
@@ -534,17 +534,12 @@ UINT32
 AcpiEvGpeDetect (
     ACPI_GPE_XRUPT_INFO     *GpeXruptList)
 {
-    ACPI_STATUS             Status;
     ACPI_GPE_BLOCK_INFO     *GpeBlock;
     ACPI_NAMESPACE_NODE     *GpeDevice;
     ACPI_GPE_REGISTER_INFO  *GpeRegisterInfo;
     ACPI_GPE_EVENT_INFO     *GpeEventInfo;
     UINT32                  GpeNumber;
-    ACPI_GPE_HANDLER_INFO   *GpeHandlerInfo;
     UINT32                  IntStatus = ACPI_INTERRUPT_NOT_HANDLED;
-    UINT8                   EnabledStatusByte;
-    UINT64                  StatusReg;
-    UINT64                  EnableReg;
     ACPI_CPU_FLAGS          Flags;
     UINT32                  i;
     UINT32                  j;
@@ -600,104 +595,24 @@ AcpiEvGpeDetect (
                 continue;
             }
 
-            /* Read the Status Register */
-
-            Status = AcpiHwRead (&StatusReg, &GpeRegisterInfo->StatusAddress);
-            if (ACPI_FAILURE (Status))
-            {
-                goto UnlockAndExit;
-            }
-
-            /* Read the Enable Register */
-
-            Status = AcpiHwRead (&EnableReg, &GpeRegisterInfo->EnableAddress);
-            if (ACPI_FAILURE (Status))
-            {
-                goto UnlockAndExit;
-            }
-
-            ACPI_DEBUG_PRINT ((ACPI_DB_INTERRUPTS,
-                "Read registers for GPE %02X-%02X: Status=%02X, Enable=%02X, "
-                "RunEnable=%02X, WakeEnable=%02X\n",
-                GpeRegisterInfo->BaseGpeNumber,
-                GpeRegisterInfo->BaseGpeNumber + (ACPI_GPE_REGISTER_WIDTH - 1),
-                (UINT32) StatusReg, (UINT32) EnableReg,
-                GpeRegisterInfo->EnableForRun,
-                GpeRegisterInfo->EnableForWake));
-
-            /* Check if there is anything active at all in this register */
-
-            EnabledStatusByte = (UINT8) (StatusReg & EnableReg);
-            if (!EnabledStatusByte)
-            {
-                /* No active GPEs in this register, move on */
-
-                continue;
-            }
-
             /* Now look at the individual GPEs in this byte register */
 
             for (j = 0; j < ACPI_GPE_REGISTER_WIDTH; j++)
             {
-                /* Examine one GPE bit */
+                /* Detect and dispatch one GPE bit */
 
                 GpeEventInfo = &GpeBlock->EventInfo[((ACPI_SIZE) i *
                     ACPI_GPE_REGISTER_WIDTH) + j];
                 GpeNumber = j + GpeRegisterInfo->BaseGpeNumber;
-
-                if (EnabledStatusByte & (1 << j))
-                {
-                    /* Invoke global event handler if present */
-
-                    AcpiGpeCount++;
-                    if (AcpiGbl_GlobalEventHandler)
-                    {
-                        AcpiGbl_GlobalEventHandler (ACPI_EVENT_TYPE_GPE,
-                            GpeDevice, GpeNumber,
-                            AcpiGbl_GlobalEventHandlerContext);
-                    }
-
-                    /* Found an active GPE */
-
-                    if (ACPI_GPE_DISPATCH_TYPE (GpeEventInfo->Flags) ==
-                        ACPI_GPE_DISPATCH_RAW_HANDLER)
-                    {
-                        /* Dispatch the event to a raw handler */
-
-                        GpeHandlerInfo = GpeEventInfo->Dispatch.Handler;
-
-                        /*
-                         * There is no protection around the namespace node
-                         * and the GPE handler to ensure a safe destruction
-                         * because:
-                         * 1. The namespace node is expected to always
-                         *    exist after loading a table.
-                         * 2. The GPE handler is expected to be flushed by
-                         *    AcpiOsWaitEventsComplete() before the
-                         *    destruction.
-                         */
-                        AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);
-                        IntStatus |= GpeHandlerInfo->Address (
-                            GpeDevice, GpeNumber, GpeHandlerInfo->Context);
-                        Flags = AcpiOsAcquireLock (AcpiGbl_GpeLock);
-                    }
-                    else
-                    {
-                        /*
-                         * Dispatch the event to a standard handler or
-                         * method.
-                         */
-                        IntStatus |= AcpiEvGpeDispatch (GpeDevice,
-                            GpeEventInfo, GpeNumber);
-                    }
-                }
+                AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);
+                IntStatus |= AcpiEvDetectGpe (
+                    GpeDevice, GpeEventInfo, GpeNumber);
+                Flags = AcpiOsAcquireLock (AcpiGbl_GpeLock);
             }
         }
 
         GpeBlock = GpeBlock->Next;
     }
-
-UnlockAndExit:
 
     AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);
     return (IntStatus);
@@ -886,6 +801,137 @@ AcpiEvFinishGpe (
 
 /*******************************************************************************
  *
+ * FUNCTION:    AcpiEvDetectGpe
+ *
+ * PARAMETERS:  GpeDevice           - Device node. NULL for GPE0/GPE1
+ *              GpeEventInfo        - Info for this GPE
+ *              GpeNumber           - Number relative to the parent GPE block
+ *
+ * RETURN:      INTERRUPT_HANDLED or INTERRUPT_NOT_HANDLED
+ *
+ * DESCRIPTION: Detect and dispatch a General Purpose Event to either a function
+ *              (e.g. EC) or method (e.g. _Lxx/_Exx) handler.
+ * NOTE:        GPE is W1C, so it is possible to handle a single GPE from both
+ *              task and irq context in parallel as long as the process to
+ *              detect and mask the GPE is atomic.
+ *              However the atomicity of ACPI_GPE_DISPATCH_RAW_HANDLER is
+ *              dependent on the raw handler itself.
+ *
+ ******************************************************************************/
+
+UINT32
+AcpiEvDetectGpe (
+    ACPI_NAMESPACE_NODE     *GpeDevice,
+    ACPI_GPE_EVENT_INFO     *GpeEventInfo,
+    UINT32                  GpeNumber)
+{
+    UINT32                  IntStatus = ACPI_INTERRUPT_NOT_HANDLED;
+    UINT8                   EnabledStatusByte;
+    UINT64                  StatusReg;
+    UINT64                  EnableReg;
+    UINT32                  RegisterBit;
+    ACPI_GPE_REGISTER_INFO  *GpeRegisterInfo;
+    ACPI_GPE_HANDLER_INFO   *GpeHandlerInfo;
+    ACPI_CPU_FLAGS          Flags;
+    ACPI_STATUS             Status;
+
+
+    ACPI_FUNCTION_TRACE (EvGpeDetect);
+
+
+    Flags = AcpiOsAcquireLock (AcpiGbl_GpeLock);
+
+    /* Get the info block for the entire GPE register */
+
+    GpeRegisterInfo = GpeEventInfo->RegisterInfo;
+
+    /* Get the register bitmask for this GPE */
+
+    RegisterBit = AcpiHwGetGpeRegisterBit (GpeEventInfo);
+
+    /* GPE currently enabled (enable bit == 1)? */
+
+    Status = AcpiHwRead (&EnableReg, &GpeRegisterInfo->EnableAddress);
+    if (ACPI_FAILURE (Status))
+    {
+        goto ErrorExit;
+    }
+
+    /* GPE currently active (status bit == 1)? */
+
+    Status = AcpiHwRead (&StatusReg, &GpeRegisterInfo->StatusAddress);
+    if (ACPI_FAILURE (Status))
+    {
+        goto ErrorExit;
+    }
+
+    /* Check if there is anything active at all in this GPE */
+
+    ACPI_DEBUG_PRINT ((ACPI_DB_INTERRUPTS,
+        "Read registers for GPE %02X: Status=%02X, Enable=%02X, "
+        "RunEnable=%02X, WakeEnable=%02X\n",
+        GpeNumber,
+        (UINT32) (StatusReg & RegisterBit),
+        (UINT32) (EnableReg & RegisterBit),
+        GpeRegisterInfo->EnableForRun,
+        GpeRegisterInfo->EnableForWake));
+
+    EnabledStatusByte = (UINT8) (StatusReg & EnableReg);
+    if (!(EnabledStatusByte & RegisterBit))
+    {
+        goto ErrorExit;
+    }
+
+    /* Invoke global event handler if present */
+
+    AcpiGpeCount++;
+    if (AcpiGbl_GlobalEventHandler)
+    {
+        AcpiGbl_GlobalEventHandler (ACPI_EVENT_TYPE_GPE,
+            GpeDevice, GpeNumber,
+            AcpiGbl_GlobalEventHandlerContext);
+    }
+
+    /* Found an active GPE */
+
+    if (ACPI_GPE_DISPATCH_TYPE (GpeEventInfo->Flags) ==
+        ACPI_GPE_DISPATCH_RAW_HANDLER)
+    {
+        /* Dispatch the event to a raw handler */
+
+        GpeHandlerInfo = GpeEventInfo->Dispatch.Handler;
+
+        /*
+         * There is no protection around the namespace node
+         * and the GPE handler to ensure a safe destruction
+         * because:
+         * 1. The namespace node is expected to always
+         *    exist after loading a table.
+         * 2. The GPE handler is expected to be flushed by
+         *    AcpiOsWaitEventsComplete() before the
+         *    destruction.
+         */
+        AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);
+        IntStatus |= GpeHandlerInfo->Address (
+            GpeDevice, GpeNumber, GpeHandlerInfo->Context);
+        Flags = AcpiOsAcquireLock (AcpiGbl_GpeLock);
+    }
+    else
+    {
+        /* Dispatch the event to a standard handler or method. */
+
+        IntStatus |= AcpiEvGpeDispatch (GpeDevice,
+            GpeEventInfo, GpeNumber);
+    }
+
+ErrorExit:
+    AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);
+    return (IntStatus);
+}
+
+
+/*******************************************************************************
+ *
  * FUNCTION:    AcpiEvGpeDispatch
  *
  * PARAMETERS:  GpeDevice           - Device node. NULL for GPE0/GPE1
@@ -896,8 +942,6 @@ AcpiEvFinishGpe (
  *
  * DESCRIPTION: Dispatch a General Purpose Event to either a function (e.g. EC)
  *              or method (e.g. _Lxx/_Exx) handler.
- *
- *              This function executes at interrupt level.
  *
  ******************************************************************************/
 

--- a/source/components/events/evgpeblk.c
+++ b/source/components/events/evgpeblk.c
@@ -648,6 +648,8 @@ AcpiEvInitializeGpeBlock (
                 continue;
             }
 
+            GpeEventInfo->Flags |= ACPI_GPE_AUTO_ENABLED;
+
             if (EventStatus & ACPI_EVENT_FLAG_STATUS_SET)
             {
                 ACPI_INFO (("GPE 0x%02X active on init",

--- a/source/components/events/evgpeblk.c
+++ b/source/components/events/evgpeblk.c
@@ -588,7 +588,6 @@ AcpiEvInitializeGpeBlock (
     void                    *Ignored)
 {
     ACPI_STATUS             Status;
-    ACPI_EVENT_STATUS       EventStatus;
     ACPI_GPE_EVENT_INFO     *GpeEventInfo;
     UINT32                  GpeEnabledCount;
     UINT32                  GpeIndex;
@@ -636,9 +635,6 @@ AcpiEvInitializeGpeBlock (
                 continue;
             }
 
-            EventStatus = 0;
-            (void) AcpiHwGetGpeStatus (GpeEventInfo, &EventStatus);
-
             Status = AcpiEvAddGpeReference (GpeEventInfo);
             if (ACPI_FAILURE (Status))
             {
@@ -649,16 +645,6 @@ AcpiEvInitializeGpeBlock (
             }
 
             GpeEventInfo->Flags |= ACPI_GPE_AUTO_ENABLED;
-
-            if (EventStatus & ACPI_EVENT_FLAG_STATUS_SET)
-            {
-                ACPI_INFO (("GPE 0x%02X active on init",
-                            GpeNumber));
-                (void) AcpiEvGpeDispatch (GpeBlock->Node,
-                                          GpeEventInfo,
-                                          GpeNumber);
-            }
-
             GpeEnabledCount++;
         }
     }

--- a/source/components/events/evxface.c
+++ b/source/components/events/evxface.c
@@ -1257,6 +1257,20 @@ AcpiRemoveGpeHandler (
         Handler->OriginallyEnabled)
     {
         (void) AcpiEvAddGpeReference (GpeEventInfo);
+        if (GpeEventInfo->RuntimeCount == 1 &&
+            AcpiGbl_AllGpesInitialized)
+        {
+            /*
+             * Poll GPEs to handle already triggered events.
+             * It is not sufficient to trigger edge-triggered GPE with
+             * specific GPE chips, software need to poll once after
+             * enabling.
+             */
+            AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);
+            (void) AcpiEvDetectGpe (
+                GpeDevice, GpeEventInfo, GpeNumber);
+            Flags = AcpiOsAcquireLock (AcpiGbl_GpeLock);
+        }
     }
 
     AcpiOsReleaseLock (AcpiGbl_GpeLock, Flags);

--- a/source/components/events/evxfgpe.c
+++ b/source/components/events/evxfgpe.c
@@ -609,6 +609,16 @@ AcpiSetupGpeForWake (
         GpeEventInfo->Flags =
             (ACPI_GPE_DISPATCH_NOTIFY | ACPI_GPE_LEVEL_TRIGGERED);
     }
+    else if (GpeEventInfo->Flags & ACPI_GPE_AUTO_ENABLED)
+    {
+        /*
+         * A reference to this GPE has been added during the GPE block
+         * initialization, so drop it now to prevent the GPE from being
+         * permanently enabled and clear its ACPI_GPE_AUTO_ENABLED flag.
+         */
+        (void) AcpiEvRemoveGpeReference (GpeEventInfo);
+        GpeEventInfo->Flags &= ~~ACPI_GPE_AUTO_ENABLED;
+    }
 
     /*
      * If we already have an implicit notify on this GPE, add

--- a/source/components/hardware/hwgpe.c
+++ b/source/components/hardware/hwgpe.c
@@ -658,7 +658,6 @@ AcpiHwDisableAllGpes (
 
 
     Status = AcpiEvWalkGpeList (AcpiHwDisableGpeBlock, NULL);
-    Status = AcpiEvWalkGpeList (AcpiHwClearGpeBlock, NULL);
     return_ACPI_STATUS (Status);
 }
 

--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -198,16 +198,8 @@ AcpiHwLegacySleep (
         return_ACPI_STATUS (Status);
     }
 
-    /* Clear all fixed and general purpose status bits */
-
-    Status = AcpiHwClearAcpiStatus ();
-    if (ACPI_FAILURE (Status))
-    {
-        return_ACPI_STATUS (Status);
-    }
-
     /*
-     * 1) Disable/Clear all GPEs
+     * 1) Disable all GPEs
      * 2) Enable all wakeup GPEs
      */
     Status = AcpiHwDisableAllGpes ();
@@ -427,7 +419,7 @@ AcpiHwLegacyWake (
      * might get fired there
      *
      * Restore the GPEs:
-     * 1) Disable/Clear all GPEs
+     * 1) Disable all GPEs
      * 2) Enable all runtime GPEs
      */
     Status = AcpiHwDisableAllGpes ();

--- a/source/components/hardware/hwxfsleep.c
+++ b/source/components/hardware/hwxfsleep.c
@@ -337,7 +337,7 @@ AcpiEnterSleepStateS4bios (
     }
 
     /*
-     * 1) Disable/Clear all GPEs
+     * 1) Disable all GPEs
      * 2) Enable all wakeup GPEs
      */
     Status = AcpiHwDisableAllGpes ();

--- a/source/include/acevents.h
+++ b/source/include/acevents.h
@@ -250,6 +250,12 @@ ACPI_STATUS
 AcpiEvFinishGpe (
     ACPI_GPE_EVENT_INFO     *GpeEventInfo);
 
+UINT32
+AcpiEvDetectGpe (
+    ACPI_NAMESPACE_NODE     *GpeDevice,
+    ACPI_GPE_EVENT_INFO     *GpeEventInfo,
+    UINT32                  GpeNumber);
+
 
 /*
  * evgpeblk - Upper-level GPE block support

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -906,7 +906,7 @@ typedef UINT32                          ACPI_EVENT_STATUS;
  *   |  | | |  +-- Type of dispatch:to method, handler, notify, or none
  *   |  | | +----- Interrupt type: edge or level triggered
  *   |  | +------- Is a Wake GPE
- *   |  +--------- Is GPE masked by the software GPE masking mechanism
+ *   |  +--------- Has been enabled automatically at init time
  *   +------------ <Reserved>
  */
 #define ACPI_GPE_DISPATCH_NONE          (UINT8) 0x00
@@ -922,6 +922,7 @@ typedef UINT32                          ACPI_EVENT_STATUS;
 #define ACPI_GPE_XRUPT_TYPE_MASK        (UINT8) 0x08
 
 #define ACPI_GPE_CAN_WAKE               (UINT8) 0x10
+#define ACPI_GPE_AUTO_ENABLED           (UINT8) 0x20
 
 /*
  * Flags for GPE and Lock interfaces


### PR DESCRIPTION
This patchset can help to avoid all kinds of GPE losses:
1. Gpe shouldn't be cleared which may cause GPE loss, but should be handled.
2. Edge-triggered GPE should be polled once right after being enabled.

However in order for GPE handler to be safe for both IRQ context and task context, GPE handling should be parallelized - achieved via per-GPE bit handling.