### PR TITLE
Utilities: split hex detection into smaller functions

### DIFF
--- a/source/components/utilities/utstrsuppt.c
+++ b/source/components/utilities/utstrsuppt.c
@@ -419,15 +419,39 @@ BOOLEAN
 AcpiUtDetectHexPrefix (
     char                    **String)
 {
+    char                    *InitialPosition = *String;
 
+    AcpiUtRemoveHexPrefix (String);
+    if (*String != InitialPosition)
+    {
+        return (TRUE); /* String is past leading 0x */
+    }
+
+    return (FALSE);     /* Not a hex string */
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiUtRemoveHexPrefix
+ *
+ * PARAMETERS:  String                  - Pointer to input ASCII string
+ *
+ * RETURN:      none
+ *
+ * DESCRIPTION: Remove a hex "0x" prefix
+ *
+ ******************************************************************************/
+
+void
+AcpiUtRemoveHexPrefix (
+    char                    **String)
+{
     if ((**String == ACPI_ASCII_ZERO) &&
         (tolower ((int) *(*String + 1)) == 'x'))
     {
         *String += 2;        /* Go past the leading 0x */
-        return (TRUE);
     }
-
-    return (FALSE);     /* Not a hex string */
 }
 
 

--- a/source/components/utilities/utstrtoul64.c
+++ b/source/components/utilities/utstrtoul64.c
@@ -383,7 +383,7 @@ AcpiUtImplicitStrtoul64 (
      * implicit conversions, and the "0x" prefix is "not allowed".
      * However, allow a "0x" prefix as an ACPI extension.
      */
-    AcpiUtDetectHexPrefix (&String);
+    AcpiUtRemoveHexPrefix (&String);
 
     if (!AcpiUtRemoveLeadingZeros (&String))
     {

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -362,6 +362,10 @@ BOOLEAN
 AcpiUtDetectHexPrefix (
     char                    **String);
 
+void
+AcpiUtRemoveHexPrefix (
+    char                    **String);
+
 BOOLEAN
 AcpiUtDetectOctalPrefix (
     char                    **String);


### PR DESCRIPTION
AcpiUtImplicitStrtoul64 called AcpiUtDetectHexPrefix and ignored the
return value. Instead, use AcpiUtRemoveHexPrefix.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>