### PR TITLE
disassembler: add a conditional in switch logic to avoid segmentation…

### DIFF
--- a/source/common/dmswitch.c
+++ b/source/common/dmswitch.c
@@ -543,6 +543,10 @@ AcpiDmIsSwitchBlock (
      * statement, so check for it.
      */
     CurrentOp = StoreOp->Common.Next->Common.Next;
+    if (!CurrentOp)
+    {
+        return (FALSE);
+    }
     if (CurrentOp->Common.AmlOpcode == AML_ELSE_OP)
     {
         CurrentOp = CurrentOp->Common.Next;


### PR DESCRIPTION
… fault

Due to potential incorrect AML, CurrentOp could be null. Check for this condition
to avoid a segmentation fault. Consequently, mark this block of the parse tree
as not a switch block.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>