### PR TITLE
Correct DSDT Address field in FACP tables

### DIFF
--- a/source/common/dmtbinfo.c
+++ b/source/common/dmtbinfo.c
@@ -292,7 +292,7 @@ ACPI_DMTABLE_INFO           AcpiDmTableInfoFacs[] =
 ACPI_DMTABLE_INFO           AcpiDmTableInfoFadt1[] =
 {
     {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Facs),                    "FACS Address", 0},
-    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Dsdt),                    "DSDT Address", DT_NON_ZERO},
+    {ACPI_DMT_UINT32,   ACPI_FADT_OFFSET (Dsdt),                    "DSDT Address", 0},
     {ACPI_DMT_UINT8,    ACPI_FADT_OFFSET (Model),                   "Model", 0},
     {ACPI_DMT_FADTPM,   ACPI_FADT_OFFSET (PreferredProfile),        "PM Profile", 0},
     {ACPI_DMT_UINT16,   ACPI_FADT_OFFSET (SciInterrupt),            "SCI Interrupt", 0},


### PR DESCRIPTION
The FADT allows either the DSDT Address or XDSDT Address field to be
zero.  However, the table definition used by the table compiler still
requires the DSDT Address to be non-zero, which is not correct.  So,
remove the DT_NON_ZERO flag from the field.

Signed-off-by: Al Stone <ahs3@redhat.com>