### PR TITLE
Namespace: fix memory leak from building prefixed pathname

### DIFF
--- a/source/components/namespace/nsnames.c
+++ b/source/components/namespace/nsnames.c
@@ -537,7 +537,7 @@ AcpiNsBuildPrefixedPathname (
 {
     ACPI_STATUS             Status;
     char                    *FullPath = NULL;
-    char                    *ExternalPath;
+    char                    *ExternalPath = NULL;
     char                    *PrefixPath = NULL;
     UINT32                  PrefixPathLength = 0;
 
@@ -589,6 +589,10 @@ Cleanup:
     if (PrefixPath)
     {
         ACPI_FREE (PrefixPath);
+    }
+    if (ExternalPath)
+    {
+        ACPI_FREE (ExternalPath);
     }
 
     return (FullPath);


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>