### PR TITLE
trivial style fix, no functional change

### DIFF
--- a/source/components/executer/exdump.c
+++ b/source/components/executer/exdump.c
@@ -747,7 +747,7 @@ AcpiExDumpOperand (
     UINT32                  Index;
 
 
-    ACPI_FUNCTION_NAME (ExDumpOperand)
+    ACPI_FUNCTION_NAME (ExDumpOperand);
 
 
     /* Check if debug output enabled */


### PR DESCRIPTION
This adds a semi-colon at the end of a macro call so that it can be processed
correctly with source code formatting tools.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>