### PR TITLE
iASL: add warning on legacy ASL Processor() keyword

### DIFF
--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -367,7 +367,8 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_UNDEFINED_EXTERNAL */         "Named object was declared external but the actual definition does not exist",
 /*    ASL_MSG_BUFFER_FIELD_OVERFLOW */      "Buffer field extends beyond end of target buffer",
 /*    ASL_MSG_INVALID_SPECIAL_NAME */       "declaration of this named object outside root scope is illegal",
-/*    ASL_MSG_INVALID_PROCESSOR_UID */      "_UID inside processor declaration must be an integer"
+/*    ASL_MSG_INVALID_PROCESSOR_UID */      "_UID inside processor declaration must be an integer",
+/*    ASL_MSG_LEGACY_PROCESSOR_OP */        "Legacy Processor() keyword detected. Use Device() keyword instead."
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -370,6 +370,7 @@ typedef enum
     ASL_MSG_BUFFER_FIELD_OVERFLOW,
     ASL_MSG_INVALID_SPECIAL_NAME,
     ASL_MSG_INVALID_PROCESSOR_UID,
+    ASL_MSG_LEGACY_PROCESSOR_OP,
 
     /* These messages are used by the Data Table compiler only */
 

--- a/source/compiler/asltransform.c
+++ b/source/compiler/asltransform.c
@@ -507,6 +507,12 @@ TrTransformSubtree (
         }
         break;
 
+    case PARSEOP_PROCESSOR:
+
+        AslError (ASL_WARNING, ASL_MSG_LEGACY_PROCESSOR_OP, Op, Op->Asl.ExternalName);
+
+        break;
+
     default:
 
         /* Nothing to do here for other opcodes */


### PR DESCRIPTION
The ASL Processor() object has been deprecated in ACPI 6.0

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>