### PR TITLE
Remove unintentional call to delete walkstate

### DIFF
--- a/source/components/dispatcher/dsmethod.c
+++ b/source/components/dispatcher/dsmethod.c
@@ -761,7 +761,6 @@ AcpiDsCallControlMethod (
         }
     }
 
-    AcpiDsDeleteWalkState(NextWalkState);
     return_ACPI_STATUS (Status);
 
 


### PR DESCRIPTION
This line was added unintentionally in commit db2638cca.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>