### PR TITLE
AcpiExec: fixing -fi option

### DIFF
--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -157,6 +157,10 @@
 #include "acnamesp.h"
 #include "acparser.h"
 
+#ifdef ACPI_EXEC_APP
+#include "aecommon.h"
+#endif
+
 
 #define _COMPONENT          ACPI_DISPATCHER
         ACPI_MODULE_NAME    ("dsfield")
@@ -430,6 +434,13 @@ AcpiDsGetFieldNames (
     UINT64                  Position;
     ACPI_PARSE_OBJECT       *Child;
 
+#ifdef ACPI_EXEC_APP
+    UINT64                  Value = 0;
+    ACPI_OPERAND_OBJECT     *ResultDesc;
+    ACPI_OPERAND_OBJECT     *ObjDesc;
+    char                    *NamePath;
+#endif
+
 
     ACPI_FUNCTION_TRACE_PTR (DsGetFieldNames, Info);
 
@@ -564,6 +575,18 @@ AcpiDsGetFieldNames (
                     {
                         return_ACPI_STATUS (Status);
                     }
+#ifdef ACPI_EXEC_APP
+                    NamePath = AcpiNsGetExternalPathname (Info->FieldNode);
+                    ObjDesc = AcpiUtCreateIntegerObject (Value);
+                    if (ACPI_SUCCESS(AeLookupInitFileEntry (NamePath, &Value)))
+                    {
+                        AcpiExWriteDataToField (ObjDesc,
+                            AcpiNsGetAttachedObject (Info->FieldNode),
+                            &ResultDesc);
+                        ACPI_FREE (NamePath);
+                        AcpiUtRemoveReference (ObjDesc);
+                    }
+#endif
                 }
             }
 
@@ -756,6 +779,9 @@ AcpiDsInitFieldObjects (
         Flags |= ACPI_NS_TEMPORARY;
     }
 
+#ifdef ACPI_EXEC_APP
+        Flags |= ACPI_NS_OVERRIDE_IF_FOUND;
+#endif
     /*
      * Walk the list of entries in the FieldList
      * Note: FieldList can be of zero length. In this case, Arg will be NULL.

--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -724,6 +724,15 @@ AcpiNsLookup (
                     CurrentNode));
             }
 
+#ifdef ACPI_EXEC_APP
+            if ((Status == AE_ALREADY_EXISTS) &&
+                (ThisNode->Flags & ANOBJ_NODE_EARLY_INIT))
+            {
+                ThisNode->Flags &= ~ANOBJ_NODE_EARLY_INIT;
+                Status = AE_OK;
+            }
+#endif
+
 #ifdef ACPI_ASL_COMPILER
             /*
              * If this ACPI name already exists within the namespace as an
@@ -844,6 +853,13 @@ AcpiNsLookup (
             }
         }
     }
+
+#ifdef ACPI_EXEC_APP
+    if (Flags & ACPI_NS_EARLY_INIT)
+    {
+        ThisNode->Flags |= ANOBJ_NODE_EARLY_INIT;
+    }
+#endif
 
     *ReturnNode = ThisNode;
     return_ACPI_STATUS (AE_OK);

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -327,6 +327,7 @@ typedef struct acpi_namespace_node
 #define ANOBJ_SUBTREE_HAS_INI           0x10    /* Used to optimize device initialization */
 #define ANOBJ_EVALUATED                 0x20    /* Set on first evaluation of node */
 #define ANOBJ_ALLOCATED_BUFFER          0x40    /* Method AML buffer is dynamic (InstallMethod) */
+#define ANOBJ_NODE_EARLY_INIT           0x80    /* AcpiExec only: Node was create via init file (-fi) */
 
 #define ANOBJ_IS_EXTERNAL               0x08    /* iASL only: This object created via External() */
 #define ANOBJ_METHOD_NO_RETVAL          0x10    /* iASL only: Method has no return value */

--- a/source/include/acnamesp.h
+++ b/source/include/acnamesp.h
@@ -168,14 +168,15 @@
 /* Flags for AcpiNsLookup, AcpiNsSearchAndEnter */
 
 #define ACPI_NS_NO_UPSEARCH         0
