### PR TITLE
memory leak prototype: free the op upon ACPI error

### DIFF
--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -264,6 +264,11 @@ AcpiPsGetArguments (
                 GET_CURRENT_ARG_TYPE (WalkState->ArgTypes), &Arg);
             if (ACPI_FAILURE (Status))
             {
+                /*
+                 * Alternate solution: do not free the op and return.
+                 * Just keep and append the arg
+                 */
+                AcpiPsFreeOp (Arg);
                 return_ACPI_STATUS (Status);
             }
 


### PR DESCRIPTION
This cleans up parse ops non-nested methods like the following:

    Method (BADD)
    {
        Add (2, 1, OBJ1) // OBJ1 does not exist
    }

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>