### PR TITLE
utdecode: fix missing comma in array declaration AcpiGbl_GenericNotify

### DIFF
--- a/source/components/utilities/utdecode.c
+++ b/source/components/utilities/utdecode.c
@@ -632,7 +632,7 @@ static const char           *AcpiGbl_GenericNotify[ACPI_GENERIC_NOTIFY_MAX + 1] 
     /* 0B */ "System Locality Update",
     /* 0C */ "Reserved (was previously Shutdown Request)",  /* Reserved in ACPI 6.0 */
     /* 0D */ "System Resource Affinity Update",
-    /* 0E */ "Heterogeneous Memory Attributes Update"       /* ACPI 6.2 */
+    /* 0E */ "Heterogeneous Memory Attributes Update",      /* ACPI 6.2 */
     /* 0F */ "Error Disconnect Recover"                     /* ACPI 6.3 */
 };
 


### PR DESCRIPTION
There is a missing comma between strings on the array declaration. Fix
this by adding the missing comma.

Fixes: 205ac8fc7210 ("ACPI 6.3: add Error Disconnect Recover Notification value")
Signed-off-by: Colin Ian King <colin.king@canonical.com>