### PR TITLE
iASL: fix custom address space range check

### DIFF
--- a/source/compiler/aslkeywords.y
+++ b/source/compiler/aslkeywords.y
@@ -202,7 +202,7 @@ AddressKeyword
     ;
 
 AddressSpaceKeyword
-    : ByteConst                             {$$ = UtCheckIntegerRange ($1, 0x0A, 0xFF);}
+    : ByteConst                             {$$ = UtCheckIntegerRange ($1, ACPI_NUM_PREDEFINED_REGIONS, 0xFF);}
     | RegionSpaceKeyword                    {}
     ;
 


### PR DESCRIPTION
This should use the ACPI_NUM_PREDEFINED_REGIONS macro instead of a
magic number.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>