### PR TITLE
iASL: fix type mismatch on IndexField

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -164,6 +164,7 @@
 
 static ACPI_STATUS
 LdLoadFieldElements (
+    UINT32                  AmlType,
     ACPI_PARSE_OBJECT       *Op,
     ACPI_WALK_STATE         *WalkState);
 
@@ -247,7 +248,8 @@ LdLoadNamespace (
  *
  * FUNCTION:    LdLoadFieldElements
  *
- * PARAMETERS:  Op              - Parent node (Field)
+ * PARAMETERS:  AmlType         - Type to search
+ *              Op              - Parent node (Field)
  *              WalkState       - Current walk state
  *
  * RETURN:      Status
@@ -259,6 +261,7 @@ LdLoadNamespace (
 
 static ACPI_STATUS
 LdLoadFieldElements (
+    UINT32                  AmlType,
     ACPI_PARSE_OBJECT       *Op,
     ACPI_WALK_STATE         *WalkState)
 {
@@ -274,7 +277,7 @@ LdLoadFieldElements (
     {
         Status = AcpiNsLookup (WalkState->ScopeInfo,
             SourceRegion->Asl.Value.String,
-            ACPI_TYPE_REGION, ACPI_IMODE_EXECUTE,
+            AmlType, ACPI_IMODE_EXECUTE,
             ACPI_NS_DONT_OPEN_SCOPE, NULL, &Node);
         if (Status == AE_NOT_FOUND)
         {
@@ -507,11 +510,15 @@ LdNamespace1Begin (
      */
     switch (Op->Asl.AmlOpcode)
     {
-    case AML_BANK_FIELD_OP:
     case AML_INDEX_FIELD_OP:
+
+        Status = LdLoadFieldElements (ACPI_TYPE_LOCAL_REGION_FIELD, Op, WalkState);
+        return (Status);
+
+    case AML_BANK_FIELD_OP:
     case AML_FIELD_OP:
 
-        Status = LdLoadFieldElements (Op, WalkState);
+        Status = LdLoadFieldElements (ACPI_TYPE_REGION, Op, WalkState);
         return (Status);
 
     case AML_INT_CONNECTION_OP:


### PR DESCRIPTION
By definition, Index field should be based off of Field units rather
than Operation Regions.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>