### PR TITLE
GPE: Clear status of all events when entering sleep states

### DIFF
--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -205,16 +205,10 @@ AcpiHwLegacySleep (
     {
         return_ACPI_STATUS (Status);
     }
-    /*
-     * If the target sleep state is S5, clear all GPEs and fixed events too
-     */
-    if (SleepState == ACPI_STATE_S5)
+    Status = AcpiHwClearAcpiStatus();
+    if (ACPI_FAILURE(Status))
     {
-        Status = AcpiHwClearAcpiStatus();
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
+        return_ACPI_STATUS(Status);
     }
     AcpiGbl_SystemAwakeAndRunning = FALSE;
 


### PR DESCRIPTION
Commit fa85015c0d95 (ACPICA: Clear status of all events when entering
S5) made the sleep state entry code in ACPICA clear the status of all
ACPI events when entering S5 to fix a functional regression reported
against commit 18996f2db918 (ACPICA: Events: Stop unconditionally
clearing ACPI IRQs during suspend/resume).  However, it is reported
now that the regression also affects system states other than S5 on
some systems and causes them to wake up from sleep prematurely.

For this reason, make the code in question clear the status of all
ACPI events when entering all sleep states (in addition to S5) to
avoid the premature wakeups (this may cause some wakeup events to
be missed in theory, but the likelihood of that is small and the
change here simply restores the previous behavior of the code).

Fixes: 18996f2db918 (ACPICA: Events: Stop unconditionally clearing ACPI IRQs during suspend/resume)
Reported-by: Paul Menzel <pmenzel@molgen.mpg.de>
Tested-by: Paul Menzel <pmenzel@molgen.mpg.de>
Cc: 4.17+ <stable@vger.kernel.org> # 4.17+: fa85015c0d95 ACPICA: Clear status ...
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>