### PR TITLE
Modify hex AML C header file generation

### DIFF
--- a/source/common/adfile.c
+++ b/source/common/adfile.c
@@ -347,11 +347,16 @@ FlGenerateFilename (
  *
  * FUNCTION:    FlStrdup
  *
- * DESCRIPTION: Local strdup function
+ * PARAMETERS:  String              - Source string to duplicate.
+ *
+ * RETURN:      New string cloned from the source string.
+ *
+ * DESCRIPTION: Generate a new string which is a clone of the
+ *              source string. Similar to strdup function.
  *
  ******************************************************************************/
 
-static char *
+char *
 FlStrdup (
     char                *String)
 {

--- a/source/include/acapps.h
+++ b/source/include/acapps.h
@@ -318,6 +318,10 @@ FlGenerateFilename (
     char                    *InputFilename,
     char                    *Suffix);
 
+char *
+FlStrdup (
+    char                *String);
+
 ACPI_STATUS
 FlSplitInputPathname (
     char                    *InputPath,


### PR DESCRIPTION
The iAsl compiler provides a list of options to support
'Firmware Support - C Text Output'.

The '-tc' option supports generation of AML hex tables
in C. Previously the output resembled:
           unsigned char AmlCode[] = {
               /* HEX AML data */
               ...
               };

However, this output did not change the name of the
generated character array (AmlCode) in the output hex file.
This limits the ability to reference more than one table from
the firmware code.

Also, the generated output does not have header file include
guards. This is desirable if the hex file is to be included
from a C source file.

A solution to this is to modify the Hex C output such that
the name of the array is derived from the input file name,
and to add header file include guards.

To address the above, the output generated by the '-tc' option
is modified as below:

1. Use the input file name as a prefix for the generated
   C array name.
   e.g. 'unsigned char dsdt_AmlCode[]'

2. Add a header file include guard.
   e.g.
        #ifndef DSDT_HEX_
        #define DSDT_HEX_
        ...

        unsigned char dsdt_AmlCode[] = {
            /* HEX AML data */
            ...
        };

        #endif /* DSDT_HEX_ */

  Where Dsdt.asl is the input file name.

  Note: The header file include guard uses '<InputFileName>_HEX_'
        format instead of '<InputFileName>_H_' to avoid possible
        collision with an existing header guard.

Signed-off-by: Sami Mujawar <sami.mujawar@arm.com>
Signed-off-by: Evan Lloyd <evan.lloyd@arm.com>