### PR TITLE
iASL: drop external name collision to a warning for now

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -921,6 +921,13 @@ AslCommonError (
     char                    *Filename,
     char                    *ExtraMessage)
 {
+    /* Check if user wants to ignore this exception */
+
+    if (AslIsExceptionIgnored (Level, MessageId))
+    {
+        return;
+    }
+
     AslLogNewError (Level, MessageId, CurrentLineNumber, LogicalLineNumber,
         LogicalByteOffset, Column, Filename, ExtraMessage,
         NULL, NULL);

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -327,8 +327,8 @@ LdLoadFieldElements (
                      * The name already exists in this scope
                      * But continue processing the elements
                      */
-                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Child,
-                        Child->Asl.Value.String, ASL_MSG_FOUND_HERE, Node->Op,
+                    AslDualParseOpError (ASL_WARNING, ASL_MSG_EXTERN_COLLISION, Child,
+                        Child->Asl.Value.String, ASL_MSG_EXTERN_FOUND_HERE, Node->Op,
                         Node->Op->Asl.ExternalName);
                 }
             }
@@ -830,8 +830,8 @@ LdNamespace1Begin (
                 if (Node->OwnerId == WalkState->OwnerId &&
                     !(Node->Flags & IMPLICIT_EXTERNAL))
                 {
-                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
-                        Op->Asl.ExternalName, ASL_MSG_FOUND_HERE, Node->Op,
+                    AslDualParseOpError (ASL_WARNING, ASL_MSG_EXTERN_COLLISION, Op,
+                        Op->Asl.ExternalName, ASL_MSG_EXTERN_FOUND_HERE, Node->Op,
                         Node->Op->Asl.ExternalName);
                 }
                 if (Node->Flags & IMPLICIT_EXTERNAL)
@@ -853,8 +853,8 @@ LdNamespace1Begin (
 
                 if (Node->OwnerId == WalkState->OwnerId)
                 {
-                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Op,
-                        Op->Asl.ExternalName, ASL_MSG_FOUND_HERE, Node->Op,
+                    AslDualParseOpError (ASL_WARNING, ASL_MSG_EXTERN_COLLISION, Op,
+                        Op->Asl.ExternalName, ASL_MSG_EXTERN_FOUND_HERE, Node->Op,
                         Node->Op->Asl.ExternalName);
                 }
             }

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -352,7 +352,9 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_EXCEPTION_NOT_RECEIVED */     "Expected remark, warning, or error did not occur. Message ID:",
 /*    ASL_MSG_NULL_RESOURCE_TEMPLATE */     "Empty Resource Template (END_TAG only)",
 /*    ASL_MSG_FOUND_HERE */                 "Original name creation/declaration below: ",
-/*    ASL_MSG_ILLEGAL_RECURSION */          "Illegal recursive call to method that creates named objects"
+/*    ASL_MSG_ILLEGAL_RECURSION */          "Illegal recursive call to method that creates named objects",
+/*    ASL_MSG_EXTERN_COLLISION */           "A name cannot be defined and declared external in the same table",
+/*    ASL_MSG_FOUND_HERE_EXTERN*/           "Remove one of the declarations indicated above or below:"
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -355,6 +355,8 @@ typedef enum
     ASL_MSG_NULL_RESOURCE_TEMPLATE,
     ASL_MSG_FOUND_HERE,
     ASL_MSG_ILLEGAL_RECURSION,
+    ASL_MSG_EXTERN_COLLISION,
+    ASL_MSG_EXTERN_FOUND_HERE,
 
     /* These messages are used by the Data Table compiler only */
 


### PR DESCRIPTION
This fix is a temporary adjustment to lower redundant externals
from an error to a warning.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>