### PR TITLE
AML parser: attempt to continue loading table after error

### DIFF
--- a/source/components/parser/psobject.c
+++ b/source/components/parser/psobject.c
@@ -154,6 +154,7 @@
 #include "acparser.h"
 #include "amlcode.h"
 #include "acconvert.h"
+#include "acnamesp.h"
 
 #define _COMPONENT          ACPI_PARSER
         ACPI_MODULE_NAME    ("psobject")
@@ -722,6 +723,20 @@ AcpiPsCompleteOp (
         {
             if (*Op)
             {
+                /*
+                 * These Opcodes need to be removed from the namespace because they
+                 * get created even if these opcodes cannot be created due to
+                 * errors.
+                 */
+                if (((*Op)->Common.AmlOpcode == AML_REGION_OP) ||
+                    ((*Op)->Common.AmlOpcode == AML_DATA_REGION_OP))
+                {
+                    AcpiNsDeleteChildren ((*Op)->Common.Node);
+                    AcpiNsRemoveNode ((*Op)->Common.Node);
+                    (*Op)->Common.Node = NULL;
+                    AcpiPsDeleteParseTree (*Op);
+                }
+
                 Status2 = AcpiPsCompleteThisOp (WalkState, *Op);
                 if (ACPI_FAILURE (Status2))
                 {
@@ -747,6 +762,20 @@ AcpiPsCompleteOp (
 #endif
         WalkState->PrevOp = NULL;
         WalkState->PrevArgTypes = WalkState->ArgTypes;
+
+        if (WalkState->ParseFlags & ACPI_PARSE_MODULE_LEVEL)
+        {
+            /*
+             * There was something that went wrong while executing code at the
+             * module-level. We need to skip parsing whatever caused the
+             * error and keep going. One runtime error during the table load
+             * should not cause the entire table to not be loaded. This is
+             * because there could be correct AML beyond the parts that caused
+             * the runtime error.
+             */
+            ACPI_ERROR ((AE_INFO, "Ignore error and continue table load"));
+            return_ACPI_STATUS (AE_OK);
+        }
         return_ACPI_STATUS (Status);
     }
 

--- a/source/components/utilities/uterror.c
+++ b/source/components/utilities/uterror.c
@@ -352,20 +352,20 @@ AcpiUtPrefixedNamespaceError (
     {
     case AE_ALREADY_EXISTS:
 
-        AcpiOsPrintf (ACPI_MSG_BIOS_ERROR);
+        AcpiOsPrintf ("\n" ACPI_MSG_BIOS_ERROR);
         Message = "Failure creating";
         break;
 
     case AE_NOT_FOUND:
 
-        AcpiOsPrintf (ACPI_MSG_BIOS_ERROR);
-        Message = "Failure looking up";
+        AcpiOsPrintf ("\n" ACPI_MSG_BIOS_ERROR);
+        Message = "Could not resolve";
         break;
 
     default:
 
-        AcpiOsPrintf (ACPI_MSG_ERROR);
-        Message = "Failure looking up";
+        AcpiOsPrintf ("\n" ACPI_MSG_ERROR);
+        Message = "Failure resolving";
         break;
     }
 


### PR DESCRIPTION
This change alters the parser so that the table load does not abort
upon an error.

Notable changes:

If there is an error while parsing an element of the termlist, we
will skip parsing the current termlist element and continue parsing
to the next opcode in the termlist.

If we get an error while parsing the conditional of If/Else/While or
the device name of Scope, we will skip the body of the statement all
together.

If we get an error while parsing the base offset and length of an
operation region declaration, we will remove the operation region
from the namespace.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>