### PR TITLE
AML Parser: ignore control method status in module-level code

### DIFF
--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -847,16 +847,20 @@ AcpiPsParseLoop (
                 Status = AE_OK;
             }
             else if ((WalkState->ParseFlags & ACPI_PARSE_MODULE_LEVEL) &&
-                ACPI_FAILURE(Status))
+                Status != AE_CTRL_TRANSFER && ACPI_FAILURE(Status))
             {
                 /*
-                 * ACPI_PARSE_MODULE_LEVEL means that we are loading a table by
-                 * executing it as a control method. However, if we encounter
-                 * an error while loading the table, we need to keep trying to
-                 * load the table rather than aborting the table load. Set the
-                 * status to AE_OK to proceed with the table load. If we get a
-                 * failure at this point, it means that the dispatcher got an
-                 * error while processing Op (most likely an AML operand error.
+                 * ACPI_PARSE_MODULE_LEVEL flag means that we are currently
+                 * loading a table by executing it as a control method.
+                 * However, if we encounter an error while loading the table,
+                 * we need to keep trying to load the table rather than
+                 * aborting the table load (setting the status to AE_OK
+                 * continues the table load). If we get a failure at this
+                 * point, it means that the dispatcher got an error while
+                 * processing Op (most likely an AML operand error) or a
+                 * control method was called from module level and the
+                 * dispatcher returned AE_CTRL_TRANSFER. In the latter case,
+                 * leave the status alone, there's nothing wrong with it.
                  */
                 Status = AE_OK;
             }


### PR DESCRIPTION
Previous change in the AML parser code blindly set all non-successful
dispatcher statuses to AE_OK. This approach is incorrect because
successful control method invocations from module-level return
AE_CTRL_TRANSFER. Overwriting AE_OK to this status causes the AML
parser to think that there was no return value from the control
method invocation.

fixes: 73c2a01c52b6 (ACPICA: AML Parser: ignore dispatcher error status during table load)
Reported-by: Linus Torvalds <torvalds@linux-foundation.org>
Tested-by: Linus Torvalds <torvalds@linux-foundation.org>
Tested-by: Oleksandr Natalenko <oleksandr@natalenko.name>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>