### PR TITLE
Fix build on a platform where char is unsigned.

### DIFF
--- a/source/compiler/aslsupport.l
+++ b/source/compiler/aslsupport.l
@@ -525,7 +525,7 @@ static void
 count (
     int                 Type)
 {
-    int                 i;
+    char                *p;
 
 
     switch (Type)
@@ -547,9 +547,9 @@ count (
         break;
     }
 
-    for (i = 0; (yytext[i] != 0) && (yytext[i] != EOF); i++)
+    for (p = yytext; *p != '\0'; p++)
     {
-        AslInsertLineBuffer (yytext[i]);
+        AslInsertLineBuffer (*p);
         *Gbl_LineBufPtr = 0;
     }
 }


### PR DESCRIPTION
`yytext[]` should never be tested against `EOF` because `lex(1)` cannot
produce `yytext` containing `EOF`.  In fact, `(yytext[i] != EOF)` is always
true on those platforms because `EOF` is defined as an implementation
specific *negative* integer by the ANSI C, often times defined as `-1`.
Specifically for the above expression, `yytext[i]` is implicitly promoted
to a signed integer before comparison and it can never be a negative
value because `sizeof int` is greater than `sizeof char`.