-#define ACPI_NS_SEARCH_PARENT       0x01
-#define ACPI_NS_DONT_OPEN_SCOPE     0x02
-#define ACPI_NS_NO_PEER_SEARCH      0x04
-#define ACPI_NS_ERROR_IF_FOUND      0x08
-#define ACPI_NS_PREFIX_IS_SCOPE     0x10
-#define ACPI_NS_EXTERNAL            0x20
-#define ACPI_NS_TEMPORARY           0x40
-#define ACPI_NS_OVERRIDE_IF_FOUND   0x80
+#define ACPI_NS_SEARCH_PARENT       0x0001
+#define ACPI_NS_DONT_OPEN_SCOPE     0x0002
+#define ACPI_NS_NO_PEER_SEARCH      0x0004
+#define ACPI_NS_ERROR_IF_FOUND      0x0008
+#define ACPI_NS_PREFIX_IS_SCOPE     0x0010
+#define ACPI_NS_EXTERNAL            0x0020
+#define ACPI_NS_TEMPORARY           0x0040
+#define ACPI_NS_OVERRIDE_IF_FOUND   0x0080
+#define ACPI_NS_EARLY_INIT          0x0100
 
 /* Flags for AcpiNsWalkNamespace */
 

--- a/source/tools/acpiexec/aecommon.h
+++ b/source/tools/acpiexec/aecommon.h
@@ -189,11 +189,22 @@ typedef struct ae_debug_regions
 } AE_DEBUG_REGIONS;
 
 
+/*
+ * Init file entry
+ */
+typedef struct init_file_entry
+{
+    char                    *Name;
+    UINT64                  Value;
+} INIT_FILE_ENTRY;
+
 extern BOOLEAN              AcpiGbl_UseLocalFaultHandler;
 extern BOOLEAN              AcpiGbl_VerboseHandlers;
 extern BOOLEAN              AcpiGbl_IgnoreErrors;
 extern BOOLEAN              AcpiGbl_AbortLoopOnTimeout;
 extern UINT8                AcpiGbl_RegionFillValue;
+extern INIT_FILE_ENTRY      *AcpiGbl_InitEntries;
+extern UINT32               AcpiGbl_InitFileLineCount;
 extern UINT8                AcpiGbl_UseHwReducedFadt;
 extern BOOLEAN              AcpiGbl_DisplayRegionAccess;
 extern BOOLEAN              AcpiGbl_DoInterfaceTests;
@@ -331,12 +342,17 @@ AeOpenInitializationFile (
     char                    *Filename);
 
 void
