### PR TITLE
Avoid null pointer dereference on Op.

### DIFF
--- a/source/components/parser/psutils.c
+++ b/source/components/parser/psutils.c
@@ -292,11 +292,11 @@ AcpiPsAllocOp (
         {
             AcpiGbl_CurrentScope = Op;
         }
-    }
 
-    if (Gbl_CaptureComments)
-    {
-        ASL_CV_TRANSFER_COMMENTS (Op);
+        if (Gbl_CaptureComments)
+        {
+            ASL_CV_TRANSFER_COMMENTS (Op);
+        }
     }
 
     return (Op);


### PR DESCRIPTION
The calls to AcpiOsAcquireObject can result in a null being assigned
to Op (for example if a mutex acquire fails) which can lead to a
null pointer dereference on Op on the call to ASL_CV_TRANSFER_COMMENTS
(via function CvTransferComments).  Move the block into the previous
block that checks for a null Op so that we never can call
CvTransferComments with a null Op.

Detected by: CoverityScan CID#1371660 ("Dereference after null check")

Signed-off-by: Colin Ian King <colin.king@canonical.com>