### PR TITLE
Revert "iASL: Additional forward reference detection (illegal)"

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -493,7 +493,7 @@ LdNamespace1Begin (
     case AML_FIELD_OP:
 
         Status = LdLoadFieldElements (Op, WalkState);
-        break;
+        return (Status);
 
     case AML_INT_CONNECTION_OP:
 
@@ -557,8 +557,7 @@ LdNamespace1Begin (
          * We only want references to named objects:
          *      Store (2, WXYZ) -> Attempt to resolve the name
          */
-        if ((OpInfo->Class == AML_CLASS_NAMED_OBJECT) &&
-            (OpInfo->Type != AML_TYPE_NAMED_FIELD))
+        if (OpInfo->Class == AML_CLASS_NAMED_OBJECT)
         {
             return (AE_OK);
         }

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -342,7 +342,7 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_RANGE */                      "Constant out of range",
 /*    ASL_MSG_BUFFER_ALLOCATION */          "Could not allocate line buffer",
 /*    ASL_MSG_MISSING_DEPENDENCY */         "Missing dependency",
-/*    ASL_MSG_ILLEGAL_FORWARD_REF */        "Forward references are not supported by the ASL language",
+/*    ASL_MSG_ILLEGAL_FORWARD_REF */        "Illegal forward reference",
 /*    ASL_MSG_ILLEGAL_METHOD_REF */         "Object is declared in a different method",
 /*    ASL_MSG_LOCAL_NOT_USED */             "Method Local is set but never used",
 /*    ASL_MSG_ARG_AS_LOCAL_NOT_USED */      "Method Argument (as a local) is set but never used",

--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -613,8 +613,7 @@ XfNamespaceLocateBegin (
         (Op->Asl.ParseOpcode != PARSEOP_NAMESTRING) &&
         (Op->Asl.ParseOpcode != PARSEOP_NAMESEG)    &&
         (Op->Asl.ParseOpcode != PARSEOP_METHODCALL) &&
-        (Op->Asl.ParseOpcode != PARSEOP_EXTERNAL)   &&
-        (OpInfo->Type != AML_TYPE_NAMED_FIELD))
+        (Op->Asl.ParseOpcode != PARSEOP_EXTERNAL))
     {
         return_ACPI_STATUS (AE_OK);
     }
@@ -638,8 +637,7 @@ XfNamespaceLocateBegin (
     if ((Op->Asl.ParseOpcode == PARSEOP_NAMESTRING) ||
         (Op->Asl.ParseOpcode == PARSEOP_NAMESEG)    ||
         (Op->Asl.ParseOpcode == PARSEOP_METHODCALL) ||
-        (Op->Asl.ParseOpcode == PARSEOP_EXTERNAL)   ||
-        (OpInfo->Type == AML_TYPE_NAMED_FIELD))
+        (Op->Asl.ParseOpcode == PARSEOP_EXTERNAL))
     {
         /*
          * These are name references, do not push the scope stack
@@ -675,10 +673,6 @@ XfNamespaceLocateBegin (
         }
 
         Path = NextOp->Asl.Value.String;
-    }
-    else if (OpInfo->Type == AML_TYPE_NAMED_FIELD)
-    {
-        Path = Op->Asl.Child->Asl.Value.String;
     }
     else
     {


### PR DESCRIPTION
This reverts commit 3132320003b348bcf48274d4e326e496ffc4b23b.

This commit unintentionally emitted AML bytecode with incorrect
package lengths for some ASL code related to Fields and
OperationRegions. This mal-formed AML can cause systems to crash
during boot.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>