### PR TITLE
Add functionality to invoke Do 2 if previous test run does not match the current test run results

### DIFF
--- a/tests/aslts/Makefile.def
+++ b/tests/aslts/Makefile.def
@@ -147,7 +147,7 @@ disasm_test_compile: $(TOP)/tmp/aml/$(ASLTS_VER)/$(ASLTS_AMLDIR)
 	@rval=0; \
 	for j in ${ASLMOD} $(ASLMODADD); do \
 		for k in ${AMLMOD}; do \
-			>&2 printf  " => Compile Ext in-place"; \
+			>&2 printf  " => Compile with externals in place"; \
 			"$(ASL)" -p $$k-extInPlace -oE $(TEST_SEQUENCE_ASL_FLAGS) $$j.asl >> $(COMPILER_LOG) 2>> $(COMPILER_ERROR_LOG); \
 			ret=$$?; \
 			if [ $$ret != 0 ]; then \

--- a/tests/aslts/bin/Do
+++ b/tests/aslts/bin/Do
@@ -328,6 +328,10 @@ binary_compare()
 	disasm_compile_dir="$ASLTSDIR/tmp/aml/$aslversion/$mode"
 	normal_compile_dir="$ASLTSDIR/tmp/aml/$aslversion/nopt/64"
 
+	echo "Performing binary comparison of AML files within"
+	echo "    $normal_compile_dir"
+	echo "    $disasm_compile_dir"
+
 	if [ ! -d $disasm_compile_dir ]; then
 		echo "$dism_compile_dir does not exist. Aborting binary compare"
 		return;
@@ -408,7 +412,7 @@ make_install()
 		echo "Make ASL minus"
 		make_target install "$1" "aslminus"
 		nres=$?
-		binary_compare "aslplus"
+		binary_compare "aslminus"
 		nres=$(($nres+ $?))
 		if [ $nres -ne 0 ]; then
 			res=$(($res + $nres))

--- a/tests/aslts/bin/asltsrun
+++ b/tests/aslts/bin/asltsrun
@@ -915,6 +915,12 @@ compare_two_summaries()
 	echo "$longDivider"
 	printf "$format" "pass diff" $o64p $n64p $o32p $n32p
 	printf "$format" "fail diff" $o64f $n64f $o32f $n32f
+	for result_value in $o64p $n64p $o32p $n32p $o64f $n64f $o32f $n32f
+	do
+		if [ $result_value -ne 0 ]; then
+			return 1
+		fi
+	done
 }
 
 # ############################## MAIN ###############################
@@ -1096,6 +1102,13 @@ if [ "$summary_to_compare" == "" ]; then
 else
 	echo "comparing against $summary_to_compare"
 	compare_two_summaries "$COMMONLOGFILE" "$summary_to_compare"
+	if [ $? -ne 0 ]; then \
+		do2path=$MULTIPATH/do2Output.txt
+		Do 2 > $do2path
+		if [ $? -ne 0 ]; then \
+			echo "Detailed comparsion of previous 2 test runs in $do2path"
+		fi
+	fi
 fi
 
 exit $UTILSTATUS


### PR DESCRIPTION
This is a convenient feature that will print the path of ./Do 2 output if mismatched results exist.