### PR TITLE
iASL: ensure that _WAK and _PTS are declared only at the root scope

### DIFF
--- a/source/compiler/asldefine.h
+++ b/source/compiler/asldefine.h
@@ -298,4 +298,20 @@
 #define COMMENT_CAPTURE_ON    AslGbl_CommentState.CaptureComments = TRUE;
 #define COMMENT_CAPTURE_OFF   AslGbl_CommentState.CaptureComments = FALSE;
 
+/*
+ * Special name segments - these must only be declared at the root scope
+ */
+#define NAMESEG__PTS    "_PTS"
+#define NAMESEG__WAK    "_WAK"
+#define NAMESEG__S0     "_S0_"
+#define NAMESEG__S1     "_S1_"
+#define NAMESEG__S2     "_S2_"
+#define NAMESEG__S3     "_S3_"
+#define NAMESEG__S4     "_S4_"
+#define NAMESEG__S5     "_S5_"
+#define NAMESEG__TTS    "_TTS"
+
+#define MAX_SPECIAL_NAMES      9
+
+
 #endif /* ASLDEFINE.H */

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -223,11 +223,26 @@ const char                          *AslGbl_OpFlagNames[ACPI_NUM_OP_FLAGS] =
     "OP_NOT_FOUND_DURING_LOAD"
 };
 
+const char                          *AslGbl_SpecialNamedObjects [MAX_SPECIAL_NAMES] =
+{
+    NAMESEG__PTS,
+    NAMESEG__WAK,
+    NAMESEG__S0,
+    NAMESEG__S1,
+    NAMESEG__S2,
+    NAMESEG__S3,
+    NAMESEG__S4,
+    NAMESEG__S5,
+    NAMESEG__TTS
+};
+
 #else
 extern ASL_FILE_DESC                AslGbl_FileDescs [ASL_NUM_FILES];
 extern UINT32                       AslGbl_ExceptionCount[ASL_NUM_REPORT_LEVELS];
 extern const char                   *AslGbl_OpFlagNames[ACPI_NUM_OP_FLAGS];
+extern const char                   *AslGbl_SpecialNamedObjects[MAX_SPECIAL_NAMES];
 #endif
+
 
 
 /*

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -190,6 +190,10 @@ LdCommonNamespaceEnd (
     UINT32                  Level,
     void                    *Context);
 
+static void
+LdCheckSpecialNames (
+    ACPI_NAMESPACE_NODE     *Node,
+    ACPI_PARSE_OBJECT       *Op);
 
 /*******************************************************************************
  *
@@ -966,6 +970,10 @@ LdNamespace1Begin (
         }
     }
 
+    /* Check special names like _WAK and _PTS */
+
+    LdCheckSpecialNames (Node, Op);
+
     if (ForceNewScope)
     {
         Status = AcpiDsScopeStackPush (Node, ObjectType, WalkState);
@@ -1001,6 +1009,42 @@ FinishNode:
     }
 
     return_ACPI_STATUS (Status);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    LdCheckSpecialNames
+ *
+ * PARAMETERS:  Node        - Node that represents the named object
+ *              Op          - Named object declaring this named object
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Check if certain named objects are declared in the incorrect
+ *              scope. Special named objects are listed in
+ *              AslGbl_SpecialNamedObjects and can only be declared at the root
+ *              scope.
+ *
+ ******************************************************************************/
+
+static void
+LdCheckSpecialNames (
+    ACPI_NAMESPACE_NODE     *Node,
+    ACPI_PARSE_OBJECT       *Op)
+{
+    UINT32                  i;
+
+
+    for (i = 0; i < MAX_SPECIAL_NAMES; i++)
+    {
+        if (ACPI_COMPARE_NAMESEG(Node->Name.Ascii, AslGbl_SpecialNamedObjects[i]) &&
+            Node->Parent != AcpiGbl_RootNode)
+        {
+            AslError (ASL_ERROR, ASL_MSG_INVALID_SPECIAL_NAME, Op, Op->Asl.ExternalName);
+            return;
+        }
+    }
 }
 
 

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -365,7 +365,8 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_REGION_LENGTH */              "Operation Region declared with zero length",
 /*    ASL_MSG_TEMPORARY_OBJECT */           "Object is created temporarily in another method and cannot be accessed",
 /*    ASL_MSG_UNDEFINED_EXTERNAL */         "Named object was declared external but the actual definition does not exist",
-/*    ASL_MSG_BUFFER_FIELD_OVERFLOW */        "Buffer field extends beyond end of target buffer"
+/*    ASL_MSG_BUFFER_FIELD_OVERFLOW */      "Buffer field extends beyond end of target buffer",
+/*    ASL_MSG_INVALID_SPECIAL_NAME */       "declaration of this named object outside root scope is illegal"
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -368,6 +368,7 @@ typedef enum
     ASL_MSG_TEMPORARY_OBJECT,
     ASL_MSG_UNDEFINED_EXTERNAL,
     ASL_MSG_BUFFER_FIELD_OVERFLOW,
+    ASL_MSG_INVALID_SPECIAL_NAME,
 
     /* These messages are used by the Data Table compiler only */
 


### PR DESCRIPTION
_WAK and _PTS in any other scope will not be invoked by OS.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>