### PR TITLE
3 minor static analysis code cleanups

### DIFF
--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -223,7 +223,7 @@ UtQueryForOverwrite (
     char                    *Pathname)
 {
     struct stat             StatInfo;
-    int                     InChar = 0x34;
+    int                     InChar;
 
 
     if (!stat (Pathname, &StatInfo))

--- a/source/components/debugger/dbdisply.c
+++ b/source/components/debugger/dbdisply.c
@@ -713,7 +713,6 @@ AcpiDbDisplayResults (
         return;
     }
 
-    ObjDesc = WalkState->MethodDesc;
     Node  = WalkState->MethodNode;
 
     if (WalkState->Results)

--- a/source/components/debugger/dbobject.c
+++ b/source/components/debugger/dbobject.c
@@ -649,7 +649,6 @@ AcpiDbDecodeArguments (
 
 
     Node = WalkState->MethodNode;
-    ObjDesc = WalkState->MethodDesc;
 
     /* There are no arguments for the module-level code case */
 

--- a/source/tools/acpisrc/asremove.c
+++ b/source/tools/acpisrc/asremove.c
@@ -264,7 +264,6 @@ AsRemoveConditionalCompile (
 
 
     KeywordLength = strlen (Keyword);
-    SubBuffer = Buffer;
     SubString = Buffer;
 
     while (SubString)


### PR DESCRIPTION
Just 3 minor static analysis code clean-ups found by Coverity.