### PR TITLE
Remove AcpiGbl_GroupModuleLevelCode and only use AcpiGbl_ExecuteTable…

### DIFF
--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -298,7 +298,7 @@ AcpiPsGetArguments (
          * future. Use of this option can cause problems with AML code that
          * depends upon in-order immediate execution of module-level code.
          */
-        if (AcpiGbl_GroupModuleLevelCode &&
+        if (!AcpiGbl_ExecuteTablesAsMethods &&
             (WalkState->PassNumber <= ACPI_IMODE_LOAD_PASS2) &&
             ((WalkState->ParseFlags & ACPI_PARSE_DISASSEMBLE) == 0))
         {

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -219,7 +219,7 @@ AcpiLoadTables (
             "While loading namespace from ACPI tables"));
     }
 
-    if (AcpiGbl_ExecuteTablesAsMethods || !AcpiGbl_GroupModuleLevelCode)
+    if (AcpiGbl_ExecuteTablesAsMethods)
     {
         /*
          * If the module-level code support is enabled, initialize the objects

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -301,13 +301,6 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_CopyDsdtLocally, FALSE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
 
 /*
- * Optionally support group module level code.
- * NOTE, this is essentially obsolete and will be removed soon
- * (01/2018).
- */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_GroupModuleLevelCode, FALSE);
-
-/*
  * Optionally support module level code by parsing an entire table as
  * a method as it is loaded. Default is TRUE.
  * NOTE, this is essentially obsolete and will be removed soon

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -255,7 +255,8 @@ usage (
     ACPI_OPTION ("-df",                 "Disable Local fault handler");
     ACPI_OPTION ("-di",                 "Disable execution of STA/INI methods during init");
     ACPI_OPTION ("-do",                 "Disable Operation Region address simulation");
-    ACPI_OPTION ("-dp",                 "Disable TermList parsing for scope objects");
+    ACPI_OPTION ("-dp",                 "Disable loading DSDT/SSDT as a control method\n"
+                  "                      (enable legacy grouping of module-level code)");
     ACPI_OPTION ("-dr",                 "Disable repair of method return values");
     ACPI_OPTION ("-ds",                 "Disable method auto-serialization");
     ACPI_OPTION ("-dt",                 "Disable allocation tracking (performance)");
@@ -265,7 +266,6 @@ usage (
     ACPI_OPTION ("-ef",                 "Enable display of final memory statistics");
     ACPI_OPTION ("-ei",                 "Enable additional tests for ACPICA interfaces");
     ACPI_OPTION ("-el",                 "Enable loading of additional test tables");
-    ACPI_OPTION ("-em",                 "Enable (legacy) grouping of module-level code");
     ACPI_OPTION ("-es",                 "Enable Interpreter Slack Mode");
     ACPI_OPTION ("-et",                 "Enable debug semaphore timeout");
     printf ("\n");
@@ -404,11 +404,6 @@ AeDoOptions (
         case 'l':
 
             AcpiGbl_LoadTestTables = TRUE;
-            break;
-
-        case 'm':
-
-            AcpiGbl_GroupModuleLevelCode = TRUE;
             break;
 
         case 's':
@@ -625,7 +620,6 @@ main (
     /* Module-level code. Use new architecture */
 
     AcpiGbl_ExecuteTablesAsMethods = TRUE;
-    AcpiGbl_GroupModuleLevelCode = FALSE;
 
     /*
      * Initialize ACPICA and start debugger thread.

--- a/source/tools/acpinames/anmain.c
+++ b/source/tools/acpinames/anmain.c
@@ -240,7 +240,6 @@ main (
     /* Set flags so that the interpreter is not used */
 
     AcpiGbl_ExecuteTablesAsMethods = FALSE;
-    AcpiGbl_GroupModuleLevelCode = TRUE;
 
     Status = AcpiInitializeSubsystem ();
     ACPI_CHECK_OK (AcpiInitializeSubsystem, Status);


### PR DESCRIPTION
…sAsMethods instead

AcpiGbl_GroupModuleLevelCode and AcpiGbl_ExecuteTablesAsMethods both
used to enable different table load behavior.

A.) AcpiGbl_GroupModuleLevelCode enabled the legacy approach where
    ASL if statements are executed after the namespace object has
    been loaded.
B.) AcpiGbl_ExecuteTablesAsMethods is currently used to enable the
    table load to be a method invocation. This meaning that ASL If
    statements are executed in-line rather than deferred until after
    the ACPI namespace has been populated. This is the correct
    behavior and option A will be removed in the future.

We do not support a table load behavior where these variables are
assigned the same value. In otherwords, we only support option A or B
and do not need AcpiGbl_GroupModuleLevelCode to enable A. For now,
AcpiGbl_ExecuteTablesAsMethods == 1 enables option B and
AcpiGbl_ExecuteTablesAsMethods == 0 enables option A.

Note: option A is expected to be removed in the future and option B
will become the only supported table load behavior.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>