### PR TITLE
acpisrc: restore check to avoid segfault on modes other than -l

### DIFF
--- a/source/tools/acpisrc/asfile.c
+++ b/source/tools/acpisrc/asfile.c
@@ -638,7 +638,10 @@ AsConvertFile (
         }
     }
 
-    AsReplaceHeader (FileBuffer, ConversionTable->NewHeader);
+    if (ConversionTable->NewHeader)
+    {
+        AsReplaceHeader (FileBuffer, ConversionTable->NewHeader);
+    }
     if (SpdxHeader)
     {
         AsDoSpdxHeader (FileBuffer, SpdxHeader);


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>