### PR TITLE
Remove legacy module-level code support

### DIFF
--- a/source/components/events/evrgnini.c
+++ b/source/components/events/evrgnini.c
@@ -724,24 +724,6 @@ AcpiEvInitializeRegion (
                 HandlerObj = ObjDesc->CommonNotify.Handler;
                 break;
 
-            case ACPI_TYPE_METHOD:
-                /*
-                 * If we are executing module level code, the original
-                 * Node's object was replaced by this Method object and we
-                 * saved the handler in the method object.
-                 *
-                 * Note: Only used for the legacy MLC support. Will
-                 * be removed in the future.
-                 *
-                 * See AcpiNsExecModuleCode
-                 */
-                if (!AcpiGbl_ExecuteTablesAsMethods &&
-                    ObjDesc->Method.InfoFlags & ACPI_METHOD_MODULE_LEVEL)
-                {
-                    HandlerObj = ObjDesc->Method.Dispatch.Handler;
-                }
-                break;
-
             default:
 
                 /* Ignore other objects */

--- a/source/components/namespace/nsparse.c
+++ b/source/components/namespace/nsparse.c
@@ -422,66 +422,18 @@ AcpiNsParseTable (
     ACPI_FUNCTION_TRACE (NsParseTable);
 
 
-    if (AcpiGbl_ExecuteTablesAsMethods)
-    {
-        /*
-         * This case executes the AML table as one large control method.
-         * The point of this is to execute any module-level code in-place
-         * as the table is parsed. Some AML code depends on this behavior.
-         *
-         * It is a run-time option at this time, but will eventually become
-         * the default.
-         *
-         * Note: This causes the table to only have a single-pass parse.
-         * However, this is compatible with other ACPI implementations.
-         */
-        ACPI_DEBUG_PRINT_RAW ((ACPI_DB_PARSE,
-            "%s: **** Start table execution pass\n", ACPI_GET_FUNCTION_NAME));
+    /*
+     * Executes the AML table as one large control method.
+     * The point of this is to execute any module-level code in-place
+     * as the table is parsed. Some AML code depends on this behavior.
+     *
+     * Note: This causes the table to only have a single-pass parse.
+     * However, this is compatible with other ACPI implementations.
+     */
+    ACPI_DEBUG_PRINT_RAW ((ACPI_DB_PARSE,
+        "%s: **** Start table execution pass\n", ACPI_GET_FUNCTION_NAME));
 
-        Status = AcpiNsExecuteTable (TableIndex, StartNode);
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
-    }
-    else
-    {
-        /*
-         * AML Parse, pass 1
-         *
-         * In this pass, we load most of the namespace. Control methods
-         * are not parsed until later. A parse tree is not created.
-         * Instead, each Parser Op subtree is deleted when it is finished.
-         * This saves a great deal of memory, and allows a small cache of
-         * parse objects to service the entire parse. The second pass of
-         * the parse then performs another complete parse of the AML.
-         */
-        ACPI_DEBUG_PRINT ((ACPI_DB_PARSE, "**** Start pass 1\n"));
-
-        Status = AcpiNsOneCompleteParse (ACPI_IMODE_LOAD_PASS1,
-            TableIndex, StartNode);
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
-
-        /*
-         * AML Parse, pass 2
-         *
-         * In this pass, we resolve forward references and other things
-         * that could not be completed during the first pass.
-         * Another complete parse of the AML is performed, but the
-         * overhead of this is compensated for by the fact that the
-         * parse objects are all cached.
-         */
-        ACPI_DEBUG_PRINT ((ACPI_DB_PARSE, "**** Start pass 2\n"));
-        Status = AcpiNsOneCompleteParse (ACPI_IMODE_LOAD_PASS2,
-            TableIndex, StartNode);
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
-    }
+    Status = AcpiNsExecuteTable (TableIndex, StartNode);
 
     return_ACPI_STATUS (Status);
 }

--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -178,13 +178,6 @@ AcpiPsGetArguments (
     UINT8                   *AmlOpStart,
     ACPI_PARSE_OBJECT       *Op);
 
-static void
-AcpiPsLinkModuleCode (
-    ACPI_PARSE_OBJECT       *ParentOp,
-    UINT8                   *AmlStart,
-    UINT32                  AmlLength,
-    ACPI_OWNER_ID           OwnerId);
-
 
 /*******************************************************************************
  *
@@ -208,7 +201,6 @@ AcpiPsGetArguments (
 {
     ACPI_STATUS             Status = AE_OK;
     ACPI_PARSE_OBJECT       *Arg = NULL;
-    const ACPI_OPCODE_INFO  *OpInfo;
 
 
     ACPI_FUNCTION_TRACE_PTR (PsGetArguments, WalkState);
@@ -287,82 +279,6 @@ AcpiPsGetArguments (
             "Final argument count: %8.8X pass %u\n",
             WalkState->ArgCount, WalkState->PassNumber));
 
-        /*
-         * This case handles the legacy option that groups all module-level
-         * code blocks together and defers execution until all of the tables
-         * are loaded. Execute all of these blocks at this time.
-         * Execute any module-level code that was detected during the table
-         * load phase.
-         *
-         * Note: this option is deprecated and will be eliminated in the
-         * future. Use of this option can cause problems with AML code that
-         * depends upon in-order immediate execution of module-level code.
-         */
-        if (!AcpiGbl_ExecuteTablesAsMethods &&
-            (WalkState->PassNumber <= ACPI_IMODE_LOAD_PASS2) &&
-            ((WalkState->ParseFlags & ACPI_PARSE_DISASSEMBLE) == 0))
-        {
-            /*
-             * We want to skip If/Else/While constructs during Pass1 because we
-             * want to actually conditionally execute the code during Pass2.
-             *
-             * Except for disassembly, where we always want to walk the
-             * If/Else/While packages
-             */
-            switch (Op->Common.AmlOpcode)
-            {
-            case AML_IF_OP:
-            case AML_ELSE_OP:
-            case AML_WHILE_OP:
-                /*
-                 * Currently supported module-level opcodes are:
-                 * IF/ELSE/WHILE. These appear to be the most common,
-                 * and easiest to support since they open an AML
-                 * package.
-                 */
-                if (WalkState->PassNumber == ACPI_IMODE_LOAD_PASS1)
-                {
-                    AcpiPsLinkModuleCode (Op->Common.Parent, AmlOpStart,
-                        (UINT32) (WalkState->ParserState.PkgEnd - AmlOpStart),
-                        WalkState->OwnerId);
-                }
-
-                ACPI_DEBUG_PRINT ((ACPI_DB_PARSE,
-                    "Pass1: Skipping an If/Else/While body\n"));
-
-                /* Skip body of if/else/while in pass 1 */
-
-                WalkState->ParserState.Aml = WalkState->ParserState.PkgEnd;
-                WalkState->ArgCount = 0;
-                break;
-
-            default:
-                /*
-                 * Check for an unsupported executable opcode at module
-                 * level. We must be in PASS1, the parent must be a SCOPE,
-                 * The opcode class must be EXECUTE, and the opcode must
-                 * not be an argument to another opcode.
-                 */
-                if ((WalkState->PassNumber == ACPI_IMODE_LOAD_PASS1) &&
-                    (Op->Common.Parent->Common.AmlOpcode == AML_SCOPE_OP))
-                {
-                    OpInfo = AcpiPsGetOpcodeInfo (Op->Common.AmlOpcode);
-                    if ((OpInfo->Class == AML_CLASS_EXECUTE) &&
-                        (!Arg))
-                    {
-                        ACPI_WARNING ((AE_INFO,
-                            "Unsupported module-level executable opcode "
-                            "0x%.2X at table offset 0x%.4X",
-                            Op->Common.AmlOpcode,
-                            (UINT32) (ACPI_PTR_DIFF (AmlOpStart,
-                                WalkState->ParserState.AmlStart) +
-                                sizeof (ACPI_TABLE_HEADER))));
-                    }
-                }
-                break;
-            }
-        }
-
         /* Special processing for certain opcodes */
 
         switch (Op->Common.AmlOpcode)
@@ -433,117 +349,6 @@ AcpiPsGetArguments (
     return_ACPI_STATUS (AE_OK);
 }
 
-
-/*******************************************************************************
- *
- * FUNCTION:    AcpiPsLinkModuleCode
- *
- * PARAMETERS:  ParentOp            - Parent parser op
- *              AmlStart            - Pointer to the AML
- *              AmlLength           - Length of executable AML
- *              OwnerId             - OwnerId of module level code
- *
- * RETURN:      None.
- *
- * DESCRIPTION: Wrap the module-level code with a method object and link the
- *              object to the global list. Note, the mutex field of the method
- *              object is used to link multiple module-level code objects.
- *
- * NOTE: In this legacy option, each block of detected executable AML
- * code that is outside of any control method is wrapped with a temporary
- * control method object and placed on a global list below.
- *
- * This function executes the module-level code for all tables only after
- * all of the tables have been loaded. It is a legacy option and is
- * not compatible with other ACPI implementations. See AcpiNsLoadTable.
- *
- * This function will be removed when the legacy option is removed.
- *
- ******************************************************************************/
-
-static void
-AcpiPsLinkModuleCode (
-    ACPI_PARSE_OBJECT       *ParentOp,
-    UINT8                   *AmlStart,
-    UINT32                  AmlLength,
-    ACPI_OWNER_ID           OwnerId)
-{
-    ACPI_OPERAND_OBJECT     *Prev;
-    ACPI_OPERAND_OBJECT     *Next;
-    ACPI_OPERAND_OBJECT     *MethodObj;
-    ACPI_NAMESPACE_NODE     *ParentNode;
-
-
-    ACPI_FUNCTION_TRACE (PsLinkModuleCode);
-
-
-    /* Get the tail of the list */
-
-    Prev = Next = AcpiGbl_ModuleCodeList;
-    while (Next)
-    {
-        Prev = Next;
-        Next = Next->Method.Mutex;
-    }
-
-    /*
-     * Insert the module level code into the list. Merge it if it is
-     * adjacent to the previous element.
-     */
-    if (!Prev ||
-       ((Prev->Method.AmlStart + Prev->Method.AmlLength) != AmlStart))
-    {
-        /* Create, initialize, and link a new temporary method object */
-
-        MethodObj = AcpiUtCreateInternalObject (ACPI_TYPE_METHOD);
-        if (!MethodObj)
-        {
-            return_VOID;
-        }
-
-        ACPI_DEBUG_PRINT ((ACPI_DB_PARSE,
-            "Create/Link new code block: %p\n", MethodObj));
-
-        if (ParentOp->Common.Node)
-        {
-            ParentNode = ParentOp->Common.Node;
-        }
-        else
-        {
-            ParentNode = AcpiGbl_RootNode;
-        }
-
-        MethodObj->Method.AmlStart = AmlStart;
-        MethodObj->Method.AmlLength = AmlLength;
-        MethodObj->Method.OwnerId = OwnerId;
-        MethodObj->Method.InfoFlags |= ACPI_METHOD_MODULE_LEVEL;
-
-        /*
-         * Save the parent node in NextObject. This is cheating, but we
-         * don't want to expand the method object.
-         */
-        MethodObj->Method.NextObject =
-            ACPI_CAST_PTR (ACPI_OPERAND_OBJECT, ParentNode);
-
-        if (!Prev)
-        {
-            AcpiGbl_ModuleCodeList = MethodObj;
-        }
-        else
-        {
-            Prev->Method.Mutex = MethodObj;
-        }
-    }
-    else
-    {
-        ACPI_DEBUG_PRINT ((ACPI_DB_PARSE,
-            "Appending to existing code block: %p\n", Prev));
-
-        Prev->Method.AmlLength += AmlLength;
-    }
-
-    return_VOID;
-}
 
 /*******************************************************************************
  *

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -219,25 +219,19 @@ AcpiLoadTables (
             "While loading namespace from ACPI tables"));
     }
 
-    if (AcpiGbl_ExecuteTablesAsMethods)
+    /*
+     * Initialize the objects in the namespace that remain uninitialized.
+     * This runs the executable AML that may be part of the declaration of
+     * these name objects:
+     *     OperationRegions, BufferFields, Buffers, and Packages.
+     *
+     */
+    Status = AcpiNsInitializeObjects ();
+    if (ACPI_SUCCESS (Status))
     {
-        /*
-         * If the module-level code support is enabled, initialize the objects
-         * in the namespace that remain uninitialized. This runs the executable
-         * AML that may be part of the declaration of these name objects:
-         *     OperationRegions, BufferFields, Buffers, and Packages.
-         *
-         * Note: The module-level code is optional at this time, but will
-         * become the default in the future.
-         */
-        Status = AcpiNsInitializeObjects ();
-        if (ACPI_FAILURE (Status))
-        {
-            return_ACPI_STATUS (Status);
-        }
+        AcpiGbl_NamespaceInitialized = TRUE;
     }
 
-    AcpiGbl_NamespaceInitialized = TRUE;
     return_ACPI_STATUS (Status);
 }
 

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -301,14 +301,6 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_CopyDsdtLocally, FALSE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_DoNotUseXsdt, FALSE);
 
 /*
- * Optionally support module level code by parsing an entire table as
- * a method as it is loaded. Default is TRUE.
- * NOTE, this is essentially obsolete and will be removed soon
- * (01/2018).
- */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_ExecuteTablesAsMethods, TRUE);
-
-/*
  * Optionally use 32-bit FADT addresses if and when there is a conflict
  * (address mismatch) between the 32-bit and 64-bit versions of the
  * address. Although ACPICA adheres to the ACPI specification which

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -255,8 +255,6 @@ usage (
     ACPI_OPTION ("-df",                 "Disable Local fault handler");
     ACPI_OPTION ("-di",                 "Disable execution of STA/INI methods during init");
     ACPI_OPTION ("-do",                 "Disable Operation Region address simulation");
-    ACPI_OPTION ("-dp",                 "Disable loading DSDT/SSDT as a control method\n"
-                  "                      (enable legacy grouping of module-level code)");
     ACPI_OPTION ("-dr",                 "Disable repair of method return values");
     ACPI_OPTION ("-ds",                 "Disable method auto-serialization");
     ACPI_OPTION ("-dt",                 "Disable allocation tracking (performance)");
@@ -351,11 +349,6 @@ AeDoOptions (
         case 'o':
 
             AcpiGbl_DbOpt_NoRegionSupport = TRUE;
-            break;
-
-        case 'p':
-
-            AcpiGbl_ExecuteTablesAsMethods = FALSE;
             break;
 
         case 'r':
@@ -629,10 +622,6 @@ main (
 
     AcpiDbgLevel = ACPI_NORMAL_DEFAULT;
     AcpiDbgLayer = 0xFFFFFFFF;
-
-    /* Module-level code. Use new architecture */
-
-    AcpiGbl_ExecuteTablesAsMethods = TRUE;
 
     /*
      * Initialize ACPICA and start debugger thread.

--- a/source/tools/acpinames/anmain.c
+++ b/source/tools/acpinames/anmain.c
@@ -239,8 +239,6 @@ main (
 
     /* Set flags so that the interpreter is not used */
 
