### PR TITLE
iASL: restrict integer package elements to integers and constants

### DIFF
--- a/source/compiler/aslrules.y
+++ b/source/compiler/aslrules.y
@@ -406,7 +406,7 @@ PackageList
     ;
 
 PackageElement
-    : DataObject                    {}
+    : PackageDataObject             {}
     | NameString                    {}
     ;
 
@@ -494,6 +494,14 @@ DataObject
     : BufferData                    {}
     | PackageData                   {}
     | IntegerData                   {}
+    | StringData                    {}
+    ;
+
+PackageDataObject
+    : BufferData                    {}
+    | PackageData                   {}
+    | Integer                       {}
+    | ConstTerm                     {}
     | StringData                    {}
     ;
 

--- a/source/compiler/asltypes.y
+++ b/source/compiler/asltypes.y
@@ -164,6 +164,7 @@ NoEcho('
 %type <n> BufferTermData
 %type <n> CompilerDirective
 %type <n> DataObject
+%type <n> PackageDataObject
 %type <n> DefinitionBlockTerm
 %type <n> DefinitionBlockList
 %type <n> IntegerData


### PR DESCRIPTION
Package elements that are integer expressions are not supported on
any known AML interpreter implementations. This change in the
compiler restricts integer package elements to integer literals and
constants.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>