### PR TITLE
iASL: change processing of external op namespace nodes for correctness

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -808,8 +808,8 @@ LdNamespace1Begin (
                 /*
                  * Allow one create on an object or segment that was
                  * previously declared External only if WalkState->OwnerId and
-                 * Node->OwnerId are found in different tables (meaning that
-                 * they have differnt OwnerIds).
+                 * Node->OwnerId are different (meaning that the current WalkState
+                 * and the Node are in different tables).
                  */
                 Node->Flags &= ~ANOBJ_IS_EXTERNAL;
                 Node->Type = (UINT8) ObjectType;

--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -775,19 +775,19 @@ AcpiNsLookup (
                     ThisNode = (ACPI_NAMESPACE_NODE *) ThisNode->Object;
                 }
             }
-#ifdef ACPI_ASL_COMPILER
-            if (!AcpiGbl_DisasmFlag &&
-                (ThisNode->Flags & ANOBJ_IS_EXTERNAL))
-            {
-                ThisNode->Flags |= IMPLICIT_EXTERNAL;
-            }
-#endif
         }
 
         /* Special handling for the last segment (NumSegments == 0) */
 
         else
         {
+#ifdef ACPI_ASL_COMPILER
+            if (!AcpiGbl_DisasmFlag && (ThisNode->Flags & ANOBJ_IS_EXTERNAL))
+            {
+                ThisNode->Flags &= ~IMPLICIT_EXTERNAL;
+            }
+#endif
+
             /*
              * Sanity typecheck of the target object:
              *

--- a/source/components/namespace/nssearch.c
+++ b/source/components/namespace/nssearch.c
@@ -545,6 +545,7 @@ AcpiNsSearchAndEnter (
         (WalkState && WalkState->Opcode == AML_SCOPE_OP))
     {
         NewNode->Flags |= ANOBJ_IS_EXTERNAL;
+        NewNode->Flags |= IMPLICIT_EXTERNAL;
     }
 #endif
 


### PR DESCRIPTION
The declaration External (ABCD.EFGH) creates two nodes in the namespace: ABCD
and EFGH where ABCD is marked as an implicit external node. ABCD is labeled as
implicit because there does not exist a specific External (ABCD) declaration.

Before this change, the declaration External (ABCD.EFGH) and
External (ABCD.EFGH.IJKL) creates the namespace nodes ABCD, EFGH, and IJKL
where ABCD and EFGH are labeled as implicit external nodes. This is incorrect.
The only implicit node should be ABCD because EFGH and IJKL are explicit nodes.
This change fixes the labeling procecess of external op namespace nodes so that
nodes are properly labeled as implicit external.

Due to this commit, the below ASL code results in a compilation error.

DefinitionBlock ("DSDT.aml", "DSDT", 0x02, "INTEL", "BDW     ", 0x0)
{
    External(\_SB.PCI0.GFX0, DeviceObj)
    External(\_SB.PCI0.GFX0.ALSI)

    Scope(\_SB)
    {
        Device(PCI0)
        {
            Device(GFX0)
            {
                Name(_ADR, 0x00020000)
            }
        }
    }
}