### PR TITLE
iASL: return -1 if AML files were not generated due to compiler errors

### DIFF
--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -853,10 +853,11 @@ CmDumpAllEvents (
  *
  ******************************************************************************/
 
-void
+int
 CmCleanupAndExit (
     void)
 {
+    int                     Status = 0;
     BOOLEAN                 DeleteAmlFile = FALSE;
     ASL_GLOBAL_FILE_NODE    *CurrentFileNode = AslGbl_FilesList;
 
@@ -915,14 +916,21 @@ CmCleanupAndExit (
     UtDisplaySummary (ASL_FILE_STDOUT);
 
     /*
-     * We will delete the AML file if there are errors and the
-     * force AML output option has not been used.
+     * Delete the AML file if there are errors and the force AML output option
+     * (-f) has not been used.
+     *
+     * Return -1 as a status of the compiler if no AML files are generated. If
+     * the AML file is generated in the presence of errors, return 0. In the
+     * latter case, the errors were ignored by the user so the compilation is
+     * considered successful.
      */
-    if (AslGbl_ParserErrorDetected || AslGbl_PreprocessOnly || ((AslGbl_ExceptionCount[ASL_ERROR] > 0) &&
+    if (AslGbl_ParserErrorDetected || AslGbl_PreprocessOnly ||
+        ((AslGbl_ExceptionCount[ASL_ERROR] > 0) &&
         (!AslGbl_IgnoreErrors) &&
         AslGbl_Files[ASL_FILE_AML_OUTPUT].Handle))
     {
         DeleteAmlFile = TRUE;
+        Status = -1;
     }
 
     /* Close all open files */
@@ -952,6 +960,8 @@ CmCleanupAndExit (
     {
         UtDeleteLocalCaches ();
     }
+
+    return (Status);
 }
 
 

--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -266,7 +266,7 @@ void
 CmDoOutputFiles (
     void);
 
-void
+int
 CmCleanupAndExit (
     void);
 

--- a/source/compiler/aslmain.c
+++ b/source/compiler/aslmain.c
@@ -350,7 +350,7 @@ CleanupAndExit:
 
     if (!AcpiGbl_DisasmFlag)
     {
-        CmCleanupAndExit ();
+        ReturnStatus = CmCleanupAndExit ();
     }
 
 


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>