### PR TITLE
iASL: fix ww option by using the correct variable to index the array

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -1239,7 +1239,7 @@ AslElevateException (
         return (AE_LIMIT);
     }
 
-    AslGbl_ElevatedMessages[AslGbl_ExpectedMessagesIndex] = MessageId;
+    AslGbl_ElevatedMessages[AslGbl_ElevatedMessagesIndex] = MessageId;
     AslGbl_ElevatedMessagesIndex++;
     return (AE_OK);
 }


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>