### PR TITLE
Events: add a return on failure from AcpiHwRegisterRead

### DIFF
--- a/source/components/events/evevent.c
+++ b/source/components/events/evevent.c
@@ -344,6 +344,7 @@ AcpiEvFixedEventDetect (
     UINT32                  FixedStatus;
     UINT32                  FixedEnable;
     UINT32                  i;
+    ACPI_STATUS             Status;
 
 
     ACPI_FUNCTION_NAME (EvFixedEventDetect);
@@ -353,8 +354,12 @@ AcpiEvFixedEventDetect (
      * Read the fixed feature status and enable registers, as all the cases
      * depend on their values. Ignore errors here.
      */
-    (void) AcpiHwRegisterRead (ACPI_REGISTER_PM1_STATUS, &FixedStatus);
-    (void) AcpiHwRegisterRead (ACPI_REGISTER_PM1_ENABLE, &FixedEnable);
+    Status = AcpiHwRegisterRead (ACPI_REGISTER_PM1_STATUS, &FixedStatus);
+    Status |= AcpiHwRegisterRead (ACPI_REGISTER_PM1_ENABLE, &FixedEnable);
+    if (ACPI_FAILURE (Status))
+    {
+        return (IntStatus);
+    }
 
     ACPI_DEBUG_PRINT ((ACPI_DB_INTERRUPTS,
         "Fixed Event Block: Enable %08X Status %08X\n",


### PR DESCRIPTION
This ensures that AcpiEvFixedEventDetect does not use FixedStatus and
and FixedEnable as uninitialized variables.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>