### PR TITLE
iASL: fix compile-time statistics for data table compiler

### DIFF
--- a/source/compiler/aslmain.c
+++ b/source/compiler/aslmain.c
@@ -282,7 +282,6 @@ main (
         if (ACPI_FAILURE (Status))
         {
             ReturnStatus = -1;
-            goto CleanupAndExit;
         }
 
         Index2++;

--- a/source/compiler/asltypes.h
+++ b/source/compiler/asltypes.h
@@ -505,6 +505,8 @@ typedef struct asl_files_node
     UINT32                  TotalLineCount;
     UINT32                  OriginalInputFileSize;
     UINT32                  TotalKeywords;
+    UINT32                  TotalFields;
+    UINT32                  OutputByteLength;
     UINT32                  TotalNamedObjects;
     UINT32                  TotalExecutableOpcodes;
     BOOLEAN                 ParserErrorDetected;

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -559,58 +559,53 @@ UtDisplayOneSummary (
 
     /* Summary of main input and output files */
 
-    if (AslGbl_FileType == ASL_INPUT_TYPE_ASCII_DATA)
+    FileNode = FlGetCurrentFileNode ();
+    if (!FileNode)
+    {
+        fprintf (stderr, "Summary could not be generated");
+        return;
+    }
+
+    if (FileNode->ParserErrorDetected)
+    {
+        FlPrintFile (FileId,
+            "%-14s %s - Compilation aborted due to parser-detected syntax error(s)\n",
+            "Input file:", AslGbl_Files[ASL_FILE_INPUT].Filename);
+    }
+    else if (AslGbl_FileType == ASL_INPUT_TYPE_ASCII_DATA)
     {
         FlPrintFile (FileId,
             "%-14s %s - %u lines, %u bytes, %u fields\n",
             "Table Input:",
-            AslGbl_Files[ASL_FILE_INPUT].Filename, AslGbl_CurrentLineNumber,
-            AslGbl_InputByteCount, AslGbl_InputFieldCount);
+            AslGbl_Files[ASL_FILE_INPUT].Filename, FileNode->TotalLineCount,
+            FileNode->OriginalInputFileSize, FileNode->TotalFields);
 
-        if ((AslGbl_ExceptionCount[ASL_ERROR] == 0) || (AslGbl_IgnoreErrors))
-        {
-            FlPrintFile (FileId,
-                "%-14s %s - %u bytes\n",
-                "Binary Output:",
-                AslGbl_Files[ASL_FILE_AML_OUTPUT].Filename, AslGbl_TableLength);
-        }
+        FlPrintFile (FileId,
+            "%-14s %s - %u bytes\n",
+            "Binary Output:",
+            AslGbl_Files[ASL_FILE_AML_OUTPUT].Filename, FileNode->OutputByteLength);
     }
-    else
+    else if (AslGbl_FileType == ASL_INPUT_TYPE_ASCII_ASL)
     {
-        FileNode = FlGetCurrentFileNode ();
-        if (!FileNode)
-        {
-            fprintf (stderr, "Summary could not be generated");
-            return;
-        }
-        if (FileNode->ParserErrorDetected)
+        FlPrintFile (FileId,
+            "%-14s %s - %7u bytes %6u keywords %6u source lines\n",
+            "ASL Input:",
+            AslGbl_Files[ASL_FILE_INPUT].Filename,
+            FileNode->OriginalInputFileSize,
+            FileNode->TotalKeywords,
+            FileNode->TotalLineCount);
+
+        /* AML summary */
+
+        if (DisplayAMLSummary)
         {
             FlPrintFile (FileId,
-                "%-14s %s - Compilation aborted due to parser-detected syntax error(s)\n",
-                "ASL Input:", AslGbl_Files[ASL_FILE_INPUT].Filename);
-        }
-        else
-        {
-            FlPrintFile (FileId,
-                "%-14s %s - %7u bytes %6u keywords %6u source lines\n",
-                "ASL Input:",
-                AslGbl_Files[ASL_FILE_INPUT].Filename,
-                FileNode->OriginalInputFileSize,
-                FileNode->TotalKeywords,
-                FileNode->TotalLineCount);
-
-            /* AML summary */
-
-            if (DisplayAMLSummary)
-            {
-                FlPrintFile (FileId,
-                    "%-14s %s - %7u bytes %6u opcodes  %6u named objects\n",
-                    "AML Output:",
-                    AslGbl_Files[ASL_FILE_AML_OUTPUT].Filename,
-                    FlGetFileSize (ASL_FILE_AML_OUTPUT),
-                    FileNode->TotalExecutableOpcodes,
-                    FileNode->TotalNamedObjects);
-            }
+                "%-14s %s - %7u bytes %6u opcodes  %6u named objects\n",
+                "AML Output:",
+                AslGbl_Files[ASL_FILE_AML_OUTPUT].Filename,
+                FlGetFileSize (ASL_FILE_AML_OUTPUT),
+                FileNode->TotalExecutableOpcodes,
+                FileNode->TotalNamedObjects);
         }
     }
 


### PR DESCRIPTION
When compiling multiple tables, the global file node struct is used
to keep statistics for each input file. This change adds support for
using global file nodes to keep track of statistics for each data
table including total line conut, total field count, errors detected
during parsing.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>