### PR TITLE
Recognize the _OSI string "Windows 2017.2"

### DIFF
--- a/source/components/utilities/utosi.c
+++ b/source/components/utilities/utosi.c
@@ -216,6 +216,7 @@ static ACPI_INTERFACE_INFO    AcpiDefaultSupportedInterfaces[] =
     {"Windows 2015",        NULL, 0, ACPI_OSI_WIN_10},           /* Windows 10 - Added 03/2015 */
     {"Windows 2016",        NULL, 0, ACPI_OSI_WIN_10_RS1},       /* Windows 10 version 1607 - Added 12/2017 */
     {"Windows 2017",        NULL, 0, ACPI_OSI_WIN_10_RS2},       /* Windows 10 version 1703 - Added 12/2017 */
+    {"Windows 2017.2",      NULL, 0, ACPI_OSI_WIN_10_RS3},       /* Windows 10 version 1709 - Added 02/2018 */
 
     /* Feature Group Strings */
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1511,6 +1511,7 @@ typedef enum
 #define ACPI_OSI_WIN_10                 0x0D
 #define ACPI_OSI_WIN_10_RS1             0x0E
 #define ACPI_OSI_WIN_10_RS2             0x0F
+#define ACPI_OSI_WIN_10_RS3             0x10
 
 
 /* Definitions of getopt */


### PR DESCRIPTION
Dell uses this string to activate Thunderbolt native mode on supported
machines.

This is necessary to support the work that was done in the Linux kernel for native mode:
https://marc.info/?l=linux-acpi&m=151853954129169&w=2