### PR TITLE
FreeBSD: Enable ACPICA mutex debugging in INVARIANTS case.

### DIFF
--- a/source/include/platform/acfreebsd.h
+++ b/source/include/platform/acfreebsd.h
@@ -203,6 +203,10 @@
 
 #define DEBUGGER_THREADING  0   /* integrated with DDB */
 
+#ifdef INVARIANTS
+#define ACPI_MUTEX_DEBUG
+#endif
+
 #else /* _KERNEL */
 
 #if __STDC_HOSTED__


### PR DESCRIPTION
This lets us detect lock order reversal in ACPICA code to avoid deadlock.

https://github.com/freebsd/freebsd/commit/3d1ee970f47db4dfd60b30b0e64539bbf4c26d0f