### PR TITLE
iASL: properly detect continuation on dos files

### DIFF
--- a/source/compiler/dtio.c
+++ b/source/compiler/dtio.c
@@ -258,7 +258,7 @@ DtTrim (
 
     while (End >= Start)
     {
-        if (*End == '\r' || *End == '\n')
+        if (*End == '\n')
         {
             End--;
             continue;
@@ -522,6 +522,7 @@ DtGetNextLine (
     UINT32                  CurrentLineOffset;
     UINT32                  i;
     int                     c;
+    int                     c1;
 
 
     memset (AslGbl_CurrentLineBuffer, 0, AslGbl_LineBufferSize);
@@ -568,6 +569,29 @@ DtGetNextLine (
              */
             c = '\n';
             State = DT_NORMAL_TEXT;
+        }
+        else if (c == '\r')
+        {
+            c1 = getc (Handle);
+            if (c1 == '\n')
+            {
+                /*
+                 * Skip the carriage return as if it didn't exist. This is
+                 * onlt meant for input files in DOS format in unix. fopen in
+                 * unix may not support "text mode" and leaves CRLF intact.
+                 */
+                c = '\n';
+            }
+            else
+            {
+                /* This was not a CRLF. Only a CR */
+
+                ungetc(c1, Handle);
+
+                DtFatal (ASL_MSG_COMPILER_INTERNAL, NULL,
+                    "Carriage return without linefeed detected");
+                return (ASL_EOF);
+            }
         }
 
         switch (State)


### PR DESCRIPTION
If the '\\' is next to a "\r\n", it is also a continuation

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>