### PR TITLE
Debugger: remove redundant assignment on ObjDesc

### DIFF
--- a/source/components/debugger/dbobject.c
+++ b/source/components/debugger/dbobject.c
@@ -567,7 +567,6 @@ AcpiDbDecodeLocals (
 
 
     Node = WalkState->MethodNode;
-    ObjDesc = WalkState->MethodDesc;
 
     /* There are no locals for the module-level code case */
 


### PR DESCRIPTION
Pointer ObjDesc is being initialized with a value that is never
read and it is being updated later with a new value. The initialization
is redundant and can be removed.

Addresses-Coverity: ("Unused value")
Signed-off-by: Colin Ian King <colin.king@canonical.com>