### PR TITLE
Revert "iASL: use .src file handle only for include file error messages"

### DIFF
--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1105,10 +1105,6 @@ ASL_GLOBAL_FILE_NODE *
 FlGetCurrentFileNode (
     void);
 
-BOOLEAN
-FlInputFileExists (
-    char                    *InputFilename);
-
 
 /*
  * aslhwmap - hardware map summary

--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -869,16 +869,8 @@ static void AslInitEnode (
             return;
         }
 
-	if (!FlInputFileExists (Filename))
-	{
-            /*
-             * This means that this file is an include file. Record the .src
-             * file as the error message source because this file is not in
-             * the global file list.
-             */
-            Enode->SourceFilename =
-                FileNode->Files[ASL_FILE_SOURCE_OUTPUT].Filename;
-	}
+        Enode->SourceFilename =
+            FileNode->Files[ASL_FILE_SOURCE_OUTPUT].Filename;
     }
 }
 

--- a/source/compiler/aslfiles.c
+++ b/source/compiler/aslfiles.c
@@ -163,6 +163,10 @@ FlOpenIncludeWithPrefix (
     ACPI_PARSE_OBJECT       *Op,
     char                    *Filename);
 
+static BOOLEAN
+FlInputFileExists (
+    char                    *InputFilename);
+
 #ifdef ACPI_OBSOLETE_FUNCTIONS
 ACPI_STATUS
 FlParseInputPathname (
@@ -250,7 +254,7 @@ FlInitOneFile (
  *
  ******************************************************************************/
 
-BOOLEAN
+static BOOLEAN
 FlInputFileExists (
     char                    *Filename)
 {


### PR DESCRIPTION
This reverts commit 1eb3ee94b6ab2e231a5f7cdf7ca6388ff886c031.