### PR TITLE
ASLTS: fix memory statistics

### DIFF
--- a/source/components/utilities/uttrack.c
+++ b/source/components/utilities/uttrack.c
@@ -891,7 +891,7 @@ Exit:
     }
     else
     {
-        ACPI_ERROR ((AE_INFO, "%u(0x%X) Outstanding allocations",
+        ACPI_ERROR ((AE_INFO, "%u (0x%X) Outstanding cache allocations",
             NumOutstanding, NumOutstanding));
     }
 

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -810,11 +810,15 @@ EnterDebugger:
 
     AcpiTerminateDebugger ();
 
+    /* re-enable debug output for AcpiTerminate output */
+
+    AcpiGbl_DbOutputFlags = ACPI_DB_CONSOLE_OUTPUT;
+
 NormalExit:
     ExitCode = 0;
 
 ErrorExit:
-    (void) AcpiOsTerminate ();
+    (void) AcpiTerminate ();
     AcDeleteTableList (ListHead);
     return (ExitCode);
 }

--- a/tests/aslts/bin/asltsrun
+++ b/tests/aslts/bin/asltsrun
@@ -144,7 +144,7 @@ get_aml_code_path()
 # arg2 - bitmap of mode
 run_test_case()
 {
-	local amlcodepath tcase=$1 modepart modename SLMODE BITMODE
+	local amlcodepath tcase=$1 modepart modename BITMODE
 	local options method commandline
 
 
@@ -172,7 +172,7 @@ run_test_case()
 		AML_DONT_EXIST=$[ $AML_DONT_EXIST + 1 ]
 		TEST_RET=1
 	else
-		options="-ep -el -to 60"
+		options="-ef -ep -el -to 60"
 		method=MN00
 
 		if [ "$DO_MEMSTAT" == "yes" ]; then
@@ -418,46 +418,44 @@ do_summary_of_test_case()
 				finish=`echo "$line" | awk -F" " '{print $8}'`
 				total=`echo "$line" | awk -F" " '{print $9}'`
 			fi
-		elif [[ "$s0" == Outstanding: ]]; then # this never seems to get used...
-			outstand0=$s1
-		elif [[ "$s0" == Mem: ]]; then # defer work on this until the output works again.
+		elif [[ "$line" == *"Mem:"* ]]; then
 			if [ $memcnt == 0 ]; then
-				memtotal=`echo "$line" | awk -F" " '{print $9}'`
+				memtotal=`echo "$line" | awk -F" " '{print $13}'`
 				memtotal=$[ 0 + 0x$memtotal ]
-				max0=`echo "$line" | awk -F" " '{print $6}'`
-				out0=`echo "$line" | awk -F" " '{print $8}'`
+				max0=`echo "$line" | awk -F" " '{print $10}'`
+				out0=`echo "$line" | awk -F" " '{print $12}'`
 				max0=$[ 0 + 0x$max0 ]
 				out0=$[ 0 + 0x$out0 ]
 			elif [ $memcnt == 1 ]; then
-				max1=`echo "$line" | awk -F" " '{print $5}'`
-				out1=`echo "$line" | awk -F" " '{print $7}'`
+				max1=`echo "$line" | awk -F" " '{print $9}'`
+				out1=`echo "$line" | awk -F" " '{print $11}'`
 				max1=$[ 0 + 0x$max1 ]
 				out1=$[ 0 + 0x$out1 ]
 			elif [ $memcnt == 2 ]; then
-				max2=`echo "$line" | awk -F" " '{print $5}'`
-				out2=`echo "$line" | awk -F" " '{print $7}'`
+				max2=`echo "$line" | awk -F" " '{print $9}'`
+				out2=`echo "$line" | awk -F" " '{print $11}'`
 				max2=$[ 0 + 0x$max2 ]
 				out2=$[ 0 + 0x$out2 ]
 			elif [ $memcnt == 3 ]; then
-				max3=`echo "$line" | awk -F" " '{print $5}'`
-				out3=`echo "$line" | awk -F" " '{print $7}'`
+				max3=`echo "$line" | awk -F" " '{print $9}'`
+				out3=`echo "$line" | awk -F" " '{print $11}'`
 				max3=$[ 0 + 0x$max3 ]
 				out3=$[ 0 + 0x$out3 ]
 			elif [ $memcnt == 4 ]; then
-				max4=`echo "$line" | awk -F" " '{print $5}'`
-				out4=`echo "$line" | awk -F" " '{print $7}'`
+				max4=`echo "$line" | awk -F" " '{print $9}'`
+				out4=`echo "$line" | awk -F" " '{print $11}'`
 				max4=$[ 0 + 0x$max4 ]
 				out4=$[ 0 + 0x$out4 ]
 			elif [ $memcnt == 5 ]; then
-				max5=`echo "$line" | awk -F" " '{print $5}'`
-				out5=`echo "$line" | awk -F" " '{print $7}'`
+				max5=`echo "$line" | awk -F" " '{print $9}'`
+				out5=`echo "$line" | awk -F" " '{print $11}'`
 				max5=$[ 0 + 0x$max5 ]
 				out5=$[ 0 + 0x$out5 ]
 			fi
 			memcnt=$[ $memcnt + 1 ]
-		elif [[ "$line" == *"Outstanding allocations"* ]]; then
-			trimmedLine=`echo "$line" | awk -F" Outstanding allocations" '{printf $1}'`
-			outstand1=`echo "$trimmedLine" | awk -F"(" '{print $1}'`
+		elif [[ "$line" == *"Outstanding cache allocations"* ]]; then
+			trimmedLine=`echo "$line" | awk -F" Outstanding cache allocations" '{printf $1}'`
+			outstand1=`echo "$trimmedLine" | awk -F" " '{print $3}'`
 		elif [[ "$line" == *"The total number of exceptions handled"* ]]; then
 			exceptionsnum=`echo "$line" | sed 's/^\[.*\]//g' | awk -F" " '{print $7}'`
 			x=`echo $exceptionsnum | sed 's/"//g'`


### PR DESCRIPTION
This fixes Acpiexec and ASLTS so that memory statistics are emitted to the output of ASLTS.