### PR TITLE
iASL: remove redundant initialization of CommentOption

### DIFF
--- a/source/compiler/cvparser.c
+++ b/source/compiler/cvparser.c
@@ -714,7 +714,7 @@ CvCaptureCommentsOnly (
     UINT8                   *Aml = ParserState->Aml;
     UINT16                  Opcode = (UINT16) ACPI_GET8 (Aml);
     UINT32                  Length = 0;
-    UINT8                   CommentOption = (UINT16) ACPI_GET8 (Aml+1);
+    UINT8                   CommentOption;
     BOOLEAN                 StdDefBlockFlag = FALSE;
     ACPI_COMMENT_NODE       *CommentNode;
     ACPI_FILE_NODE          *FileNode;


### PR DESCRIPTION
CommentOption is being initialized and then this value is being
overwritten by a subsequent assignment to CommentOption, hence the
first setting of CommentOption is redundant and can be removed. Cleans
up clang warning:

Value stored to 'CommentOption' during its initialization is never read

Signed-off-by: Colin Ian King <colin.king@canonical.com>