### PR TITLE
Tables: Fix spelling mistake in comment

### DIFF
--- a/source/components/tables/tbinstal.c
+++ b/source/components/tables/tbinstal.c
@@ -236,7 +236,7 @@ AcpiTbInstallTableWithOverride (
  * DESCRIPTION: This function is called to verify and install an ACPI table.
  *              When this function is called by "Load" or "LoadTable" opcodes,
  *              or by AcpiLoadTable() API, the "Reload" parameter is set.
- *              After sucessfully returning from this function, table is
+ *              After successfully returning from this function, table is
  *              "INSTALLED" but not "VALIDATED".
  *
  ******************************************************************************/


### PR DESCRIPTION
The spelling of "sucessfully" should be "successfully", fix this

Signed-off-by: Colin Ian King <colin.king@canonical.com>