### PR TITLE
acpiexec:change acpiexec's max loop count

### DIFF
--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -600,7 +600,7 @@ main (
 
     /* ACPICA runtime configuration */
 
-    AcpiGbl_MaxLoopIterations = 400;
+    AcpiGbl_MaxLoopIterations = AcpiGbl_MaxLoopIterations;
 
 
     /* Initialize the AML debugger */


### PR DESCRIPTION
This increases the max loop global and results in fixing a few ASLTS test cases due to large loop iterations.