### PR TITLE
DT compiler: prevent error if optional field at the end of table is n…

### DIFF
--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -559,9 +559,17 @@ DtCompileTable (
     ACPI_STATUS             Status = AE_OK;
 
 
-    if (!Field || !*Field)
+    if (!Field)
     {
         return (AE_BAD_PARAMETER);
+    }
+    if (!*Field)
+    {
+        /*
+         * The field list is empty, this means that we are out of fields to
+         * parse. In other words, we are at the end of the table.
+         */
+        return (AE_END_OF_TABLE);
     }
 
     /* Ignore optional subtable if name does not match */

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -596,7 +596,13 @@ DtCompileDbg2 (
 
         Status = DtCompileTable (PFieldList, AcpiDmTableInfoDbg2OemData,
             &Subtable, TRUE);
-        if (ACPI_FAILURE (Status))
+        if (Status == AE_END_OF_TABLE)
+        {
+            /* optional field was not found and we're at the end of the file */
+
+            goto subtableDone;
+        }
+        else if (ACPI_FAILURE (Status))
         {
             return (Status);
         }
@@ -615,7 +621,7 @@ DtCompileDbg2 (
 
             DtInsertSubtable (ParentTable, Subtable);
         }
-
+subtableDone:
         SubtableCount--;
         DtPopSubtable (); /* Get next Device Information subtable */
     }

--- a/source/include/acexcep.h
+++ b/source/include/acexcep.h
@@ -241,8 +241,9 @@ typedef struct acpi_exception_info
 #define AE_HEX_OVERFLOW                 EXCEP_ENV (0x0020)
 #define AE_DECIMAL_OVERFLOW             EXCEP_ENV (0x0021)
 #define AE_OCTAL_OVERFLOW               EXCEP_ENV (0x0022)
+#define AE_END_OF_TABLE                 EXCEP_ENV (0x0023)
 
-#define AE_CODE_ENV_MAX                 0x0022
+#define AE_CODE_ENV_MAX                 0x0023
 
 
 /*
@@ -379,7 +380,8 @@ static const ACPI_EXCEPTION_INFO    AcpiGbl_ExceptionNames_Env[] =
     EXCEP_TXT ("AE_NUMERIC_OVERFLOW",           "Overflow during string-to-integer conversion"),
     EXCEP_TXT ("AE_HEX_OVERFLOW",               "Overflow during ASCII hex-to-binary conversion"),
     EXCEP_TXT ("AE_DECIMAL_OVERFLOW",           "Overflow during ASCII decimal-to-binary conversion"),
-    EXCEP_TXT ("AE_OCTAL_OVERFLOW",             "Overflow during ASCII octal-to-binary conversion")
+    EXCEP_TXT ("AE_OCTAL_OVERFLOW",             "Overflow during ASCII octal-to-binary conversion"),
+    EXCEP_TXT ("AE_END_OF_TABLE",               "Reached the end of table")
 };
 
 static const ACPI_EXCEPTION_INFO    AcpiGbl_ExceptionNames_Pgm[] =


### PR DESCRIPTION
…ot present

The data table compiler throws under the following conditions:
1.) there is a table with a last field that is optional
2.) if the optional field is not present
3.) the optional field is the last line of the data table

A change was made to DtCompileTable to return an AE_EOF under these conditions.
This AE_EOF means that we are at the end of the file. The caller to DtCompileTable
is responsible for handling this case. For DBG2 table, we will complete the
compilation of this subtable. For other tables, this could be different.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>