### PR TITLE
Recognize the Windows 10 version 1607 and 1703 OSI strings

### DIFF
--- a/source/components/utilities/utosi.c
+++ b/source/components/utilities/utosi.c
@@ -214,6 +214,8 @@ static ACPI_INTERFACE_INFO    AcpiDefaultSupportedInterfaces[] =
     {"Windows 2012",        NULL, 0, ACPI_OSI_WIN_8},            /* Windows 8 and Server 2012 - Added 08/2012 */
     {"Windows 2013",        NULL, 0, ACPI_OSI_WIN_8},            /* Windows 8.1 and Server 2012 R2 - Added 01/2014 */
     {"Windows 2015",        NULL, 0, ACPI_OSI_WIN_10},           /* Windows 10 - Added 03/2015 */
+    {"Windows 2016",        NULL, 0, ACPI_OSI_WIN_10_RS1},       /* Windows 10 version 1607 - Added 12/2017 */
+    {"Windows 2017",        NULL, 0, ACPI_OSI_WIN_10_RS2},       /* Windows 10 version 1703 - Added 12/2017 */
 
     /* Feature Group Strings */
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1509,6 +1509,8 @@ typedef enum
 #define ACPI_OSI_WIN_7                  0x0B
 #define ACPI_OSI_WIN_8                  0x0C
 #define ACPI_OSI_WIN_10                 0x0D
+#define ACPI_OSI_WIN_10_RS1             0x0E
+#define ACPI_OSI_WIN_10_RS2             0x0F
 
 
 /* Definitions of getopt */


### PR DESCRIPTION
The [public Microsoft document](http://download.microsoft.com/download/7/e/7/7e7662cf-cbea-470b-a97e-ce7ce0d98dc2/winacpi_osi.docx) listing recognized Windows OSI strings shows that these two strings were introduced in recent versions.

- version 1607 / Anniversary Update / "Redstone 1"
- version 1703 / Creators Update / "Redstone 2"
