### PR TITLE
Debugger: fix slight indentation issue

### DIFF
--- a/source/components/utilities/utdebug.c
+++ b/source/components/utilities/utdebug.c
@@ -343,7 +343,7 @@ AcpiDebugPrint (
     }
 
     AcpiOsPrintf ("[%02ld] %*s",
-        AcpiGbl_NestingLevel, AcpiGbl_NestingLevel, " ");
+        AcpiGbl_NestingLevel, AcpiGbl_NestingLevel + 1, " ");
     AcpiOsPrintf ("%s%*s: ",
         AcpiUtTrimFunctionName (FunctionName), FillCount, " ");
 


### PR DESCRIPTION
The %*s format specifier prints a string with a width indicated by an integer
In the case of AcpiOsPrintf ("%*s", AcpiGbl_NestingLevel, " "), a single space
is printed to the console when AcpiGbl_NestingLevel is 0 or 1. This change
increments AcpiGbl_NestingLevel so that there is one space printed when
AcpiGbl_NestingLevel is 0 and two spaces printed when AcpiGbl_NestingLevel is 1.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>