### PR TITLE
ASLTS: parallelize ASLTS acpiexec execution for speed

### DIFF
--- a/tests/aslts/bin/asltsrun
+++ b/tests/aslts/bin/asltsrun
@@ -63,6 +63,7 @@ cent_str_to_cent_units()
 	eval "rval=$[ (((1$1 - 100) * 60 + (1$2 - 100)) * 60 + (1$3 - 100)) * 100 + (1$4 - 100) ]"
 	echo "$rval"
 }
+export -f cent_str_to_cent_units
 
 # Convert {h:m:s} string to centisecond time units
 # arg1 - time string {h:m:s}
@@ -76,6 +77,7 @@ sec_str_to_cent_units()
 
 	echo "$rval"
 }
+export -f sec_str_to_cent_units
 
 # Return the length ot time period in centisecond time units
 # Note: assumed the total running time is less than 24 hours
@@ -96,6 +98,7 @@ get_cent_units_diff()
 
 	echo "$rval"
 }
+export -f get_cent_units_diff
 
 # Calculate and return the length ot time period as string {[h:]m:s.c}
 # arg1 - start time string {h:m:s}
@@ -111,6 +114,7 @@ get_cent_str_diff()
 
 	echo "$rval"
 }
+export -f get_cent_str_diff
 
 # Get version of AcpiExec
 get_acpiexec_version()
@@ -138,6 +142,7 @@ get_aml_code_path()
 	path="$ASLTSDIR/tmp/aml/$EXECVERSION/$OPTMODE/$BITMODE/$1.aml"
 	echo "$path"
 }
+export -f get_aml_code_path
 
 # Run particular test case
 # arg1 - the name of test case
@@ -154,6 +159,13 @@ run_test_case()
 	OPTMODE=`get_mode_string $2 3`
 
 	TEST_TITLE="$tcase $modename"
+
+	amlcodepath=`get_aml_code_path $1 $2`
+	if [ ! -f "$amlcodepath" ]; then
+		echo "Test doesn't exist: $amlcodepath"
+		AML_DONT_EXIST=$[ $AML_DONT_EXIST + 1 ]
+		return
+	fi
 
 	# Start time
 
@@ -215,6 +227,7 @@ run_test_case()
 
 	return $TEST_RET
 }
+export -f run_test_case
 
 # Run a set of test cases (specified by INIT_SET_OF_TEST_CASES)
 # in one particular mode.
@@ -224,6 +237,10 @@ run_test_case()
 run_set_of_test_cases()
 {
 	local x y z q status=0 total modepart modename tcase amlcodepath
+	test_case_arr=($3)
+	res_dir=$2
+	bit_mode=$1
+	procs=`nproc --all`
 
 	modepart=`get_mode_string $1 0`
 	modename=`get_mode_string $1 1`
@@ -235,36 +252,16 @@ run_set_of_test_cases()
 
 	total="$x $y"
 
-	for tcase in $3; do
-		amlcodepath=`get_aml_code_path $tcase $1`
-		if [ ! -f "$amlcodepath" ]; then
-			echo "Test doesn't exist: $amlcodepath"
-			AML_DONT_EXIST=$[ $AML_DONT_EXIST + 1 ]
-		else
-			if [ $ENABLELOG != 0 ]; then
-				run_test_case $tcase $1 > "$2/$modepart/$tcase"
-			else
-				run_test_case $tcase $1
-			fi
-			# See comment below.
-			# if [ $? -ne 0 ]; then
-			#	status=1
-			# fi
-		fi
-	done
+	# Explanation of command below:
+	# For each testcase that we will run, we are goin to parallelize the
+	# execution with the number of available processors.
+	printf '%s\n' "${test_case_arr[@]}" |\
+	xargs -n 1 -P $procs -I {} bash -c 'run_test_case $1 $2 > $3/$4/$1'\
+	_ {} $bit_mode $res_dir $modepart
 
 	z=$(date +%T)
 	q=`get_cent_str_diff $y $z`
 
-	# AcpiExec doesn't provide status of test execution,
-	# so dont report STATUS of AcpiExec execution here
-	# not to mislead as if it means STATUS of the tests
-	# execution.
-	# if [ $status == 0 ]; then
-	#	status=PASS
-	# else
-	#	status=FAIL
-	# fi
 	x="$(date +%F)"
 	multi_log "$modename finished $x $z, ($q)"
 
@@ -930,7 +927,7 @@ AML_DONT_EXIST=0
 DO_INNER_MODES_COMPARE=no
 
 MULTIPATH=
-EXECVERSION=
+export EXECVERSION=
 COMMONLOGFILE=
 MODES_TIMES=
 MODES_SUMMARIES=

--- a/tests/aslts/bin/common
+++ b/tests/aslts/bin/common
@@ -137,6 +137,7 @@ get_mode_string()
 		echo "$OPTMODE"
 	fi
 }
+export -f get_mode_string
 
 # Return string describing mode of run
 # arg1 - bitmap of mode
@@ -574,6 +575,7 @@ cent_units_to_cent_str()
 
 	echo "$rval"
 }
+export -f cent_units_to_cent_str
 
 # Convert time to centisecond units
 #
@@ -679,8 +681,8 @@ diff_of_str_times()
 # Constants
 
 # Bitmap: 1 - 64, 2 - opt
-FLAG64=1
-FLAGOPT=2
+export FLAG64=1
+export FLAGOPT=2
 NORM32=0
 NORM64=1
 OPT32=2


### PR DESCRIPTION
This change adds parallelization of ASLTS execution via xargs. This
results in a performance gain of 2.3x (14m 22sec to 6m 7sec).
Various functions and variables are exported so that they can be used
in each run_test_case execution.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>