### PR TITLE
Remove calling of _STA from AcpiGetObjectInfo()

### DIFF
--- a/source/components/debugger/dbdisply.c
+++ b/source/components/debugger/dbdisply.c
@@ -820,9 +820,8 @@ AcpiDbDisplayObjectType (
         return;
     }
 
-    AcpiOsPrintf ("ADR: %8.8X%8.8X, STA: %8.8X, Flags: %X\n",
-        ACPI_FORMAT_UINT64 (Info->Address),
-        Info->CurrentStatus, Info->Flags);
+    AcpiOsPrintf ("ADR: %8.8X%8.8X, Flags: %X\n",
+        ACPI_FORMAT_UINT64 (Info->Address), Info->Flags);
 
     AcpiOsPrintf ("S1D-%2.2X S2D-%2.2X S3D-%2.2X S4D-%2.2X\n",
         Info->HighestDstates[0], Info->HighestDstates[1],

--- a/source/components/namespace/nsdumpdv.c
+++ b/source/components/namespace/nsdumpdv.c
@@ -208,9 +208,8 @@ AcpiNsDumpOneDevice (
         }
 
         ACPI_DEBUG_PRINT_RAW ((ACPI_DB_TABLES,
-            "    HID: %s, ADR: %8.8X%8.8X, Status: %X\n",
-            Info->HardwareId.Value, ACPI_FORMAT_UINT64 (Info->Address),
-            Info->CurrentStatus));
+            "    HID: %s, ADR: %8.8X%8.8X\n",
+            Info->HardwareId.Value, ACPI_FORMAT_UINT64 (Info->Address)));
         ACPI_FREE (Info);
     }
 

--- a/source/components/namespace/nsxfname.c
+++ b/source/components/namespace/nsxfname.c
@@ -376,7 +376,7 @@ AcpiNsCopyDeviceId (
  *              namespace node and possibly by running several standard
  *              control methods (Such as in the case of a device.)
  *
- * For Device and Processor objects, run the Device _HID, _UID, _CID, _STA,
+ * For Device and Processor objects, run the Device _HID, _UID, _CID,
  * _CLS, _ADR, _SxW, and _SxD methods.
  *
  * Note: Allocates the return buffer, must be freed by the caller.
@@ -385,8 +385,9 @@ AcpiNsCopyDeviceId (
  * discovery namespace traversal. Therefore, no complex methods can be
  * executed, especially those that access operation regions. Therefore, do
  * not add any additional methods that could cause problems in this area.
- * this was the fate of the _SUB method which was found to cause such
- * problems and was removed (11/2015).
+ * Because of this reason support for the following methods has been removed:
+ * 1) _SUB method was removed (11/2015)
+ * 2) _STA method was removed (02/2018)
  *
  ******************************************************************************/
 
@@ -517,25 +518,12 @@ AcpiGetObjectInfo (
     {
         /*
          * Get extra info for ACPI Device/Processor objects only:
-         * Run the _STA, _ADR and, SxW, and _SxD methods.
+         * Run the _ADR and, SxW, and _SxD methods.
          *
          * Notes: none of these methods are required, so they may or may
          * not be present for this device. The Info->Valid bitfield is used
          * to indicate which methods were found and run successfully.
-         *
-         * For _STA, if the method does not exist, then (as per the ACPI
-         * specification), the returned CurrentStatus flags will indicate
-         * that the device is present/functional/enabled. Otherwise, the
-         * CurrentStatus flags reflect the value returned from _STA.
          */
-
-        /* Execute the Device._STA method */
-
-        Status = AcpiUtExecute_STA (Node, &Info->CurrentStatus);
-        if (ACPI_SUCCESS (Status))
-        {
-            Valid |= ACPI_VALID_STA;
-        }
 
         /* Execute the Device._ADR method */
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1388,7 +1388,6 @@ typedef struct acpi_device_info
     UINT8                           Flags;              /* Miscellaneous info */
     UINT8                           HighestDstates[4];  /* _SxD values: 0xFF indicates not valid */
     UINT8                           LowestDstates[5];   /* _SxW values: 0xFF indicates not valid */
-    UINT32                          CurrentStatus;      /* _STA value */
     UINT64                          Address;            /* _ADR value */
     ACPI_PNP_DEVICE_ID              HardwareId;         /* _HID value */
     ACPI_PNP_DEVICE_ID              UniqueId;           /* _UID value */
@@ -1403,7 +1402,6 @@ typedef struct acpi_device_info
 
 /* Flags for Valid field above (AcpiGetObjectInfo) */
 
-#define ACPI_VALID_STA                  0x0001
 #define ACPI_VALID_ADR                  0x0002
 #define ACPI_VALID_HID                  0x0004
 #define ACPI_VALID_UID                  0x0008


### PR DESCRIPTION
As the documentatuon above its declaration indicates, AcpiGetObjectInfo()
is intended for early probe usage and as such should not call any methods
which may rely on OpRegions, before this commit it was also calling _STA,
which on some systems does rely on OpRegions.

Calling _STA before things are ready leads to errors such as these
(under Linux, on some hardware):

[    0.123579] ACPI Error: No handler for Region [ECRM] (00000000ba9edc4c)
               [GenericSerialBus] (20170831/evregion-166)
[    0.123601] ACPI Error: Region GenericSerialBus (ID=9) has no handler
               (20170831/exfldio-299)
[    0.123618] ACPI Error: Method parse/execution failed
               \_SB.I2C1.BAT1._STA, AE_NOT_EXIST (20170831/psparse-550)

End 2015 support for the _SUB method was removed for exactly the same
reason. Removing CurrentStatus from ACPI_DEVICE_INFO only has a limited
impact. Within ACPICA it is only used by 2 debug messages, both
of which are modified to no longer print it with this commit.

Outside of ACPICA, there was one user in Linux, which has been patched to
no longer use CurrentStatus in Torvald's current master.

I've not checked if FreeBSD or others are using the CurrentStatus field.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>