### PR TITLE
ACPICA: Clear status of all events when entering S5

### DIFF
--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -198,16 +198,27 @@ AcpiHwLegacySleep (
         return_ACPI_STATUS (Status);
     }
 
-    /*
-     * 1) Disable all GPEs
-     * 2) Enable all wakeup GPEs
-     */
+    /* Disable all GPEs */
+
     Status = AcpiHwDisableAllGpes ();
     if (ACPI_FAILURE (Status))
     {
         return_ACPI_STATUS (Status);
     }
+    /*
+     * If the target sleep state is S5, clear all GPEs and fixed events too
+     */
+    if (SleepState == ACPI_STATE_S5)
+    {
+        Status = AcpiHwClearAcpiStatus();
+        if (ACPI_FAILURE (Status))
+        {
+            return_ACPI_STATUS (Status);
+        }
+    }
     AcpiGbl_SystemAwakeAndRunning = FALSE;
+
+    /* Enable all wakeup GPEs */
 
     Status = AcpiHwEnableAllWakeupGpes ();
     if (ACPI_FAILURE (Status))


### PR DESCRIPTION
After commit 18996f2db918 (ACPICA: Events: Stop unconditionally
clearing ACPI IRQs during suspend/resume) the status of ACPI events
is not cleared any more when entering the ACPI S5 system state (power
off) which causes some systems to power up immediately after turing
off power in certain situations.

That is a functional regression, so address it by making the code
clear the status of all ACPI events again when entering S5 (for
system-wide suspend or hibernation the clearing of the status of all
events is not desirable, as it might cause the kernel to miss wakeup
events sometimes).

Fixes: 18996f2db918 (ACPICA: Events: Stop unconditionally clearing ACPI IRQs during suspend/resume)
Reported-by: Takashi Iwai <tiwai@suse.de>
Tested-by: Thomas Hänig <haenig@cosifan.de>
Cc: 4.17+ <stable@vger.kernel.org> # 4.17+
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>