### PR TITLE
Use %d for signed int print formatting instead of %u 

### DIFF
--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -858,7 +858,7 @@ CmCleanupAndExit (
 
     if (AslGbl_ExceptionCount[ASL_ERROR] > ASL_MAX_ERROR_COUNT)
     {
-        printf ("\nMaximum error count (%u) exceeded\n",
+        printf ("\nMaximum error count (%d) exceeded\n",
             ASL_MAX_ERROR_COUNT);
     }
 

--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -1097,7 +1097,7 @@ AslExpectException (
 
     if (AslGbl_ExpectedMessagesIndex >= ASL_MAX_EXPECTED_MESSAGES)
     {
-        printf ("Too many messages have been registered as expected (max %u)\n",
+        printf ("Too many messages have been registered as expected (max %d)\n",
             ASL_MAX_DISABLED_MESSAGES);
         return (AE_LIMIT);
     }
@@ -1144,7 +1144,7 @@ AslDisableException (
 
     if (AslGbl_DisabledMessagesIndex >= ASL_MAX_DISABLED_MESSAGES)
     {
-        printf ("Too many messages have been disabled (max %u)\n",
+        printf ("Too many messages have been disabled (max %d)\n",
             ASL_MAX_DISABLED_MESSAGES);
         return (AE_LIMIT);
     }

--- a/source/compiler/aslmain.c
+++ b/source/compiler/aslmain.c
@@ -329,7 +329,7 @@ AslSignalHandler (
 
     default:
 
-        printf (ASL_PREFIX "Unknown interrupt signal (%u)\n", Sig);
+        printf (ASL_PREFIX "Unknown interrupt signal (%d)\n", Sig);
         break;
     }
 

--- a/source/compiler/aslpredef.c
+++ b/source/compiler/aslpredef.c
@@ -222,7 +222,7 @@ ApCheckForPredefinedMethod (
 
         if (MethodInfo->NumArguments != 0)
         {
-            sprintf (AslGbl_MsgBuffer, "%s requires %u", Op->Asl.ExternalName, 0);
+            sprintf (AslGbl_MsgBuffer, "%s requires %d", Op->Asl.ExternalName, 0);
 
             AslError (ASL_WARNING, ASL_MSG_RESERVED_ARG_COUNT_HI, Op,
                 AslGbl_MsgBuffer);

--- a/source/tools/acpidump/apmain.c
+++ b/source/tools/acpidump/apmain.c
@@ -268,7 +268,7 @@ ApInsertAction (
     CurrentAction++;
     if (CurrentAction > AP_MAX_ACTIONS)
     {
-        fprintf (stderr, "Too many table options (max %u)\n", AP_MAX_ACTIONS);
+        fprintf (stderr, "Too many table options (max %d)\n", AP_MAX_ACTIONS);
         return (-1);
     }
 

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -319,7 +319,7 @@ AeDoOptions (
 
         if (strlen (AcpiGbl_Optarg) > (AE_BUFFER_SIZE -1))
         {
-            printf ("**** The length of command line (%u) exceeded maximum (%u)\n",
+            printf ("**** The length of command line (%u) exceeded maximum (%d)\n",
                 (UINT32) strlen (AcpiGbl_Optarg), (AE_BUFFER_SIZE -1));
             return (-1);
         }


### PR DESCRIPTION
… is defined

When building ACPICA in the Linux kernel with Clang with ACPI_DISASSEMBLER
not defined we get a the following warning on variable DisplayOp:

warning: variable 'display_op' set but not used [-Wunused-but-set-variable]

Fix this warning by guarding the declaration of DisplayOp with some
ACPI_DISASSEMBLER #ifdefs

Signed-off-by: Colin Ian King <colin.king@canonical.com>