### PR TITLE
iASL: do not perform static analysis with -P option

### DIFF
--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -224,7 +224,6 @@ CmDoCompile (
         if (AslGbl_PreprocessOnly)
         {
             UtEndEvent (Event);
-            CmCleanupAndExit ();
             return (AE_OK);
         }
     }
@@ -919,7 +918,7 @@ CmCleanupAndExit (
      * We will delete the AML file if there are errors and the
      * force AML output option has not been used.
      */
-    if (AslGbl_ParserErrorDetected || ((AslGbl_ExceptionCount[ASL_ERROR] > 0) &&
+    if (AslGbl_ParserErrorDetected || AslGbl_PreprocessOnly || ((AslGbl_ExceptionCount[ASL_ERROR] > 0) &&
         (!AslGbl_IgnoreErrors) &&
         AslGbl_Files[ASL_FILE_AML_OUTPUT].Handle))
     {

--- a/source/compiler/aslmain.c
+++ b/source/compiler/aslmain.c
@@ -291,7 +291,8 @@ main (
     /*
      * At this point, compilation of a data table or disassembly is complete.
      */
-    if (AslGbl_FileType == ASL_INPUT_TYPE_ASCII_DATA || AcpiGbl_DisasmFlag)
+    if (AslGbl_PreprocessOnly || AcpiGbl_DisasmFlag ||
+        AslGbl_FileType == ASL_INPUT_TYPE_ASCII_DATA)
     {
         goto CleanupAndExit;
     }

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -541,7 +541,13 @@ UtDisplayOneSummary (
 {
     UINT32                  i;
     ASL_GLOBAL_FILE_NODE    *FileNode;
+    BOOLEAN                 DisplayAMLSummary;
 
+
+    DisplayAMLSummary =
+        !AslGbl_PreprocessOnly && !AslGbl_ParserErrorDetected &&
+        ((AslGbl_ExceptionCount[ASL_ERROR] == 0) || AslGbl_IgnoreErrors) &&
+        AslGbl_Files[ASL_FILE_AML_OUTPUT].Handle;
 
     if (FileId != ASL_FILE_STDOUT)
     {
@@ -595,9 +601,7 @@ UtDisplayOneSummary (
 
             /* AML summary */
 
-            if (!AslGbl_ParserErrorDetected &&
-                ((AslGbl_ExceptionCount[ASL_ERROR] == 0) || AslGbl_IgnoreErrors) &&
-                AslGbl_Files[ASL_FILE_AML_OUTPUT].Handle)
+            if (DisplayAMLSummary)
             {
                 FlPrintFile (FileId,
                     "%-14s %s - %7u bytes %6u opcodes  %6u named objects\n",
@@ -633,7 +637,7 @@ UtDisplayOneSummary (
             continue;
         }
 
-        FlPrintFile (FileId, "%14s %s - %u bytes\n",
+        FlPrintFile (FileId, "%-14s %s - %7u bytes\n",
             AslGbl_FileDescs[i].ShortDescription,
             AslGbl_Files[i].Filename, FlGetFileSize (i));
     }


### PR DESCRIPTION
This option only does preprocessing. No need to perform static
analysis.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>