### PR TITLE
Initialize FixedStatus/FixedEnable variables

### DIFF
--- a/source/components/events/evevent.c
+++ b/source/components/events/evevent.c
@@ -341,8 +341,8 @@ AcpiEvFixedEventDetect (
     void)
 {
     UINT32                  IntStatus = ACPI_INTERRUPT_NOT_HANDLED;
-    UINT32                  FixedStatus;
-    UINT32                  FixedEnable;
+    UINT32                  FixedStatus = 0;
+    UINT32                  FixedEnable = 0;
     UINT32                  i;
 
 


### PR DESCRIPTION
Latest versions of GCC are able to track variable initialization/usage.
And the compiler produces warnings that FixedStatus/FixedEnable can be
used without any initialization. It can happen if AcpiHwRegisterRead()
fails, the function does not assign output value in this case. But
despite that FixedStatus/FixedEnable are still used. Initialize these
variables to 0 to silense the warning.