### PR TITLE
Remove defines that use deprecated ACPI_NO_METHOD_EXECUTE flag

### DIFF
--- a/source/components/dispatcher/dsobject.c
+++ b/source/components/dispatcher/dsobject.c
@@ -161,7 +161,6 @@
         ACPI_MODULE_NAME    ("dsobject")
 
 
-#ifndef ACPI_NO_METHOD_EXECUTION
 /*******************************************************************************
  *
  * FUNCTION:    AcpiDsBuildInternalObject
@@ -460,7 +459,6 @@ AcpiDsCreateNode (
     return_ACPI_STATUS (Status);
 }
 
-#endif /* ACPI_NO_METHOD_EXECUTION */
 
 
 /*******************************************************************************
@@ -571,9 +569,7 @@ AcpiDsInitObjectFromOp (
 
                 /* Truncate value if we are executing from a 32-bit ACPI table */
 
-#ifndef ACPI_NO_METHOD_EXECUTION
                 (void) AcpiExTruncateFor32bitTable (ObjDesc);
-#endif
                 break;
 
             case AML_REVISION_OP:
@@ -594,7 +590,6 @@ AcpiDsInitObjectFromOp (
 
             ObjDesc->Integer.Value = Op->Common.Value.Integer;
 
-#ifndef ACPI_NO_METHOD_EXECUTION
             if (AcpiExTruncateFor32bitTable (ObjDesc))
             {
                 /* Warn if we found a 64-bit constant in a 32-bit table */
@@ -604,7 +599,6 @@ AcpiDsInitObjectFromOp (
                     ACPI_FORMAT_UINT64 (Op->Common.Value.Integer),
                     (UINT32) ObjDesc->Integer.Value));
             }
-#endif
             break;
 
         default:
