### PR TITLE
iASL: stop clearing error log after parsing each file

### DIFF
--- a/source/compiler/aslstartup.c
+++ b/source/compiler/aslstartup.c
@@ -550,13 +550,9 @@ AslDoOneFile (
         Status = CmDoCompile ();
         if (ACPI_FAILURE (Status))
         {
+            PrTerminatePreprocessor ();
             return (Status);
         }
-
-        /* Cleanup (for next source file) and exit */
-
-        AeClearErrorLog ();
-        PrTerminatePreprocessor ();
 
         /*
          * At this point, we know how many lines are in the input file. Save it


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>