### PR TITLE
disassembler: reset ParserState's Aml pointer when parsing bad external declarations

### DIFF
--- a/source/components/parser/psobject.c
+++ b/source/components/parser/psobject.c
@@ -500,14 +500,8 @@ AcpiPsCreateOp (
              * external declaration opcode. Setting WalkState->Aml to
              * WalkState->ParserState.Aml + 2 moves increments the
              * WalkState->Aml past the object type and the paramcount of the
-             * external opcode. For the error message, only print the AML
-             * offset. We could attempt to print the name but this may cause
-             * a segmentation fault when printing the namepath because the
-             * AML may be incorrect.
+             * external opcode.
              */
-            AcpiOsPrintf (
-                "// Invalid external declaration at AML offset 0x%x.\n",
-                WalkState->Aml - WalkState->ParserState.AmlStart);
             WalkState->Aml = WalkState->ParserState.Aml + 2;
             WalkState->ParserState.Aml = WalkState->Aml;
             return_ACPI_STATUS (AE_CTRL_PARSE_CONTINUE);

--- a/source/components/parser/psobject.c
+++ b/source/components/parser/psobject.c
@@ -509,6 +509,7 @@ AcpiPsCreateOp (
                 "// Invalid external declaration at AML offset 0x%x.\n",
                 WalkState->Aml - WalkState->ParserState.AmlStart);
             WalkState->Aml = WalkState->ParserState.Aml + 2;
+            WalkState->ParserState.Aml = WalkState->Aml;
             return_ACPI_STATUS (AE_CTRL_PARSE_CONTINUE);
         }
 #endif


### PR DESCRIPTION
resolves [bz1397](https://bugs.acpica.org/show_bug.cgi?id=1397)