### PR TITLE
Fix potential infinite loop in AcpiRsDumpByteList

### DIFF
--- a/source/components/resources/rsdump.c
+++ b/source/components/resources/rsdump.c
@@ -768,7 +768,7 @@ AcpiRsDumpByteList (
     UINT16                  Length,
     UINT8                   *Data)
 {
-    UINT8                   i;
+    UINT16                  i;
 
 
     for (i = 0; i < Length; i++)


### PR DESCRIPTION
There is a potential infinite loop if AcpiRsDumpByteList is
called with a Length greater than 255 since the current loop
counter is just a UINT8 and will wrap to zero and never reach
the desired value in Length.  Fix this by making the loop
counter the size type as Length.

Signed-off-by: Colin Ian King <colin.king@canonical.com>