### PR TITLE
iASL: add null terminator to name strings that only consist of multip…

### DIFF
--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1288,6 +1288,10 @@ UtInternalizeName (
     char                    *ExternalName,
     char                    **ConvertedName);
 
+BOOLEAN
+UtNameContainsAllPrefix (
+    ACPI_PARSE_OBJECT       *Op);
+
 void
 UtAttachNamepathToOwner (
     ACPI_PARSE_OBJECT       *Op,

--- a/source/compiler/asllength.c
+++ b/source/compiler/asllength.c
@@ -479,12 +479,13 @@ CgGenerateAmlLengths (
         Op->Asl.AmlLength = strlen (Buffer);
 
         /*
-         * Check for single backslash reference to root,
-         * make it a null terminated string in the AML
+         * Check for single backslash reference to root or reference to a name
+         * consisting of only prefix (^) characters. Make it a null terminated
+         * string in the AML.
          */
-        if (Op->Asl.AmlLength == 1)
+        if (Op->Asl.AmlLength == 1 || UtNameContainsAllPrefix(Op))
         {
-            Op->Asl.AmlLength = 2;
+            Op->Asl.AmlLength++;
         }
         break;
 

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -994,6 +994,37 @@ UtAttachNamepathToOwner (
 
 /*******************************************************************************
  *
+ * FUNCTION:    UtNameContainsAllPrefix
+ *
+ * PARAMETERS:  Op                  - Op containing NameString
+ *
+ * RETURN:      NameString consists of all ^ characters
+ *
+ * DESCRIPTION: Determine if this Op contains a name segment that consists of
+ *              all '^' characters.
+ *
+ ******************************************************************************/
+
+BOOLEAN
+UtNameContainsAllPrefix (
+    ACPI_PARSE_OBJECT       *Op)
+{
+    UINT32                  Length = Op->Asl.AmlLength;
+    UINT32                  i;
+
+    for (i = 0; i < Length; i++)
+    {
+        if (Op->Asl.Value.String[i] != '^')
+        {
+            return (FALSE);
+        }
+    }
+
+    return (TRUE);
+}
+
+/*******************************************************************************
+ *
  * FUNCTION:    UtDoConstant
  *
  * PARAMETERS:  String              - Hex/Decimal/Octal


### PR DESCRIPTION
…le prefixes (^)

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>