### PR TITLE
ASLTS: add iASL template test suite

### DIFF
--- a/tests/aslts.sh
+++ b/tests/aslts.sh
@@ -116,6 +116,29 @@ build_acpi_tools() {
 	cd $restore_dir
 }
 
+# Run a simple compiler test.
+# This test does the following:
+# 1 generate all sample tables in the compiler
+# 2 compile all tables (.asl -> .aml)
+# 3 disassembles all tables (.aml -> .dsl)
+# 4 recompiles all all tables (.dsl -> recomp.aml)
+# 5 runs binary comparison between .aml and recomp.aml
+run_compiler_template_test()
+{
+	pushd templates
+
+	rm -f *.asl *.aml *.dsl
+
+	iasl -T all 2> /dev/null
+	for filename in *.asl
+	do
+		make -s NAME=$(basename "$filename" .asl)
+	done
+
+	rm -f *.asl *.aml *.dsl
+	popd
+}
+
 
 # Compile and run the ASLTS suite
 run_aslts() {
@@ -123,6 +146,10 @@ run_aslts() {
 	# Remove a previous version of the AML test code
 	version=`$ASL | grep version | awk '{print $5}'`
 	rm -rf $ASLTSDIR/tmp/aml/$version
+
+	# run templates test
+
+	run_compiler_template_test
 
 	if [ "x$TEST_MODES" = "x" ]; then
 		TEST_MODES="n32 n64 o32 o64"

--- a/tests/templates/Makefile
+++ b/tests/templates/Makefile
@@ -1,9 +1,34 @@
+# Before running this file, we assume we have generated all tables by running
+# the command `iasl -T ALL`
+#
+# Note: the NAME flag is required when running the test
 
-PROG= templates
+aml_obj=$(NAME).aml
+dsl_obj=$(NAME).dsl
+aml_obj2=$(NAME)_recomp.aml
+
+
+all: $(aml_obj2)
+
+# recompile and binary compare
+$(aml_obj2): %_recomp.aml: %.dsl
+	iasl -p `basename $@` $< > /dev/null 2> /dev/null
+	acpibin -c $@ $(patsubst %_recomp.aml,%.aml,$@) > /dev/null 2> /dev/null
+	printf "Data table %s PASS\n" $(basename $< .dsl)
+
+# disassemble
+$(dsl_obj): %.dsl:  %.aml
+	iasl -d $< > /dev/null 2> /dev/null
+
+# initial compile
+$(aml_obj): %.aml:  %.asl
+	iasl $< > /dev/null 2> /dev/null
+
 
 templates :
 	sh templates.sh
 
-clean :
+.PHONY: clean
+clean:
 	rm -f *.asl *.aml *.dsl *.hex diff.log
 


### PR DESCRIPTION
For each template supported by iASL, this test suite does the
following:

    1) Compile with iASL
    2) Disassemble .aml file generated from 1)
    3) Re-compile .dsl file generated from 2)
    4) Use acpibin to compare files generated from 1) and 3) using
       acpibin

This test exercises the data table compiler as well as the data table
disassembler.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>