### PR TITLE
macros: fix ACPI_ERROR_NAMESPACE macro

### DIFF
--- a/source/components/events/evgpeblk.c
+++ b/source/components/events/evgpeblk.c
@@ -591,10 +591,10 @@ AcpiEvInitializeGpeBlock (
     ACPI_GPE_EVENT_INFO     *GpeEventInfo;
     UINT32                  GpeEnabledCount;
     UINT32                  GpeIndex;
-    UINT32                  GpeNumber;
     UINT32                  i;
     UINT32                  j;
     BOOLEAN                 *IsPollingNeeded = Context;
+    ACPI_ERROR_ONLY (UINT32 GpeNumber);
 
 
     ACPI_FUNCTION_TRACE (EvInitializeGpeBlock);
@@ -624,7 +624,7 @@ AcpiEvInitializeGpeBlock (
 
             GpeIndex = (i * ACPI_GPE_REGISTER_WIDTH) + j;
             GpeEventInfo = &GpeBlock->EventInfo[GpeIndex];
-            GpeNumber = GpeBlock->BlockBaseNumber + GpeIndex;
+            ACPI_ERROR_ONLY(GpeNumber = GpeBlock->BlockBaseNumber + GpeIndex);
             GpeEventInfo->Flags |= ACPI_GPE_INITIALIZED;
 
             /*

--- a/source/components/parser/psobject.c
+++ b/source/components/parser/psobject.c
@@ -182,7 +182,7 @@ static ACPI_STATUS
 AcpiPsGetAmlOpcode (
     ACPI_WALK_STATE         *WalkState)
 {
-    UINT32                  AmlOffset;
+    ACPI_ERROR_ONLY (UINT32 AmlOffset);
 
 
     ACPI_FUNCTION_TRACE_PTR (PsGetAmlOpcode, WalkState);
@@ -217,8 +217,8 @@ AcpiPsGetAmlOpcode (
 
         if (WalkState->PassNumber == 2)
         {
-            AmlOffset = (UINT32) ACPI_PTR_DIFF (WalkState->Aml,
-                WalkState->ParserState.AmlStart);
+            ACPI_ERROR_ONLY(AmlOffset = (UINT32) ACPI_PTR_DIFF (WalkState->Aml,
+                WalkState->ParserState.AmlStart));
 
             ACPI_ERROR ((AE_INFO,
                 "Unknown opcode 0x%.2X at table offset 0x%.4X, ignoring",

--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -356,11 +356,11 @@ AcpiTbOverrideTable (
     ACPI_TABLE_DESC         *OldTableDesc)
 {
     ACPI_STATUS             Status;
-    char                    *OverrideType;
     ACPI_TABLE_DESC         NewTableDesc;
     ACPI_TABLE_HEADER       *Table;
     ACPI_PHYSICAL_ADDRESS   Address;
     UINT32                  Length;
+    ACPI_ERROR_ONLY (char   *OverrideType);
 
 
     /* (1) Attempt logical override (returns a logical address) */
@@ -370,7 +370,7 @@ AcpiTbOverrideTable (
     {
         AcpiTbAcquireTempTable (&NewTableDesc, ACPI_PTR_TO_PHYSADDR (Table),
             ACPI_TABLE_ORIGIN_EXTERNAL_VIRTUAL);
-        OverrideType = "Logical";
+        ACPI_ERROR_ONLY (OverrideType = "Logical");
         goto FinishOverride;
     }
 
@@ -382,7 +382,7 @@ AcpiTbOverrideTable (
     {
         AcpiTbAcquireTempTable (&NewTableDesc, Address,
             ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL);
-        OverrideType = "Physical";
+        ACPI_ERROR_ONLY (OverrideType = "Physical");
         goto FinishOverride;
     }
 

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -572,16 +572,18 @@
 #define ACPI_WARN_PREDEFINED(plist)         AcpiUtPredefinedWarning plist
 #define ACPI_INFO_PREDEFINED(plist)         AcpiUtPredefinedInfo plist
 #define ACPI_BIOS_ERROR_PREDEFINED(plist)   AcpiUtPredefinedBiosError plist
+#define ACPI_ERROR_ONLY(s)                  s
 
 #else
 
 /* No error messages */
 
-#define ACPI_ERROR_NAMESPACE(s, e)
+#define ACPI_ERROR_NAMESPACE(s, p, e)
 #define ACPI_ERROR_METHOD(s, n, p, e)
 #define ACPI_WARN_PREDEFINED(plist)
 #define ACPI_INFO_PREDEFINED(plist)
 #define ACPI_BIOS_ERROR_PREDEFINED(plist)
+#define ACPI_ERROR_ONLY(s)
 
 #endif /* ACPI_NO_ERROR_MESSAGES */
 


### PR DESCRIPTION
This fix also involves putting some ACPI_ERROR_NAMESPACE parameters inside
macros. By doing so, we avoid compilation errors from unused variables.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>