### PR TITLE
ACPICA: add status check for AcpiHwRead before assigning return value

### DIFF
--- a/source/components/hardware/hwregs.c
+++ b/source/components/hardware/hwregs.c
@@ -724,13 +724,20 @@ AcpiHwRegisterRead (
     case ACPI_REGISTER_PM2_CONTROL:          /* 8-bit access */
 
         Status = AcpiHwRead (&Value64, &AcpiGbl_FADT.XPm2ControlBlock);
-        Value = (UINT32) Value64;
+        if (ACPI_SUCCESS (Status))
+        {
+            Value = (UINT32) Value64;
+        }
         break;
 
     case ACPI_REGISTER_PM_TIMER:             /* 32-bit access */
 
         Status = AcpiHwRead (&Value64, &AcpiGbl_FADT.XPmTimerBlock);
-        Value = (UINT32) Value64;
+        if (ACPI_SUCCESS (Status))
+        {
+            Value = (UINT32) Value64;
+        }
+
         break;
 
     case ACPI_REGISTER_SMI_COMMAND_BLOCK:    /* 8-bit access */


### PR DESCRIPTION
Reported-by: Mark Gross <mark.gross@intel.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>