### PR TITLE
iASL: add explanation for nameseg lexing, no functional change

### DIFF
--- a/source/compiler/aslcompiler.l
+++ b/source/compiler/aslcompiler.l
@@ -816,6 +816,13 @@ NamePathTail                [.]{NameSeg}
                                 s=UtLocalCacheCalloc (ACPI_NAME_SIZE + 1);
                                 if (strcmp (AslCompilertext, "\\"))
                                 {
+                                    /*
+                                     * According to the ACPI specification,
+                                     * NameSegments must have length of 4. If
+                                     * the NameSegment has length less than 4,
+                                     * they are padded with underscores to meet
+                                     * the required length.
+                                     */
                                     strcpy (s, "____");
                                     AcpiUtStrupr (AslCompilertext);
                                 }


### PR DESCRIPTION
I was looking at the lexer and had to think about this for a few minutes to realize what this part of the code base was doing. I added a short explanation