### PR TITLE
ACPICA: Drop leading newlines from error messages

### DIFF
--- a/source/components/utilities/uterror.c
+++ b/source/components/utilities/uterror.c
@@ -352,19 +352,19 @@ AcpiUtPrefixedNamespaceError (
     {
     case AE_ALREADY_EXISTS:
 
-        AcpiOsPrintf ("\n" ACPI_MSG_BIOS_ERROR);
+        AcpiOsPrintf (ACPI_MSG_BIOS_ERROR);
         Message = "Failure creating";
         break;
 
     case AE_NOT_FOUND:
 
-        AcpiOsPrintf ("\n" ACPI_MSG_BIOS_ERROR);
+        AcpiOsPrintf (ACPI_MSG_BIOS_ERROR);
         Message = "Could not resolve";
         break;
 
     default:
 
-        AcpiOsPrintf ("\n" ACPI_MSG_ERROR);
+        AcpiOsPrintf (ACPI_MSG_ERROR);
         Message = "Failure resolving";
         break;
     }


### PR DESCRIPTION
Commit 5088814a6e93 (ACPICA: AML parser: attempt to continue loading table
after error) unintentionally added leading newlines to error messages emitted by
ACPICA which caused unexpected things to be printed to the kernel log.  Drop
these newlines (which effectively reverts the part of commit 5088814a6e93
adding them).

Fixes: 5088814a6e93 (ACPICA: AML parser: attempt to continue loading table
after error)
Reported-by: Toralf Förster <toralf.foerster@gmx.de>
Reported-by: Guenter Roeck <linux@roeck-us.net>
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>