### PR TITLE
AML Parser: ignore all exceptions that result from incorrect AML duri…

### DIFF
--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -847,16 +847,18 @@ AcpiPsParseLoop (
                 Status = AE_OK;
             }
             else if ((WalkState->ParseFlags & ACPI_PARSE_MODULE_LEVEL) &&
-                ACPI_FAILURE(Status))
+                (ACPI_AML_EXCEPTION(Status) || Status == AE_ALREADY_EXISTS ||
+                Status == AE_NOT_FOUND))
             {
                 /*
-                 * ACPI_PARSE_MODULE_LEVEL means that we are loading a table by
-                 * executing it as a control method. However, if we encounter
-                 * an error while loading the table, we need to keep trying to
-                 * load the table rather than aborting the table load. Set the
-                 * status to AE_OK to proceed with the table load. If we get a
-                 * failure at this point, it means that the dispatcher got an
-                 * error while processing Op (most likely an AML operand error.
+                 * ACPI_PARSE_MODULE_LEVEL flag means that we are currently
+                 * loading a table by executing it as a control method.
+                 * However, if we encounter an error while loading the table,
+                 * we need to keep trying to load the table rather than
+                 * aborting the table load (setting the status to AE_OK
+                 * continues the table load). If we get a failure at this
+                 * point, it means that the dispatcher got an error while
+                 * trying to execute the Op.
                  */
                 Status = AE_OK;
             }

--- a/source/include/acexcep.h
+++ b/source/include/acexcep.h
@@ -204,6 +204,13 @@ typedef struct acpi_exception_info
 
 #define AE_OK                           (ACPI_STATUS) 0x0000
 
+#define ACPI_ENV_EXCEPTION(Status)      (Status & AE_CODE_ENVIRONMENTAL)
+#define ACPI_AML_EXCEPTION(Status)      (Status & AE_CODE_AML)
+#define ACPI_PROG_EXCEPTION(Status)     (Status & AE_CODE_PROGRAMMER)
+#define ACPI_TABLE_EXCEPTION(Status)    (Status & AE_CODE_ACPI_TABLES)
+#define ACPI_CNTL_EXCEPTION(Status)     (Status & AE_CODE_CONTROL)
+
+
 /*
  * Environmental exceptions
  */


### PR DESCRIPTION
…ng table load

In order to ignore this, macros to classify different AML exception
codes have been added.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>