### PR TITLE
iASL: adding support for more detailed compiler errors

### DIFF
--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -450,6 +450,16 @@ AslAbort (
     void);
 
 void
+AslDualParseOpError (
+    UINT8                   Level,
+    UINT16                  MainMessageId,
+    ACPI_PARSE_OBJECT       *MainOp,
+    char                    *MainMessage,
+    UINT16                  SecondMessageId,
+    ACPI_PARSE_OBJECT       *SecondOp,
+    char                    *SecondaryMessage);
+
+void
 AslError (
     UINT8                   Level,
     UINT16                  MessageId,

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -327,8 +327,9 @@ LdLoadFieldElements (
                      * The name already exists in this scope
                      * But continue processing the elements
                      */
-                    AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Child,
-                        Child->Asl.Value.String);
+                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Child,
+                        Child->Asl.Value.String, ASL_MSG_FOUND_HERE, Node->Op,
+                        Node->Op->Asl.ExternalName);
                 }
             }
             else
@@ -388,8 +389,10 @@ LdLoadResourceElements (
         {
             /* Actual node causing the error was saved in ParentMethod */
 
-            AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS,
-                (ACPI_PARSE_OBJECT *) Op->Asl.ParentMethod, Op->Asl.Namepath);
+            AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS,
+                (ACPI_PARSE_OBJECT *) Op->Asl.ParentMethod,
+                Op->Asl.Namepath, ASL_MSG_FOUND_HERE, Node->Op,
+                Node->Op->Asl.ExternalName);
             return (AE_OK);
         }
         return (Status);
@@ -827,8 +830,9 @@ LdNamespace1Begin (
                 if (Node->OwnerId == WalkState->OwnerId &&
                     !(Node->Flags & IMPLICIT_EXTERNAL))
                 {
-                    AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
-                        Op->Asl.ExternalName);
+                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
+                        Op->Asl.ExternalName, ASL_MSG_FOUND_HERE, Node->Op,
+                        Node->Op->Asl.ExternalName);
                 }
                 if (Node->Flags & IMPLICIT_EXTERNAL)
                 {
@@ -849,8 +853,9 @@ LdNamespace1Begin (
 
                 if (Node->OwnerId == WalkState->OwnerId)
                 {
-                    AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
-                        Op->Asl.ExternalName);
+                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
+                        Op->Asl.ExternalName, ASL_MSG_FOUND_HERE, Node->Op,
+                        Node->Op->Asl.ExternalName);
                 }
             }
             else if ((Node->Flags & ANOBJ_IS_EXTERNAL) &&
@@ -905,8 +910,9 @@ LdNamespace1Begin (
             {
                 /* Valid error, object already exists */
 
-                AslError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
-                    Op->Asl.ExternalName);
+                AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
+                    Op->Asl.ExternalName, ASL_MSG_FOUND_HERE, Node->Op,
+                    Node->Op->Asl.ExternalName);
                 return_ACPI_STATUS (AE_OK);
             }
         }

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -350,7 +350,8 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_CONSTANT_REQUIRED */          "Non-reducible expression",
 /*    ASL_MSG_CROSS_TABLE_SCOPE */          "Illegal open scope on external object from within DSDT",
 /*    ASL_MSG_EXCEPTION_NOT_RECEIVED */     "Expected remark, warning, or error did not occur. Message ID:",
-/*    ASL_MSG_NULL_RESOURCE_TEMPLATE */     "Empty Resource Template (END_TAG only)"
+/*    ASL_MSG_NULL_RESOURCE_TEMPLATE */     "Empty Resource Template (END_TAG only)",
+/*    ASL_MSG_FOUND_HERE */                 "Original name creation/declaration below: "
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -353,6 +353,7 @@ typedef enum
     ASL_MSG_CROSS_TABLE_SCOPE,
     ASL_MSG_EXCEPTION_NOT_RECEIVED,
     ASL_MSG_NULL_RESOURCE_TEMPLATE,
+    ASL_MSG_FOUND_HERE,
 
     /* These messages are used by the Data Table compiler only */
 

--- a/source/compiler/asltypes.h
+++ b/source/compiler/asltypes.h
@@ -337,8 +337,11 @@ typedef struct asl_include_dir
 } ASL_INCLUDE_DIR;
 
 
-/* An entry in the exception list, one for each error/warning */
-
+/*
+ * An entry in the exception list, one for each error/warning
+ * Note: SubError nodes would be treated with the same messageId and Level
+ * as the parent error node.
+ */
 typedef struct asl_error_msg
 {
     UINT32                      LineNumber;
@@ -347,6 +350,7 @@ typedef struct asl_error_msg
     UINT32                      Column;
     char                        *Message;
     struct asl_error_msg        *Next;
+    struct asl_error_msg        *SubError;
     char                        *Filename;
     char                        *SourceLine;
     UINT32                      FilenameLength;


### PR DESCRIPTION
This pull request adds AslDualParseOpError, a function that takes two parse nodes and two messages so that more detailed error messages can be emitted. For example, the following error message indicates the location of multiple declarations by using multiple parse nodes:
```
DSDT.iiii   1692:       Device(PEG2) {
Error    6074 -                  ^ Name already exists in scope (PEG2)
                 Original name creation/declaration below:
DSDT.iiii     93:   External(\_SB.PCI0.PEG2, DeviceObj)
```