@@ -642,12 +636,10 @@ AcpiDsInitObjectFromOp (
             ObjDesc->Reference.Value = ((UINT32) Opcode) - AML_FIRST_LOCAL_OP;
             ObjDesc->Reference.Class = ACPI_REFCLASS_LOCAL;
 
-#ifndef ACPI_NO_METHOD_EXECUTION
             Status = AcpiDsMethodDataGetNode (ACPI_REFCLASS_LOCAL,
                 ObjDesc->Reference.Value, WalkState,
                 ACPI_CAST_INDIRECT_PTR (ACPI_NAMESPACE_NODE,
                     &ObjDesc->Reference.Object));
-#endif
             break;
 
         case AML_TYPE_METHOD_ARGUMENT:
@@ -657,12 +649,10 @@ AcpiDsInitObjectFromOp (
             ObjDesc->Reference.Value = ((UINT32) Opcode) - AML_FIRST_ARG_OP;
             ObjDesc->Reference.Class = ACPI_REFCLASS_ARG;
 
-#ifndef ACPI_NO_METHOD_EXECUTION
             Status = AcpiDsMethodDataGetNode (ACPI_REFCLASS_ARG,
                 ObjDesc->Reference.Value, WalkState,
                 ACPI_CAST_INDIRECT_PTR (ACPI_NAMESPACE_NODE,
                     &ObjDesc->Reference.Object));
-#endif
             break;
 
         default: /* Object name or Debug object */

--- a/source/components/dispatcher/dsutils.c
+++ b/source/components/dispatcher/dsutils.c
@@ -209,7 +209,6 @@ AcpiDsClearImplicitReturn (
 }
 
 
-#ifndef ACPI_NO_METHOD_EXECUTION
 /*******************************************************************************
  *
  * FUNCTION:    AcpiDsDoImplicitReturn
@@ -583,7 +582,6 @@ AcpiDsClearOperands (
     WalkState->NumOperands = 0;
     return_VOID;
 }
-#endif
 
 
 /*******************************************************************************

--- a/source/components/dispatcher/dswload.c
+++ b/source/components/dispatcher/dswload.c
@@ -221,12 +221,10 @@ AcpiDsInitCallbacks (
 
         /* Execution pass */
 
-#ifndef ACPI_NO_METHOD_EXECUTION
         WalkState->ParseFlags        |= ACPI_PARSE_EXECUTE  |
                                         ACPI_PARSE_DELETE_TREE;
         WalkState->DescendingCallback = AcpiDsExecBeginOp;
         WalkState->AscendingCallback  = AcpiDsExecEndOp;
-#endif
         break;
 
     default:
@@ -517,7 +515,7 @@ AcpiDsLoad1BeginOp (
 
     /* Initialize the op */
 
-#if (defined (ACPI_NO_METHOD_EXECUTION) || defined (ACPI_CONSTANT_EVAL_ONLY))
+#ifdef ACPI_CONSTANT_EVAL_ONLY
     Op->Named.Path = Path;
 #endif
 
@@ -580,7 +578,6 @@ AcpiDsLoad1EndOp (
 
     ObjectType = WalkState->OpInfo->ObjectType;
 
-#ifndef ACPI_NO_METHOD_EXECUTION
     if (WalkState->OpInfo->Flags & AML_FIELD)
     {
         /*
@@ -626,7 +623,6 @@ AcpiDsLoad1EndOp (
             }
         }
     }
-#endif
 
     if (Op->Common.AmlOpcode == AML_NAME_OP)
     {

--- a/source/components/dispatcher/dswload2.c
+++ b/source/components/dispatcher/dswload2.c
@@ -529,10 +529,8 @@ AcpiDsLoad2EndOp (
     ACPI_NAMESPACE_NODE     *Node;
     ACPI_PARSE_OBJECT       *Arg;
     ACPI_NAMESPACE_NODE     *NewNode;
-#ifndef ACPI_NO_METHOD_EXECUTION
     UINT32                  i;
     UINT8                   RegionSpace;
-#endif
 
 
     ACPI_FUNCTION_TRACE (DsLoad2EndOp);
@@ -622,7 +620,6 @@ AcpiDsLoad2EndOp (
 
     switch (WalkState->OpInfo->Type)
     {
-#ifndef ACPI_NO_METHOD_EXECUTION
 
     case AML_TYPE_CREATE_FIELD:
         /*
@@ -718,13 +715,11 @@ AcpiDsLoad2EndOp (
         }
 
         break;
-#endif /* ACPI_NO_METHOD_EXECUTION */
 
     case AML_TYPE_NAMED_COMPLEX:
 
         switch (Op->Common.AmlOpcode)
         {
-#ifndef ACPI_NO_METHOD_EXECUTION
         case AML_REGION_OP:
         case AML_DATA_REGION_OP:
 
@@ -809,7 +804,6 @@ AcpiDsLoad2EndOp (
             }
             break;
 
-#endif /* ACPI_NO_METHOD_EXECUTION */
 
         default:
 

--- a/source/components/dispatcher/dswstate.c
+++ b/source/components/dispatcher/dswstate.c
@@ -733,7 +733,7 @@ AcpiDsCreateWalkState (
 
     /* Init the method args/local */
 
-#if (!defined (ACPI_NO_METHOD_EXECUTION) && !defined (ACPI_CONSTANT_EVAL_ONLY))
+#ifndef ACPI_CONSTANT_EVAL_ONLY
     AcpiDsMethodDataInit (WalkState);
 #endif
 

--- a/source/components/executer/excreate.c
+++ b/source/components/executer/excreate.c
@@ -161,7 +161,6 @@
         ACPI_MODULE_NAME    ("excreate")
 
 
-#ifndef ACPI_NO_METHOD_EXECUTION
 /*******************************************************************************
  *
  * FUNCTION:    AcpiExCreateAlias
@@ -573,7 +572,6 @@ AcpiExCreatePowerResource (
     AcpiUtRemoveReference (ObjDesc);
     return_ACPI_STATUS (Status);
 }
-#endif
 
 
 /*******************************************************************************

--- a/source/components/executer/exutils.c
+++ b/source/components/executer/exutils.c
@@ -181,7 +181,6 @@ AcpiExDigitsNeeded (
     UINT32                  Base);
 
 
-#ifndef ACPI_NO_METHOD_EXECUTION
 /*******************************************************************************
  *
  * FUNCTION:    AcpiExEnterInterpreter
@@ -615,4 +614,3 @@ AcpiIsValidSpaceId (
     return (TRUE);
 }
 
-#endif

--- a/source/components/namespace/nsload.c
+++ b/source/components/namespace/nsload.c
@@ -173,7 +173,6 @@ AcpiNsDeleteSubtree (
 #endif
 
 
-#ifndef ACPI_NO_METHOD_EXECUTION
 /*******************************************************************************
  *
  * FUNCTION:    AcpiNsLoadTable
@@ -476,5 +475,4 @@ AcpiNsUnloadNamespace (
     Status = AcpiNsDeleteSubtree (Handle);
     return_ACPI_STATUS (Status);
 }
-#endif
 #endif

--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -580,7 +580,7 @@ AcpiPsParseLoop (
     ParserState = &WalkState->ParserState;
     WalkState->ArgTypes = 0;
 
-#if (!defined (ACPI_NO_METHOD_EXECUTION) && !defined (ACPI_CONSTANT_EVAL_ONLY))
+#ifndef ACPI_CONSTANT_EVAL_ONLY
 
     if (WalkState->WalkType & ACPI_WALK_METHOD_RESTART)
     {

--- a/source/components/utilities/utglobal.c
+++ b/source/components/utilities/utglobal.c
@@ -235,10 +235,7 @@ const ACPI_PREDEFINED_NAMES     AcpiGbl_PreDefinedNames[] =
     {"_REV",    ACPI_TYPE_INTEGER,          ACPI_CAST_PTR (char, 2)},
     {"_OS_",    ACPI_TYPE_STRING,           ACPI_OS_NAME},
     {"_GL_",    ACPI_TYPE_MUTEX,            ACPI_CAST_PTR (char, 1)},
-
-#if !defined (ACPI_NO_METHOD_EXECUTION) || defined (ACPI_CONSTANT_EVAL_ONLY)
     {"_OSI",    ACPI_TYPE_METHOD,           ACPI_CAST_PTR (char, 1)},
-#endif
 
     /* Table terminator */
 

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -317,11 +317,7 @@ ACPI_GLOBAL (BOOLEAN,                   AcpiGbl_DisableMemTracking);
  *
  ****************************************************************************/
 
-#if !defined (ACPI_NO_METHOD_EXECUTION) || defined (ACPI_CONSTANT_EVAL_ONLY)
 #define NUM_PREDEFINED_NAMES            10
-#else
-#define NUM_PREDEFINED_NAMES            9
-#endif
 
 ACPI_GLOBAL (ACPI_NAMESPACE_NODE,       AcpiGbl_RootNodeStruct);
 ACPI_GLOBAL (ACPI_NAMESPACE_NODE *,     AcpiGbl_RootNode);


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>