### PR TITLE
ACPICA: Clear status of GPEs on first direct enable

### DIFF
--- a/source/components/events/evgpe.c
+++ b/source/components/events/evgpe.c
@@ -316,6 +316,7 @@ AcpiEvMaskGpe (
  * FUNCTION:    AcpiEvAddGpeReference
  *
  * PARAMETERS:  GpeEventInfo            - Add a reference to this GPE
+ *              ClearOnEnable           - Clear GPE status before enabling it
  *
  * RETURN:      Status
  *
@@ -326,7 +327,8 @@ AcpiEvMaskGpe (
 
 ACPI_STATUS
 AcpiEvAddGpeReference (
-    ACPI_GPE_EVENT_INFO     *GpeEventInfo)
+    ACPI_GPE_EVENT_INFO     *GpeEventInfo,
+    BOOLEAN                 ClearOnEnable)
 {
     ACPI_STATUS             Status = AE_OK;
 
@@ -343,6 +345,11 @@ AcpiEvAddGpeReference (
     if (GpeEventInfo->RuntimeCount == 1)
     {
         /* Enable on first reference */
+
+        if (ClearOnEnable)
+        {
+            (void) AcpiHwClearGpe (GpeEventInfo);
+        }
 
         Status = AcpiEvUpdateGpeEnableMask (GpeEventInfo);
         if (ACPI_SUCCESS (Status))

--- a/source/components/events/evgpeblk.c
+++ b/source/components/events/evgpeblk.c
@@ -637,7 +637,7 @@ AcpiEvInitializeGpeBlock (
                 continue;
             }
 
-            Status = AcpiEvAddGpeReference (GpeEventInfo);
+            Status = AcpiEvAddGpeReference (GpeEventInfo, FALSE);
             if (ACPI_FAILURE (Status))
             {
                 ACPI_EXCEPTION ((AE_INFO, Status,

--- a/source/components/events/evxface.c
+++ b/source/components/events/evxface.c
@@ -1256,7 +1256,7 @@ AcpiRemoveGpeHandler (
             ACPI_GPE_DISPATCH_NOTIFY)) &&
         Handler->OriginallyEnabled)
     {
-        (void) AcpiEvAddGpeReference (GpeEventInfo);
+        (void) AcpiEvAddGpeReference (GpeEventInfo, FALSE);
         if (ACPI_GPE_IS_POLLING_NEEDED (GpeEventInfo))
         {
             /* Poll edge triggered GPEs to handle existing events */

--- a/source/components/events/evxfgpe.c
+++ b/source/components/events/evxfgpe.c
@@ -267,7 +267,7 @@ AcpiEnableGpe (
         if (ACPI_GPE_DISPATCH_TYPE (GpeEventInfo->Flags) !=
             ACPI_GPE_DISPATCH_NONE)
         {
-            Status = AcpiEvAddGpeReference (GpeEventInfo);
+            Status = AcpiEvAddGpeReference (GpeEventInfo, TRUE);
             if (ACPI_SUCCESS (Status) &&
                 ACPI_GPE_IS_POLLING_NEEDED (GpeEventInfo))
             {

--- a/source/include/acevents.h
+++ b/source/include/acevents.h
@@ -245,7 +245,8 @@ AcpiEvMaskGpe (
 
 ACPI_STATUS
 AcpiEvAddGpeReference (
-    ACPI_GPE_EVENT_INFO     *GpeEventInfo);
+    ACPI_GPE_EVENT_INFO     *GpeEventInfo,
+    BOOLEAN                 ClearOnEnable);
 
 ACPI_STATUS
 AcpiEvRemoveGpeReference (


### PR DESCRIPTION
ACPI GPEs (other than the EC one) can be enabled in two situations.
First, the GPEs with existing _Lxx and _Exx methods are enabled
implicitly by ACPICA during system initialization.  Second, the GPEs
without these methods (like GPEs listed by _PRW objects for wakeup
devices) need to be enabled directly by the code that is going to use
them (e.g. ACPI power management or device drivers).

In the former case, if the status of a given GPE is set to start
with, its handler method (either _Lxx or _Exx) needs to be invoked to
take care of the events (possibly) signaled before the GPE was
enabled. In the latter case, however, the first caller of
acpi_enable_gpe() for a given GPE should not be expected to care
about any events that might be signaled through it earlier.  In that
case, it is better to clear the status of the GPE before enabling it,
to prevent stale events from triggering unwanted actions (like
spurious system resume, for example).

For this reason, modify acpi_ev_add_gpe_reference() to take an
additional boolean argument indicating whether or not the GPE status
needs to be cleared when its reference counter changes from zero to
one and make acpi_enable_gpe() pass TRUE to it through that new
argument.

Fixes: 18996f2db918 ("ACPICA: Events: Stop unconditionally clearing ACPI IRQs during suspend/resume")
Reported-by: Furquan Shaikh <furquan@google.com>
Tested-by: Furquan Shaikh <furquan@google.com>
Tested-by: Mika Westerberg <mika.westerberg@linux.intel.com>
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>