### PR TITLE
make acpi_load_table() return table index

### DIFF
--- a/source/components/debugger/dbfileio.c
+++ b/source/components/debugger/dbfileio.c
@@ -253,7 +253,7 @@ AcpiDbLoadTables (
     {
         Table = TableListHead->Table;
 
-        Status = AcpiLoadTable (Table);
+        Status = AcpiLoadTable (Table, NULL);
         if (ACPI_FAILURE (Status))
         {
             if (Status == AE_ALREADY_EXISTS)

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -445,6 +445,8 @@ ACPI_EXPORT_SYMBOL_INIT (AcpiInstallTable)
  *
  * PARAMETERS:  Table               - Pointer to a buffer containing the ACPI
  *                                    table to be loaded.
+ *              TableIdx            - Pointer to a UINT32 for storing the table
+ *                                    index, might be NULL
  *
  * RETURN:      Status
  *
@@ -458,7 +460,8 @@ ACPI_EXPORT_SYMBOL_INIT (AcpiInstallTable)
 
 ACPI_STATUS
 AcpiLoadTable (
-    ACPI_TABLE_HEADER       *Table)
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  *TableIdx)
 {
     ACPI_STATUS             Status;
     UINT32                  TableIndex;
@@ -479,6 +482,11 @@ AcpiLoadTable (
     ACPI_INFO (("Host-directed Dynamic ACPI Table Load:"));
     Status = AcpiTbInstallAndLoadTable (ACPI_PTR_TO_PHYSADDR (Table),
         ACPI_TABLE_ORIGIN_EXTERNAL_VIRTUAL, FALSE, &TableIndex);
+    if (TableIdx)
+    {
+        *TableIdx = TableIndex;
+    }
+
     if (ACPI_SUCCESS (Status))
     {
         /* Complete the initialization/resolution of new objects */

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -664,7 +664,8 @@ AcpiInstallTable (
 ACPI_EXTERNAL_RETURN_STATUS (
 ACPI_STATUS
 AcpiLoadTable (
-    ACPI_TABLE_HEADER       *Table))
+    ACPI_TABLE_HEADER       *Table,
+    UINT32                  *TableIdx))
 
 ACPI_EXTERNAL_RETURN_STATUS (
 ACPI_STATUS

--- a/source/tools/acpiexec/aetests.c
+++ b/source/tools/acpiexec/aetests.c
@@ -218,7 +218,7 @@ AeMiscellaneousTests (
 
         /* Load and unload SSDT4 */
 
-        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt4Code);
+        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt4Code, NULL);
         ACPI_CHECK_OK (AcpiLoadTable, Status);
 
         Status = AcpiGetHandle (NULL, "\\_T96", &Handle);
@@ -229,7 +229,7 @@ AeMiscellaneousTests (
 
         /* Re-load SSDT4 */
 
-        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt4Code);
+        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt4Code, NULL);
         ACPI_CHECK_OK (AcpiLoadTable, Status);
 
         /* Unload and re-load SSDT2 (SSDT2 is in the XSDT) */
@@ -240,12 +240,12 @@ AeMiscellaneousTests (
         Status = AcpiUnloadParentTable (Handle);
         ACPI_CHECK_OK (AcpiUnloadParentTable, Status);
 
-        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt2Code);
+        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt2Code, NULL);
         ACPI_CHECK_OK (AcpiLoadTable, Status);
 
         /* Load OEM9 table (causes table override) */
 
-        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt3Code);
+        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt3Code, NULL);
         ACPI_CHECK_OK (AcpiLoadTable, Status);
     }
 

--- a/source/tools/acpiexec/aetests.c
+++ b/source/tools/acpiexec/aetests.c
@@ -190,6 +190,7 @@ AeMiscellaneousTests (
     ACPI_STATUS             Status;
     ACPI_STATISTICS         Stats;
     ACPI_HANDLE             Handle;
+    UINT32                  TableIndex;
 
 #if (!ACPI_REDUCED_HARDWARE)
     UINT32                  Temp;
@@ -218,14 +219,11 @@ AeMiscellaneousTests (
 
         /* Load and unload SSDT4 */
 
-        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt4Code, NULL);
+        Status = AcpiLoadTable ((ACPI_TABLE_HEADER *) Ssdt4Code, &TableIndex);
         ACPI_CHECK_OK (AcpiLoadTable, Status);
 
-        Status = AcpiGetHandle (NULL, "\\_T96", &Handle);
-        ACPI_CHECK_OK (AcpiGetHandle, Status);
-
-        Status = AcpiUnloadParentTable (Handle);
-        ACPI_CHECK_OK (AcpiUnloadParentTable, Status);
+        Status = AcpiUnloadTable (TableIndex);
+        ACPI_CHECK_OK (AcpiUnloadTable, Status);
 
         /* Re-load SSDT4 */
 


### PR DESCRIPTION
For unloading an ACPI table, it is necessary to provide the index of
the table. The method intended for dynamically loading or hotplug
addition of tables, AcpiLoadTable(), should provide this information
via an optional pointer to the loaded table index.

This patch fixes the table unload function of acpi_configfs.

Reported-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
Fixes: d06c47e3dd07f ("ACPI: configfs: Resolve objects on host-directed
table loads")
Signed-off-by: Nikolaus Voss <nikolaus.voss@loewensteinmedical.de>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>