### PR TITLE
Data table enhancements

### DIFF
--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -233,6 +233,7 @@ DtDoCompile (
         DtCompilerInitLexer (AslGbl_Files[ASL_FILE_INPUT].Handle);
         DtCompilerParserparse ();
         FieldList = AslGbl_FieldList;
+        DtCompilerTerminateLexer ();
 
         UtEndEvent (Event);
     }
@@ -274,6 +275,8 @@ DtDoCompile (
     {
         FileNode->TotalLineCount = AslGbl_CurrentLineNumber;
         FileNode->OriginalInputFileSize = AslGbl_InputByteCount;
+        DbgPrint (ASL_PARSE_OUTPUT, "Line count: %u input file size: %u\n",
+                FileNode->TotalLineCount, FileNode->OriginalInputFileSize);
     }
 
     if (ACPI_FAILURE (Status))

--- a/source/compiler/dtcompilerparser.l
+++ b/source/compiler/dtcompilerparser.l
@@ -240,4 +240,10 @@ void
 DtCompilerTerminateLexer (
     void)
 {
+    /*
+     * Flex/Bison increments the lineno for the EOF so decrement by 1 to get
+     * the correct number of lines.
+     */
+    AslGbl_CurrentLineNumber = DtCompilerParserlineno - 1;
+    AslGbl_InputByteCount = DtCompilerParserByteOffset;
 }

--- a/source/compiler/dtcompilerparser.l
+++ b/source/compiler/dtcompilerparser.l
@@ -177,6 +177,9 @@ int DtCompilerParserByteOffset = 0;
 
 %option nounput noinput yylineno
 
+    /* Indicates a state used for parsing multiline C comments */
+%x ML_COMMENT
+
 WhiteSpace      [ \t\v\r]+
 NewLines        [\n]+
 
@@ -186,6 +189,13 @@ StringData      [0-9a-zA-Z\\_][ 0-9a-zA-Z]*
 Comment         \[{Text}\]
 
 %%
+
+"/*"                     { BEGIN (ML_COMMENT); }
+<ML_COMMENT>"*/"         { BEGIN (INITIAL); }
+<ML_COMMENT>"*/\n"       { BEGIN (INITIAL); }
+<ML_COMMENT>([^*]|\n)+|. /* Ignore */
+"//".*                   /* Ignore */
+
 
 {WhiteSpace}     /* Ignore */
 {Comment}        /* Ignore */

--- a/source/compiler/dtcompilerparser.l
+++ b/source/compiler/dtcompilerparser.l
@@ -203,7 +203,7 @@ Comment         \[{Text}\]
                    char *s;
                    int size = strlen (DtCompilerParsertext);
                    s=UtLocalCacheCalloc (size + 1);
-                   AcpiUtSafeStrcpy (s, size, DtCompilerParsertext);
+                   AcpiUtSafeStrncpy (s, DtCompilerParsertext, size + 1);
                    DtCompilerParserlval.s = s;
                    DbgPrint (ASL_PARSE_OUTPUT, "Data: %s\n", s);
                    return (DT_PARSEOP_DATA);
@@ -213,9 +213,9 @@ Comment         \[{Text}\]
                    char *s;
                    int size = strlen (DtCompilerParsertext);
                    s=UtLocalCacheCalloc (size - 1);
-                   AcpiUtSafeStrcpy (s, size - 2, DtCompilerParsertext + 1);
+                   AcpiUtSafeStrncpy (s, DtCompilerParsertext + 1, size - 1);
                    DtCompilerParserlval.s = s;
-                   DbgPrint (ASL_PARSE_OUTPUT, "Data: %s\n", s);
+                   DbgPrint (ASL_PARSE_OUTPUT, "String Data: %s\n", s);
                    return (DT_PARSEOP_STRING_DATA);
                  }
 


### PR DESCRIPTION
This adds support for /* ... */ and // comments, uses AcpiUtSafeStrncpy instead of strcpy in the lexer, and fixes compile-time statistics for the data table compiler