### PR TITLE
iASL: emit error when _UID under a processor object is a string

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -1031,7 +1031,8 @@ FinishNode:
  * DESCRIPTION: Check if certain named objects are declared in the incorrect
  *              scope. Special named objects are listed in
  *              AslGbl_SpecialNamedObjects and can only be declared at the root
- *              scope.
+ *              scope. _UID inside of a processor declaration must not be a
+ *              string.
  *
  ******************************************************************************/
 
@@ -1051,6 +1052,13 @@ LdCheckSpecialNames (
             AslError (ASL_ERROR, ASL_MSG_INVALID_SPECIAL_NAME, Op, Op->Asl.ExternalName);
             return;
         }
+    }
+
+    if (ACPI_COMPARE_NAMESEG (Node->Name.Ascii, "_UID") &&
+        Node->Parent->Type == ACPI_TYPE_PROCESSOR &&
+        Node->Type == ACPI_TYPE_STRING)
+    {
+        AslError (ASL_ERROR, ASL_MSG_INVALID_PROCESSOR_UID , Op, "found a string");
     }
 }
 

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -366,7 +366,8 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_TEMPORARY_OBJECT */           "Object is created temporarily in another method and cannot be accessed",
 /*    ASL_MSG_UNDEFINED_EXTERNAL */         "Named object was declared external but the actual definition does not exist",
 /*    ASL_MSG_BUFFER_FIELD_OVERFLOW */      "Buffer field extends beyond end of target buffer",
-/*    ASL_MSG_INVALID_SPECIAL_NAME */       "declaration of this named object outside root scope is illegal"
+/*    ASL_MSG_INVALID_SPECIAL_NAME */       "declaration of this named object outside root scope is illegal",
+/*    ASL_MSG_INVALID_PROCESSOR_UID */      "_UID inside processor declaration must be an integer"
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -369,6 +369,7 @@ typedef enum
     ASL_MSG_UNDEFINED_EXTERNAL,
     ASL_MSG_BUFFER_FIELD_OVERFLOW,
     ASL_MSG_INVALID_SPECIAL_NAME,
+    ASL_MSG_INVALID_PROCESSOR_UID,
 
     /* These messages are used by the Data Table compiler only */
 


### PR DESCRIPTION
_UID under a processor object must evaluate to an integer rather than
a string.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>