### PR TITLE
iASL: add additional check for strings with length zero

### DIFF
--- a/source/compiler/dtio.c
+++ b/source/compiler/dtio.c
@@ -236,7 +236,7 @@ DtTrim (
 
     /* Skip lines that start with a space */
 
-    if (!strcmp (String, " "))
+    if (*String == 0 || !strcmp (String, " "))
     {
         ReturnString = UtLocalCacheCalloc (1);
         return (ReturnString);


### PR DESCRIPTION
Without this check there is a bounds violation that occurs when
DtTrim attempts to remove a double quote charater later in the
function. The End gets set to 1 byte before Start.

Suggested-by: Steven Noonan
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>