-AeDoObjectOverrides (
+AeProcessInitFile (
     void);
 
 ACPI_STATUS
 AeSetupConfiguration (
     void                    *RegionAddr);
+
+ACPI_STATUS
+AeLookupInitFileEntry (
+    char                    *Pathname,
+    UINT64                  *Value);
 
 /* aeexec */
 

--- a/source/tools/acpiexec/aeinitfile.c
+++ b/source/tools/acpiexec/aeinitfile.c
@@ -159,10 +159,8 @@
 /* Local prototypes */
 
 static void
-AeDoOneOverride (
-    char                    *Pathname,
-    char                    *ValueString,
-    ACPI_OPERAND_OBJECT     *ObjDesc,
+AeEnterInitFileEntry (
+    INIT_FILE_ENTRY         InitEntry,
     ACPI_WALK_STATE         *WalkState);
 
 
@@ -206,13 +204,15 @@ AeOpenInitializationFile (
 
 /******************************************************************************
  *
- * FUNCTION:    AeDoObjectOverrides
+ * FUNCTION:    AeProcessInitFile
  *
  * PARAMETERS:  None
  *
  * RETURN:      None
  *
- * DESCRIPTION: Read the initialization file and perform all overrides
+ * DESCRIPTION: Read the initialization file and perform all namespace
+ *              initializations. AcpiGbl_InitEntries will be used for region
+ *              field initialization.
  *
  * NOTE:        The format of the file is multiple lines, each of format:
  *                  <ACPI-pathname> <Integer Value>
@@ -220,12 +220,15 @@ AeOpenInitializationFile (
  *****************************************************************************/
 
 void
-AeDoObjectOverrides (
+AeProcessInitFile(
     void)
 {
-    ACPI_OPERAND_OBJECT     *ObjDesc;
     ACPI_WALK_STATE         *WalkState;
     int                     i;
+    char                    *TempBuffer = NULL;
+    UINT64                  TempInt = 0;
+    UINT64                  idx;
+    ACPI_STATUS             Status;
 
 
     if (!InitFile)
@@ -235,13 +238,19 @@ AeDoObjectOverrides (
 
     /* Create needed objects to be reused for each init entry */
 
-    ObjDesc = AcpiUtCreateIntegerObject (0);
     WalkState = AcpiDsCreateWalkState (0, NULL, NULL, NULL);
     NameBuffer[0] = '\\';
 
-    /* Read the entire file line-by-line */
+    while (getline (&TempBuffer, &TempInt, InitFile) != -1)
+    {
+        ++AcpiGbl_InitFileLineCount;
+    }
+    AcpiOsFree (TempBuffer);
+    rewind (InitFile);
 
-    while (fgets (LineBuffer, AE_FILE_BUFFER_SIZE, InitFile) != NULL)
+    AcpiGbl_InitEntries =
+        AcpiOsAllocate (sizeof (INIT_FILE_ENTRY) * AcpiGbl_InitFileLineCount);
+    for (idx = 0; fgets (LineBuffer, AE_FILE_BUFFER_SIZE, InitFile); ++idx)
     {
         if (sscanf (LineBuffer, "%s %s\n",
                 &NameBuffer[1], ValueBuffer) != 2)
@@ -257,7 +266,20 @@ AeDoObjectOverrides (
             i = 1;
         }
 
-        AeDoOneOverride (&NameBuffer[i], ValueBuffer, ObjDesc, WalkState);
+        AcpiGbl_InitEntries[idx].Name =
+            AcpiOsAllocateZeroed (strnlen (NameBuffer + i, AE_FILE_BUFFER_SIZE) + 1);
+
+        strcpy (AcpiGbl_InitEntries[idx].Name, NameBuffer + i);
+
+        Status = AcpiUtStrtoul64 (ValueBuffer, &AcpiGbl_InitEntries[idx].Value);
+        if (ACPI_FAILURE (Status))
+        {
+            AcpiOsPrintf ("%s %s\n", ValueBuffer,
+                AcpiFormatException (Status));
+            return;
+        }
+
+        AeEnterInitFileEntry (AcpiGbl_InitEntries[idx], WalkState);
     }
 
     /* Cleanup */
@@ -265,77 +287,97 @@ AeDoObjectOverrides (
 CleanupAndExit:
     fclose (InitFile);
     AcpiDsDeleteWalkState (WalkState);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AeInitFileEntry
+ *
+ * PARAMETERS:  InitEntry           - Entry of the init file
+ *              WalkState           - Used for the Store operation
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Perform initialization of a single namespace object
+ *
+ *              Note: namespace of objects are limited to integers and region
+ *              fields units of 8 bytes at this time.
+ *
+ *****************************************************************************/
+
+static void
+AeEnterInitFileEntry (
+    INIT_FILE_ENTRY         InitEntry,
+    ACPI_WALK_STATE         *WalkState)
+{
+    char                    *Pathname = InitEntry.Name;
+    UINT64                  Value = InitEntry.Value;
+    ACPI_OPERAND_OBJECT     *ObjDesc;
+    ACPI_NAMESPACE_NODE     *NewNode;
+    ACPI_STATUS             Status;
+
+
+    AcpiOsPrintf ("Initializing namespace element: %s\n", Pathname);
+    Status = AcpiNsLookup (NULL, Pathname, ACPI_TYPE_INTEGER,
+        ACPI_IMODE_LOAD_PASS2, ACPI_NS_ERROR_IF_FOUND | ACPI_NS_NO_UPSEARCH |
+        ACPI_NS_EARLY_INIT, NULL, &NewNode);
+    if (ACPI_FAILURE (Status))
+    {
+        ACPI_EXCEPTION ((AE_INFO, Status,
+            "While creating name from namespace initialization file: %s",
+            Pathname));
+        return;
+    }
+
+    ObjDesc = AcpiUtCreateIntegerObject (Value);
+
+    AcpiOsPrintf ("New value: 0x%8.8X%8.8X\n",
+        ACPI_FORMAT_UINT64 (Value));
+
+    /* Store pointer to value descriptor in the Node */
+
+    Status = AcpiNsAttachObject (NewNode, ObjDesc,
+         ACPI_TYPE_INTEGER);
+
+    /* Remove local reference to the object */
+
     AcpiUtRemoveReference (ObjDesc);
 }
 
 
 /******************************************************************************
  *
- * FUNCTION:    AeDoOneOverride
+ * FUNCTION:    AeLookupInitFileEntry
  *
- * PARAMETERS:  Pathname            - AML namepath
- *              ValueString         - New integer value to be stored
- *              ObjDesc             - Descriptor with integer override value
- *              WalkState           - Used for the Store operation
+ * PARAMETERS:  Pathname            - AML namepath in external format
+ *              ValueString         - value of the namepath if it exitst
  *
  * RETURN:      None
  *
- * DESCRIPTION: Perform an override for a single namespace object
+ * DESCRIPTION: Search the init file for a particular name and its value.
  *
  *****************************************************************************/
 
-static void
-AeDoOneOverride (
+ACPI_STATUS
+AeLookupInitFileEntry (
     char                    *Pathname,
-    char                    *ValueString,
-    ACPI_OPERAND_OBJECT     *ObjDesc,
-    ACPI_WALK_STATE         *WalkState)
+    UINT64                  *Value)
 {
-    ACPI_HANDLE             Handle;
-    ACPI_STATUS             Status;
-    UINT64                  Value;
+    UINT32                  i;
 
-
-    AcpiOsPrintf ("Value Override: %s, ", Pathname);
-
-    /*
-     * Get the namespace node associated with the override
-     * pathname from the init file.
-     */
-    Status = AcpiGetHandle (NULL, Pathname, &Handle);
-    if (ACPI_FAILURE (Status))
+    if (!AcpiGbl_InitEntries)
     {
-        AcpiOsPrintf ("%s\n", AcpiFormatException (Status));
-        return;
+        return AE_NOT_FOUND;
     }
 
-    /* Extract the 64-bit integer */
-
-    Status = AcpiUtStrtoul64 (ValueString, &Value);
-    if (ACPI_FAILURE (Status))
+    for (i = 0; i < AcpiGbl_InitFileLineCount; ++i)
     {
-        AcpiOsPrintf ("%s %s\n", ValueString,
-            AcpiFormatException (Status));
-        return;
+        if (!strcmp(AcpiGbl_InitEntries[i].Name, Pathname))
+        {
+            *Value = AcpiGbl_InitEntries[i].Value;
+            return AE_OK;
+        }
     }
-
-    ObjDesc->Integer.Value = Value;
-
-    /*
-     * At the point this function is called, the namespace is fully
-     * built and initialized. We can simply store the new object to
-     * the target node.
-     */
-    AcpiExEnterInterpreter ();
-    Status = AcpiExStore (ObjDesc, Handle, WalkState);
-    AcpiExExitInterpreter ();
-
-    if (ACPI_FAILURE (Status))
-    {
-        AcpiOsPrintf ("%s\n", AcpiFormatException (Status));
-        return;
-    }
-
-    AcpiOsPrintf ("New value: 0x%8.8X%8.8X\n",
-        ACPI_FORMAT_UINT64 (Value));
+    return AE_NOT_FOUND;
 }

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -199,6 +199,8 @@ BOOLEAN                     AcpiGbl_LoadTestTables = FALSE;
 BOOLEAN                     AcpiGbl_AeLoadOnly = FALSE;
 static UINT8                AcpiGbl_ExecutionMode = AE_MODE_COMMAND_LOOP;
 static char                 BatchBuffer[AE_BUFFER_SIZE];    /* Batch command buffer */
+INIT_FILE_ENTRY             *AcpiGbl_InitEntries = NULL;
+UINT32                      AcpiGbl_InitFileLineCount = 0;
 
 #define ACPIEXEC_NAME               "AML Execution/Debug Utility"
 #define AE_SUPPORTED_OPTIONS        "?b:d:e:f^ghlm^rt^v^:x:"
@@ -677,6 +679,8 @@ main (
         signal (SIGSEGV, AeSignalHandler);
     }
 
+    AeProcessInitFile();
+
     /* The remaining arguments are filenames for ACPI tables */
 
     if (!argv[AcpiGbl_Optind])
@@ -785,12 +789,6 @@ main (
      */
     AeInstallLateHandlers ();
 
-    /*
-     * This call implements the "initialization file" option for AcpiExec.
-     * This is the precise point that we want to perform the overrides.
-     */
-    AeDoObjectOverrides ();
-
     /* Finish the ACPICA initialization */
 
     Status = AcpiInitializeObjects (InitFlags);
@@ -848,5 +846,6 @@ NormalExit:
 ErrorExit:
     (void) AcpiTerminate ();
     AcDeleteTableList (ListHead);
+    AcpiOsFree (AcpiGbl_InitEntries);
     return (ExitCode);
 }


### PR DESCRIPTION
Field elements listed in the init file used to be initialized after
the table load and before executing module-level code blocks. The
recent changes in module-level code means that the table load becomes
a method execution. If fields are used within module-level code and
we are executing with -fi option, then these values are populated
after the table has finished loading. This commit changes the
initialization of objects listed in the init file so that field unit
values are populated during the table load.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>