### PR TITLE
iASL: remove unnecessary null checks

### DIFF
--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -588,11 +588,6 @@ DtCompileTable (
         return (AE_END_OF_TABLE);
     }
 
-    if (!(*Field)->Name || !Info->Name)
-    {
-        return (AE_ERROR);
-    }
-
     /* Ignore optional subtable if name does not match */
 
     if ((Info->Flags & DT_OPTIONAL) &&


### PR DESCRIPTION
At this point in the program, assume that *(Field)->Name is non-null
because the data table parser will emit an error on fields that do
not contain data. Info->Name can only be NULL when Info is a
ACPI_DMT_TERMINATOR which does not set the DT_OPTIONAL flag.

This change will revert the table compiler to the previous behavior
by creating an instance of a subtable struct for empty subtables such
as VRTC and MTMR data tables.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>