### PR TITLE
iASL: do not get additional arguments for -d or -da options

### DIFF
--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -416,24 +416,10 @@ AslDoOptions (
         {
         case '^':
 
-            /* Get the required argument */
-
-            if (AcpiGetoptArgument (argc, argv))
-            {
-                return (-1);
-            }
-
             Gbl_DoCompile = FALSE;
             break;
 
         case 'a':
-
-            /* Get the required argument */
-
-            if (AcpiGetoptArgument (argc, argv))
-            {
-                return (-1);
-            }
 
             Gbl_DoCompile = FALSE;
             Gbl_DisassembleAll = TRUE;


### PR DESCRIPTION
The -da option consumes the next argument incorrectly. This
change prevents -da from consuming additional arguments.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>