### PR TITLE
iASL: increase the length of MsgBuffer to avoid overflow

### DIFF
--- a/source/common/dmextern.c
+++ b/source/common/dmextern.c
@@ -538,7 +538,7 @@ AcpiDmGetExternalsFromFile (
 
     /* Each line defines a method */
 
-    while (fgets (StringBuffer, ASL_MSG_BUFFER_SIZE, ExternalRefFile))
+    while (fgets (StringBuffer, ASL_STRING_BUFFER_SIZE, ExternalRefFile))
     {
         Token = strtok (StringBuffer, METHOD_SEPARATORS);   /* "External" */
         if (!Token)

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -251,7 +251,8 @@ extern int                  AslCompilerdebug;
 
 
 #define ASL_DEFAULT_LINE_BUFFER_SIZE    (1024 * 32) /* 32K */
-#define ASL_MSG_BUFFER_SIZE             (1024 * 32) /* 32k */
+#define ASL_MSG_BUFFER_SIZE             (1024 * 128) /* 128k */
+#define ASL_STRING_BUFFER_SIZE          (1024 * 32) /* 32k */
 #define ASL_MAX_DISABLED_MESSAGES       32
 #define ASL_MAX_EXPECTED_MESSAGES       32
 #define HEX_TABLE_LINE_SIZE             8
@@ -438,8 +439,8 @@ ASL_EXTERN UINT8                    AslGbl_NamespaceEvent;
 
 ASL_EXTERN UINT8                    Gbl_AmlBuffer[HEX_LISTING_LINE_SIZE];
 ASL_EXTERN char                     MsgBuffer[ASL_MSG_BUFFER_SIZE];
-ASL_EXTERN char                     StringBuffer[ASL_MSG_BUFFER_SIZE];
-ASL_EXTERN char                     StringBuffer2[ASL_MSG_BUFFER_SIZE];
+ASL_EXTERN char                     StringBuffer[ASL_STRING_BUFFER_SIZE];
+ASL_EXTERN char                     StringBuffer2[ASL_STRING_BUFFER_SIZE];
 ASL_EXTERN UINT32                   Gbl_DisabledMessages[ASL_MAX_DISABLED_MESSAGES];
 ASL_EXTERN ASL_EXPECTED_MESSAGE     Gbl_ExpectedMessages[ASL_MAX_EXPECTED_MESSAGES];
 

--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -1080,7 +1080,7 @@ AslDoResponseFile (
      * Process all lines in the response file. There must be one complete
      * option per line
      */
-    while (fgets (StringBuffer, ASL_MSG_BUFFER_SIZE, ResponseFile))
+    while (fgets (StringBuffer, ASL_STRING_BUFFER_SIZE, ResponseFile))
     {
         /* Compress all tokens, allowing us to use a single argv entry */
 


### PR DESCRIPTION
There are some functions that attempt to store 2 String buffers in
MsgBuffer. This causes compiler warnings due to potential overflow
of MsgBuffer.

By increasing the MsgBuffer, we retain current behavior for functions
using StringBuffer. This also results in separating the size between
MsgBuffer and StringBuffer.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>