### PR TITLE
ACPICA: Fix handling of buffer-size in acpi_ex_write_data_to_field()

### DIFF
--- a/source/components/executer/exserial.c
+++ b/source/components/executer/exserial.c
@@ -445,14 +445,12 @@ AcpiExWriteSerialBus (
     case ACPI_ADR_SPACE_SMBUS:
 
         BufferLength = ACPI_SMBUS_BUFFER_SIZE;
-        DataLength = ACPI_SMBUS_DATA_SIZE;
         Function = ACPI_WRITE | (ObjDesc->Field.Attribute << 16);
         break;
 
     case ACPI_ADR_SPACE_IPMI:
 
         BufferLength = ACPI_IPMI_BUFFER_SIZE;
-        DataLength = ACPI_IPMI_DATA_SIZE;
         Function = ACPI_WRITE;
         break;
 
@@ -471,28 +469,12 @@ AcpiExWriteSerialBus (
         /* Add header length to get the full size of the buffer */
 
         BufferLength += ACPI_SERIAL_HEADER_SIZE;
-        DataLength = SourceDesc->Buffer.Pointer[1];
         Function = ACPI_WRITE | (AccessorType << 16);
         break;
 
     default:
         return_ACPI_STATUS (AE_AML_INVALID_SPACE_ID);
     }
-
-#if 0
-OBSOLETE?
-    /* Check for possible buffer overflow */
-
-    if (DataLength > SourceDesc->Buffer.Length)
-    {
-        ACPI_ERROR ((AE_INFO,
-            "Length in buffer header (%u)(%u) is greater than "
-            "the physical buffer length (%u) and will overflow",
-            DataLength, BufferLength, SourceDesc->Buffer.Length));
-
-        return_ACPI_STATUS (AE_AML_BUFFER_LIMIT);
-    }
-#endif
 
     /* Create the transfer/bidirectional/return buffer */
 
@@ -505,6 +487,8 @@ OBSOLETE?
     /* Copy the input buffer data to the transfer buffer */
 
     Buffer = BufferDesc->Buffer.Pointer;
+    DataLength = (BufferLength < SourceDesc->Buffer.Length ?
+        BufferLength : SourceDesc->Buffer.Length);
     memcpy (Buffer, SourceDesc->Buffer.Pointer, DataLength);
 
     /* Lock entire transaction if requested */


### PR DESCRIPTION
This is a back-port of Hans de Goede's patch.

Generic Serial Bus transfers use a data struct like this:

struct gsb_buffer {
        u8      status;
        u8      len;
        u8      data[0];
};

acpi_ex_write_data_to_field() copies the data which is to be written from
the source-buffer to a temp-buffer. This is done because the OpReg-handler
overwrites the status field and some transfers do a write + read-back.

Commit f99b89eefeb6 ("ACPICA: Update for generic_serial_bus and
attrib_raw_process_bytes protocol") acpi_ex_write_data_to_field()
introduces a number of problems with this:

 1) It drops a "length += 2" statement used to calculate the temp-buffer
 size causing the temp-buffer to only be 1/2 bytes large for byte/word
 transfers while it should be 3/4 bytes (taking the status and len field
 into account). This is already fixed in commit e324e10109fc ("ACPICA:
 Update for field unit access") which refactors the code.

The ACPI 6.0 spec (ACPI_6.0.pdf) "5.5.2.4.5.2 Declaring and Using a
GenericSerialBusData Buffer" (page 232) states that the GenericSerialBus
Data Buffer Length field is only valid when doing a Read/Write Block
(AttribBlock) transfer, but since the troublesome commit we unconditionally
use the len field to determine how much data to copy from the source-buffer
into the temp-buffer passed to the OpRegion.

This causes 3 further issues:

 2) This may lead to not copying enough data to the temp-buffer causing the
 OpRegion handler for the serial-bus to write garbage to the hardware.

 3) The temp-buffer passed to the OpRegion is allocated to the size
 returned by acpi_ex_get_serial_access_length(), which may be as little
 as 1, so potentially this may lead to a write overflow of the temp-buffer.

 4) Commit e324e10109fc ("ACPICA: Update for field unit access") drops a
 length check on the source-buffer, leading to a potential read overflow
 of the source-buffer.

This commit fixes all 3 remaining issues by not looking at the len field at
all (the interpretation of this field is left up to the OpRegion handler),
and copying the minimum of the source- and temp-buffer sizes from the
source-buffer to the temp-buffer.

This fixes e.g. an Acer S1003 no longer booting since the troublesome
commit.

Fixes: f99b89eefeb6 (ACPICA: Update for generic_serial_bus and ...)
Fixes: e324e10109fc (ACPICA: Update for field unit access)
Signed-off-by: Hans de Goede <hdegoede@redhat.com>
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>