### PR TITLE
Table load: exit interpreter before initializing objects

### DIFF
--- a/source/components/executer/exconfig.c
+++ b/source/components/executer/exconfig.c
@@ -344,7 +344,9 @@ AcpiExLoadTableOp (
 
     /* Complete the initialization/resolution of new objects */
 
-    AcpiNsInitializeObjects ();
+    AcpiExExitInterpreter();
+    AcpiNsInitializeObjects();
+    AcpiExEnterInterpreter();
 
     /* Parameter Data (optional) */
 


### PR DESCRIPTION
This prevents re-acquiring the interpreter lock when loading tables

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>