### PR TITLE
Linux: add support for X32 ABI compilation

### DIFF
--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -315,7 +315,7 @@
 #define ACPI_FLUSH_CPU_CACHE()
 #define ACPI_CAST_PTHREAD_T(Pthread) ((ACPI_THREAD_ID) (Pthread))
 
-#if defined(__ia64__)    || defined(__x86_64__) ||\
+#if defined(__ia64__)    || (defined(__x86_64__) && !defined(__ILP32__)) ||\
     defined(__aarch64__) || defined(__PPC64__) ||\
     defined(__s390x__)
 #define ACPI_MACHINE_WIDTH          64


### PR DESCRIPTION
X32 follows ILP32 model. Check for ILP32 as well when checking for
x86_64 to ensure the defines are correct for X32 ABI.

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>