-    AcpiGbl_ExecuteTablesAsMethods = FALSE;
-
     Status = AcpiInitializeSubsystem ();
     ACPI_CHECK_OK (AcpiInitializeSubsystem, Status);
     if (ACPI_FAILURE (Status))


### PR DESCRIPTION
Module-level code refers to executable ASL code that runs during
table load. This is typically used in ASL to declare named objects
based on a condition evaluated during table load like so:

DefinitionBlock(...)
{
  OpreationRegion (OPR1, SystemMemory, ...)
  Field (OPR1)
  {
    FLD1, 8 /* Assume that FLD1's value is 0x1 */
  }

  /* The if statement below is referred to as module-level code */

  If (FLD1)
  {
    /* Declare DEV1 conditionally */
    Device (DEV1) {...}
  }

  Device (DEV2)
  {
    ...
  }
}

In legacy module-level code, the execution of the If statement
was deferred after other modules were loaded. The order of
code execution for the table above is the following:

1.) Load OPR1 to the ACPI Namespace
2.) Load FLD1 to the ACPI Namespace (not intended for drivers)
3.) Load DEV2 to the ACPI Namespace
4.) Execute If (FLD1) and load DEV1 if the condition is true

This legacy approach can be problematic for tables that look like the
following:

DefinitionBlock(...)
{
  OpreationRegion (OPR1, SystemMemory, ...)
  Field (OPR1)
  {
    FLD1, 8 /* Assume that FLD1's value is 0x1 */
  }

  /* The if statement below is referred to as module-level code */

  If (FLD1)
  {
    /* Declare DEV1 conditionally */
    Device (DEV1) {...}
  }

  Scope (DEV1)
  {
    /* Add objects DEV1's scope */
    Name (OBJ1, 0x1234)
  }
}

When loading this in the legacy approach, Scope DEV1 gets evaluated
before the If statement. The following is the order of execution:

1.) Load OPR1 to the ACPI Namespace
2.) Load FLD1 to the ACPI Namespace (not intended for drivers)
3.) Add OBJ1 under DEV1's scope -- ERROR. DEV1 does not exist
4.) Execute If (FLD1) and load DEV1 if the condition is true

The legacy approach can never succeed for tables like this due to the
deferral of the module-level code. Due to this limitation, a new
module-level code was developed. This new approach exeutes if
statements in the order that they appear in the definition block.
With this approach, the order of execution for the above defintion
block is as follows:

1.) Load OPR1 to the ACPI Namespace
2.) Load FLD1 to the ACPI Namespace (not intended for drivers)
3.) Execute If (FLD1) and load DEV1 because the condition is true
4.) Add OBJ1 under DEV1's scope.

Since DEV1 is loaded in the namespace in step 3, step 4 executes
successfully.

This change removes support for the legacy module-level code
execution. From this point onward, the new module-level code
execution will be the official approach.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>