### PR TITLE
iASL: add a check for some definition block parameters for compliance

### DIFF
--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -354,7 +354,9 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_FOUND_HERE */                 "Original name creation/declaration below: ",
 /*    ASL_MSG_ILLEGAL_RECURSION */          "Illegal recursive call to method that creates named objects",
 /*    ASL_MSG_EXTERN_COLLISION */           "A name cannot be defined and declared external in the same table",
-/*    ASL_MSG_FOUND_HERE_EXTERN*/           "Remove one of the declarations indicated above or below:"
+/*    ASL_MSG_FOUND_HERE_EXTERN */          "Remove one of the declarations indicated above or below:",
+/*    ASL_MSG_TABLE_OEM_ID */               "Invalid OEM table ID",
+/*    ASL_MSG_OEM_ID */                     "Invalid OEM ID"
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -357,6 +357,8 @@ typedef enum
     ASL_MSG_ILLEGAL_RECURSION,
     ASL_MSG_EXTERN_COLLISION,
     ASL_MSG_EXTERN_FOUND_HERE,
+    ASL_MSG_TABLE_OEM_ID,
+    ASL_MSG_OEM_ID,
 
     /* These messages are used by the Data Table compiler only */
 

--- a/source/compiler/asloperands.c
+++ b/source/compiler/asloperands.c
@@ -1078,6 +1078,7 @@ OpnDoDefinitionBlock (
 
     Child = Child->Asl.Next;
     Child->Asl.ParseOpcode = PARSEOP_DEFAULT_ARG;
+
     /*
      * We used the revision to set the integer width earlier
      */
@@ -1086,6 +1087,12 @@ OpnDoDefinitionBlock (
 
     Child = Child->Asl.Next;
     Child->Asl.ParseOpcode = PARSEOP_DEFAULT_ARG;
+    if (Child->Asl.Value.String &&
+        strlen (Child->Asl.Value.String) > ACPI_OEM_ID_SIZE)
+    {
+        AslError (ASL_ERROR, ASL_MSG_OEM_ID, Child,
+            "Length should be at most 6");
+    }
 
     /* OEM TableID */
 
@@ -1094,6 +1101,12 @@ OpnDoDefinitionBlock (
     if (Child->Asl.Value.String)
     {
         Length = strlen (Child->Asl.Value.String);
+        if (Length > ACPI_OEM_TABLE_ID_SIZE)
+        {
+            AslError (ASL_ERROR, ASL_MSG_TABLE_OEM_ID, Child,
+                "Length should be at most 8");
+        }
+
         Gbl_TableId = UtLocalCacheCalloc (Length + 1);
         strcpy (Gbl_TableId, Child->Asl.Value.String);
 


### PR DESCRIPTION
This commit addds a check during the compilation of a definition
block. It ensures that OEM table ID is at most 8 characters and the
OEM ID is at most 6 characters.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>