### PR TITLE
Fix printf format for UINT8.

### DIFF
--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -327,7 +327,7 @@ AdCreateTableHeader (
      * makes it easier to rename the disassembled ASL file if needed.
      */
     AcpiOsPrintf (
-        "DefinitionBlock (\"\", \"%4.4s\", %hu, \"%.6s\", \"%.8s\", 0x%8.8X)\n",
+        "DefinitionBlock (\"\", \"%4.4s\", %hhu, \"%.6s\", \"%.8s\", 0x%8.8X)\n",
         Table->Signature, Table->Revision,
         Table->OemId, Table->OemTableId, Table->OemRevision);
 }

--- a/source/components/namespace/nsdump.c
+++ b/source/components/namespace/nsdump.c
@@ -478,7 +478,7 @@ AcpiNsDumpOneObject (
                     AcpiOsPrintf (" =");
                     for (i = 0; (i < ObjDesc->Buffer.Length && i < 12); i++)
                     {
-                        AcpiOsPrintf (" %.2hX", ObjDesc->Buffer.Pointer[i]);
+                        AcpiOsPrintf (" %.2hhX", ObjDesc->Buffer.Pointer[i]);
                     }
                 }
                 AcpiOsPrintf ("\n");
@@ -575,7 +575,7 @@ AcpiNsDumpOneObject (
         case ACPI_TYPE_LOCAL_BANK_FIELD:
         case ACPI_TYPE_LOCAL_INDEX_FIELD:
 
-            AcpiOsPrintf (" Off %.3X Len %.2X Acc %.2hd\n",
+            AcpiOsPrintf (" Off %.3X Len %.2X Acc %.2hhu\n",
                 (ObjDesc->CommonField.BaseByteOffset * 8)
                     + ObjDesc->CommonField.StartFieldBitOffset,
                 ObjDesc->CommonField.BitLength,


### PR DESCRIPTION
This fixes build with Clang, i.e.,

```
../../../source/common/dmtables.c:331:27: error: format specifies type 'unsigned short' but the argument has type 'UINT8' (aka 'unsigned char') [-Werror,-Wformat]
        Table->Signature, Table->Revision,
                          ^~~~~~~~~~~~~~~
1 error generated.
```
and
```
../../../source/components/namespace/nsdump.c:481:49: error: format specifies type 'unsigned short' but the argument has type 'UINT8' (aka 'unsigned char') [-Werror,-Wformat]
                        AcpiOsPrintf (" %.2hX", ObjDesc->Buffer.Pointer[i]);
                                        ~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                        %.2hhX
obj/acpiexec ../../../source/components/namespace/nsinit.c
../../../source/components/namespace/nsdump.c:582:17: error: format specifies type 'short' but the argument has type 'UINT8' (aka 'unsigned char') [-Werror,-Wformat]
                ObjDesc->CommonField.AccessByteWidth);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```