### PR TITLE
iASL: DT: eliminate %code directive, it is not POSIX compliant

### DIFF
--- a/source/compiler/dtcompilerparser.l
+++ b/source/compiler/dtcompilerparser.l
@@ -161,18 +161,18 @@ YYSTYPE DtCompilerlval;
 /* handle locations */
 
 int DtCompilerParsercolumn = 1;
+int DtLabelByteOffset = 0;
 int DtCompilerParserByteOffset = 0;
 
 #define YY_USER_ACTION \
             DtCompilerParserlloc.first_line = DtCompilerParserlloc.last_line = DtCompilerParserlineno; \
             DtCompilerParserlloc.first_column = DtCompilerParsercolumn; \
-            DtCompilerParserlloc.first_byte_offset = DtCompilerParserByteOffset; \
             DtCompilerParserlloc.last_column = DtCompilerParsercolumn + DtCompilerParserleng-1; \
             DtCompilerParsercolumn += DtCompilerParserleng; \
             DtCompilerParserByteOffset += DtCompilerParserleng; \
             DbgPrint (ASL_PARSE_OUTPUT,\
-                "user action occurred. DtCompilerParserlloc.first_line: %u offset: %u\n",\
-                DtCompilerParserlloc.first_line, DtCompilerParserlloc.first_byte_offset);
+                "user action occurred. DtCompilerParserlloc.first_line: %u\n",\
+                DtCompilerParserlloc.first_line);
 %}
 
 %option nounput noinput yylineno
@@ -237,6 +237,7 @@ CommentField    {LabelName}{WhiteSpace}*:{WhiteSpace}{Comment}?$
     s=UtLocalCacheCalloc (size + 1);
     AcpiUtSafeStrncpy (s, DtCompilerParsertext, size + 1);
     DtCompilerParserlval.s = s;
+    DtLabelByteOffset = DtCompilerParserByteOffset;
     DbgPrint (ASL_PARSE_OUTPUT, "Label: %s\n", s);
     return (DT_PARSEOP_LABEL);
 }

--- a/source/compiler/dtcompilerparser.y
+++ b/source/compiler/dtcompilerparser.y
@@ -169,6 +169,7 @@ void                        DtCompilerParsererror (char const *msg);
 extern char                 *DtCompilerParsertext;
 extern DT_FIELD             *AslGbl_CurrentField;
 
+extern int                  DtLabelByteOffset;
 extern UINT64               DtCompilerParserResult; /* Expression return value */
 extern UINT64               DtCompilerParserlineno; /* Current line number */
 
@@ -185,19 +186,6 @@ extern UINT64               DtCompilerParserlineno; /* Current line number */
 #define YYFREE              free
 
 %}
-
-%code requires {
-
-    typedef struct YYLTYPE {
-        int first_line;
-        int last_line;
-        int first_column;
-        int last_column;
-        int first_byte_offset;
-    } YYLTYPE;
-
-    #define YYLTYPE_IS_DECLARED 1
-}
 
 
 %union {
@@ -221,7 +209,7 @@ extern UINT64               DtCompilerParserlineno; /* Current line number */
 
 Table
     :
-    FieldList { DtCompilerParserResult = 5;}
+    FieldList { }
     ;
 
 FieldList
@@ -230,7 +218,7 @@ FieldList
     ;
 
 Field
-    : DT_PARSEOP_LABEL ':' Data { DtCreateField ($1, $3, (@3).first_line, (@1).first_byte_offset, (@1).first_column, (@3).first_column); }
+    : DT_PARSEOP_LABEL ':' Data { DtCreateField ($1, $3, (@3).first_line, DtLabelByteOffset, (@1).first_column, (@3).first_column); }
     ;
 
 Data


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>