### PR TITLE
Makefile: allow support for compilers other than gcc via CC environme…

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -35,7 +35,7 @@
 .SUFFIXES :
 PROGS = acpibin acpidump acpiexamples acpiexec acpihelp acpinames acpisrc acpixtract iasl
 HOST ?= _CYGWIN
-CC =    gcc
+CC ?=    gcc
 
 #
 # Common defines


### PR DESCRIPTION
…nt variable

Patch credited to Nikolai SAOUKH

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>