### PR TITLE
ASLTS: exc: allow implicit conversion of strings with "0x" to hex

### DIFF
--- a/tests/aslts/src/runtime/collections/exceptions/exc/exc.asl
+++ b/tests/aslts/src/runtime/collections/exceptions/exc/exc.asl
@@ -794,6 +794,9 @@ Method(m154,, Serialized)
  * Updated specs 12.03.05:
  * "Note: the first non-hex character terminates the conversion
  * without error, and a '0x' prefix is not allowed."
+ *
+ * Update 08.10.17
+ * Allow '0x' prefix for usability and clarity.
  */
 Method(m155,, Serialized)
 {
@@ -810,7 +813,7 @@ Method(m155,, Serialized)
 	 * New:
 	 */
 	CH03(ts, z058, 106, __LINE__, 0)
-	if (LNotEqual(Local0, 0)) {
+	if (LNotEqual(Local0, 0x1111)) {
 		// Bug 63, Bugzilla 5329.
 		err(ts, z058, __LINE__, 0, 0, Local0, 0)
 	}


### PR DESCRIPTION
The ACPI spec's definition of implicit conversion does not allow
'0x' within strings that are converted to integers. Without '0x'
the number being converted could be mistaken as a decimal number.
Instead we are allowing with 0x or no 0x and both versions are
implicitly converted to hex.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>