### PR TITLE
acpidump and acpixtract should handle table sizes greater than 1MB

### DIFF
--- a/source/components/utilities/utbuffer.c
+++ b/source/components/utilities/utbuffer.c
@@ -205,7 +205,7 @@ AcpiUtDumpBuffer (
     {
         /* Print current offset */
 
-        AcpiOsPrintf ("%6.4X: ", (BaseOffset + i));
+        AcpiOsPrintf ("%7.4X: ", (BaseOffset + i));
 
         /* Print 16 hex chars */
 
@@ -387,7 +387,7 @@ AcpiUtDumpBufferToFile (
     {
         /* Print current offset */
 
-        fprintf (File, "%6.4X: ", (BaseOffset + i));
+        fprintf (File, "%7.4X: ", (BaseOffset + i));
 
         /* Print 16 hex chars */
 


### PR DESCRIPTION
There is a bug in the interaction of acpidump and acpixtract when the table
size is greater than 1MB. The acpixtract code will stop parsing a table if
the first character on a line is not a space (' '). The acpidump code will
overflow the offset into the first character after 1MB. 

This patch is developed in illumos.