### PR TITLE
Reference Counts: increase max to 0x4000 for large servers

### DIFF
--- a/source/include/acconfig.h
+++ b/source/include/acconfig.h
@@ -233,7 +233,7 @@
 
 /* Maximum object reference count (detects object deletion issues) */
 
-#define ACPI_MAX_REFERENCE_COUNT        0x800
+#define ACPI_MAX_REFERENCE_COUNT        0x4000
 
 /* Default page size for use in mapping memory for operation regions */
 


### PR DESCRIPTION
Reviewed-by: Dimitri Sivanich <dimitri.sivanich@hpe.com>
Tested-by: Russ Anderson <russ.anderson@hpe.com>
Reported-by: Mike Travis <mike.travis@hpe.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>