### PR TITLE
debugger: fix build warnings on set but not used variable NumStatements

### DIFF
--- a/source/components/debugger/dbmethod.c
+++ b/source/components/debugger/dbmethod.c
@@ -412,7 +412,9 @@ AcpiDbDisassembleAml (
     char                    *Statements,
     ACPI_PARSE_OBJECT       *Op)
 {
+#ifdef ACPI_DISASSEMBLER
     UINT32                  NumStatements = 8;
+#endif
 
 
     if (!Op)
@@ -421,12 +423,12 @@ AcpiDbDisassembleAml (
         return;
     }
 
+#ifdef ACPI_DISASSEMBLER
     if (Statements)
     {
         NumStatements = strtoul (Statements, NULL, 0);
     }
 
-#ifdef ACPI_DISASSEMBLER
     AcpiDmDisassemble (NULL, Op, NumStatements);
 #endif
 }


### PR DESCRIPTION
When building the Linux kernel integrated version of ACPICA with clang
we get warnings that NumStatements is set but not used. Fix this by
adding more #if guarding around this variable so that it is only
declared and set when it is being required.

Fixes Linux clang build warning:
warning: variable 'num_statements' set but not used [-Wunused-but-set-variable]

Signed-off-by: Colin Ian King <colin.king@canonical.com>