### PR TITLE
acpiexamples: rename ExecuteOSI to ExecuteExampleOSI to avoid redecla…

### DIFF
--- a/source/tools/examples/examples.c
+++ b/source/tools/examples/examples.c
@@ -213,7 +213,7 @@ static void
 ExecuteMAIN (void);
 
 static void
-ExecuteOSI (void);
+ExecuteExampleOSI (void);
 
 ACPI_STATUS
 InitializeAcpiTables (
@@ -263,7 +263,7 @@ main (
     ACPI_EXCEPTION   ((AE_INFO, AE_AML_OPERAND_TYPE,
         "Example ACPICA exception message"));
 
-    ExecuteOSI ();
+    ExecuteExampleOSI ();
     ExecuteMAIN ();
     return (0);
 }
@@ -541,7 +541,7 @@ InstallHandlers (void)
  *****************************************************************************/
 
 static void
-ExecuteOSI (void)
+ExecuteExampleOSI (void)
 {
     ACPI_STATUS             Status;
     ACPI_OBJECT_LIST        ArgList;


### PR DESCRIPTION
…ration error

Recent changes in the acpiexec files inserted the ExecuteOSI function prototype
within aecommon.h. This file is included by acpiexamples and acpiexamples contains
a statically defined function called ExecuteOSI within examples.c. This change
fixes the compilation error intoduced by changes within aecommon.h.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>