### PR TITLE
Add "Windows 2018.2" string in the _OSI support

### DIFF
--- a/source/components/utilities/utosi.c
+++ b/source/components/utilities/utosi.c
@@ -218,6 +218,7 @@ static ACPI_INTERFACE_INFO    AcpiDefaultSupportedInterfaces[] =
     {"Windows 2017",        NULL, 0, ACPI_OSI_WIN_10_RS2},       /* Windows 10 version 1703 - Added 12/2017 */
     {"Windows 2017.2",      NULL, 0, ACPI_OSI_WIN_10_RS3},       /* Windows 10 version 1709 - Added 02/2018 */
     {"Windows 2018",        NULL, 0, ACPI_OSI_WIN_10_RS4},       /* Windows 10 version 1803 - Added 11/2018 */
+    {"Windows 2018.2",      NULL, 0, ACPI_OSI_WIN_10_RS5},       /* Windows 10 version 1809 - Added 11/2018 */
 
     /* Feature Group Strings */
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1513,6 +1513,7 @@ typedef enum
 #define ACPI_OSI_WIN_10_RS2             0x0F
 #define ACPI_OSI_WIN_10_RS3             0x10
 #define ACPI_OSI_WIN_10_RS4             0x11
+#define ACPI_OSI_WIN_10_RS5             0x12
 
 
 /* Definitions of getopt */


### PR DESCRIPTION
"Windows 2018.2" was added for Windows 10, version 1809.

https://docs.microsoft.com/en-us/windows-hardware/drivers/acpi/winacpi-osi