### PR TITLE
acpisrc: don't fclose a file twice on an error exit path

### DIFF
--- a/source/tools/acpisrc/asfile.c
+++ b/source/tools/acpisrc/asfile.c
@@ -922,7 +922,6 @@ AsGetFile (
     }
 
     Buffer [Size] = 0;         /* Null terminate the buffer */
-    fclose (File);
 
     /* This option checks the entire file for non-printable chars */
 
@@ -945,6 +944,7 @@ AsGetFile (
      */
     AsConvertToLineFeeds (Buffer);
 
+    fclose (File);
     *FileBuffer = Buffer;
     *FileSize = Size;
     return (0);


### PR DESCRIPTION
The check on Gbl_CheckAscii in function AsProcessOneFile jumps to the
ErrorFree exit path that fcloses a file a second time.  Avoid this
double fclose by moving first fclose to close to the end path of the
function.

Detected by CoverityScan, CID#175021 ("Use after close")

Fixes: a2c83e75a595 ("acpisrc: Add option to check files for non-printable characters")
Signed-off-by: Colin Ian King <colin.king@canonical.com>