### PR TITLE
 Add "Windows 2019" string to _OSI support.

### DIFF
--- a/source/components/utilities/utosi.c
+++ b/source/components/utilities/utosi.c
@@ -219,6 +219,7 @@ static ACPI_INTERFACE_INFO    AcpiDefaultSupportedInterfaces[] =
     {"Windows 2017.2",      NULL, 0, ACPI_OSI_WIN_10_RS3},       /* Windows 10 version 1709 - Added 02/2018 */
     {"Windows 2018",        NULL, 0, ACPI_OSI_WIN_10_RS4},       /* Windows 10 version 1803 - Added 11/2018 */
     {"Windows 2018.2",      NULL, 0, ACPI_OSI_WIN_10_RS5},       /* Windows 10 version 1809 - Added 11/2018 */
+    {"Windows 2019",        NULL, 0, ACPI_OSI_WIN_10_19H1},      /* Windows 10 version 1903 - Added 08/2019 */
 
     /* Feature Group Strings */
 

--- a/source/components/utilities/utosi.c
+++ b/source/components/utilities/utosi.c
@@ -212,7 +212,7 @@ static ACPI_INTERFACE_INFO    AcpiDefaultSupportedInterfaces[] =
     {"Windows 2006 SP2",    NULL, 0, ACPI_OSI_WIN_VISTA_SP2},    /* Windows Vista SP2 - Added 09/2010 */
     {"Windows 2009",        NULL, 0, ACPI_OSI_WIN_7},            /* Windows 7 and Server 2008 R2 - Added 09/2009 */
     {"Windows 2012",        NULL, 0, ACPI_OSI_WIN_8},            /* Windows 8 and Server 2012 - Added 08/2012 */
-    {"Windows 2013",        NULL, 0, ACPI_OSI_WIN_8},            /* Windows 8.1 and Server 2012 R2 - Added 01/2014 */
+    {"Windows 2013",        NULL, 0, ACPI_OSI_WIN_8_1},          /* Windows 8.1 and Server 2012 R2 - Added 01/2014 */
     {"Windows 2015",        NULL, 0, ACPI_OSI_WIN_10},           /* Windows 10 - Added 03/2015 */
     {"Windows 2016",        NULL, 0, ACPI_OSI_WIN_10_RS1},       /* Windows 10 version 1607 - Added 12/2017 */
     {"Windows 2017",        NULL, 0, ACPI_OSI_WIN_10_RS2},       /* Windows 10 version 1703 - Added 12/2017 */

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1513,12 +1513,13 @@ typedef enum
 #define ACPI_OSI_WIN_VISTA_SP2          0x0A
 #define ACPI_OSI_WIN_7                  0x0B
 #define ACPI_OSI_WIN_8                  0x0C
-#define ACPI_OSI_WIN_10                 0x0D
-#define ACPI_OSI_WIN_10_RS1             0x0E
-#define ACPI_OSI_WIN_10_RS2             0x0F
-#define ACPI_OSI_WIN_10_RS3             0x10
-#define ACPI_OSI_WIN_10_RS4             0x11
-#define ACPI_OSI_WIN_10_RS5             0x12
+#define ACPI_OSI_WIN_8_1                0x0D
+#define ACPI_OSI_WIN_10                 0x0E
+#define ACPI_OSI_WIN_10_RS1             0x0F
+#define ACPI_OSI_WIN_10_RS2             0x10
+#define ACPI_OSI_WIN_10_RS3             0x11
+#define ACPI_OSI_WIN_10_RS4             0x12
+#define ACPI_OSI_WIN_10_RS5             0x13
 
 
 /* Definitions of getopt */

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1520,6 +1520,7 @@ typedef enum
 #define ACPI_OSI_WIN_10_RS3             0x11
 #define ACPI_OSI_WIN_10_RS4             0x12
 #define ACPI_OSI_WIN_10_RS5             0x13
+#define ACPI_OSI_WIN_10_19H1            0x14
 
 
 /* Definitions of getopt */


### PR DESCRIPTION
This adds Windows 10 1903 release to _OSI support.

https://docs.microsoft.com/en-us/windows-hardware/drivers/acpi/winacpi-osi
https://github.com/MicrosoftDocs/windows-driver-docs/commit/881e49865d833a6e0f582162fa2731ec48b05c70

Note the code name is 19H1.

https://en.wikipedia.org/wiki/Windows_10_version_history#Version_1903_(May_2019_Update)
https://blogs.windows.com/windowsexperience/2018/07/25/announcing-windows-10-insider-preview-build-17723-and-build-18204