### PR TITLE
Linux: use different debug default than ACPICA

### DIFF
--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -221,6 +221,11 @@
 #define ACPI_NO_ERROR_MESSAGES
 #undef ACPI_DEBUG_OUTPUT
 
+/* Use a specific bugging default separate from ACPICA */
+
+#undef ACPI_DEBUG_DEFAULT
+#define ACPI_DEBUG_DEFAULT          (ACPI_LV_INFO | ACPI_LV_REPAIR)
+
 /* External interface for __KERNEL__, stub is needed */
 
 #define ACPI_EXTERNAL_RETURN_STATUS(Prototype) \


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>