### PR TITLE
iASL: remove obsolete AcpiGbl_DoExternals flag

### DIFF
--- a/source/compiler/aslcodegen.c
+++ b/source/compiler/aslcodegen.c
@@ -773,12 +773,6 @@ CgWriteNode (
         return;
     }
 
-    if ((Op->Asl.ParseOpcode == PARSEOP_EXTERNAL) &&
-        AslGbl_DoExternals == FALSE)
-    {
-        return;
-    }
-
     Op->Asl.FinalAmlLength = 0;
 
     switch (Op->Asl.AmlOpcode)

--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -388,23 +388,20 @@ CmDoCompile (
 
     /* Resolve External Declarations */
 
-    if (AslGbl_DoExternals)
-    {
-        Event = UtBeginEvent ("Resolve all Externals");
-        DbgPrint (ASL_DEBUG_OUTPUT, "\nResolve Externals\n\n");
+    Event = UtBeginEvent ("Resolve all Externals");
+    DbgPrint (ASL_DEBUG_OUTPUT, "\nResolve Externals\n\n");
 
-        if (AslGbl_DoExternalsInPlace)
-        {
-            TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_DOWNWARD,
-                ExAmlExternalWalkBegin, NULL, NULL);
-        }
-        else
-        {
-            TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_TWICE,
-                ExAmlExternalWalkBegin, ExAmlExternalWalkEnd, NULL);
-        }
-        UtEndEvent (Event);
+    if (AslGbl_DoExternalsInPlace)
+    {
+        TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_DOWNWARD,
+            ExAmlExternalWalkBegin, NULL, NULL);
     }
+    else
+    {
+        TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_TWICE,
+            ExAmlExternalWalkBegin, ExAmlExternalWalkEnd, NULL);
+    }
+    UtEndEvent (Event);
 
     /*
      * Semantic analysis. This can happen only after the

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -319,7 +319,6 @@ ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_AllExceptionsDisable
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_PruneParseTree, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DoTypechecking, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_EnableReferenceTypechecking, FALSE);
-ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DoExternals, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DoExternalsInPlace, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DoAslConversion, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_OptimizeTrivialParseNodes, TRUE);

--- a/source/compiler/asllength.c
+++ b/source/compiler/asllength.c
@@ -519,10 +519,7 @@ CgGenerateAmlLengths (
 
     case PARSEOP_EXTERNAL:
 
-        if (AslGbl_DoExternals == TRUE)
-        {
-            CgGenerateAmlOpcodeLength (Op);
-        }
+        CgGenerateAmlOpcodeLength (Op);
         break;
 
     default:

--- a/source/compiler/aslopcodes.c
+++ b/source/compiler/aslopcodes.c
@@ -927,15 +927,6 @@ OpcGenerateAmlOpcode (
         AslGbl_HasIncludeFiles = TRUE;
         break;
 
-    case PARSEOP_EXTERNAL:
-
-        if (AslGbl_DoExternals == FALSE)
-        {
-            Op->Asl.Child->Asl.ParseOpcode = PARSEOP_DEFAULT_ARG;
-            Op->Asl.Child->Asl.Next->Asl.ParseOpcode = PARSEOP_DEFAULT_ARG;
-        }
-        break;
-
     case PARSEOP_TIMER:
 
         if (AcpiGbl_IntegerBitWidth == 32)

--- a/source/compiler/asltransform.c
+++ b/source/compiler/asltransform.c
@@ -460,11 +460,7 @@ TrTransformSubtree (
 
     case PARSEOP_EXTERNAL:
 
-        if (AslGbl_DoExternals == TRUE)
-        {
-            ExDoExternal (Op);
-        }
-
+        ExDoExternal (Op);
         break;
 
     case PARSEOP___METHOD__:


### PR DESCRIPTION
This was meant to be a debug flag during the development of external
opcode. This flag is no longer needed because generation of external
opcodes are stable.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>