### PR TITLE
Disassembler: IORT: fix output of optional padding field

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -187,6 +187,7 @@ AcpiDmDumpIort (
     ACPI_DMTABLE_INFO       *InfoTable;
     char                    *String;
     UINT32                  i;
+    UINT32                  MappingByteLength;
 
 
     /* Main table */
@@ -330,8 +331,10 @@ AcpiDmDumpIort (
 
             if (IortNode->Length > NodeOffset)
             {
+                MappingByteLength =
+                    IortNode->MappingCount * sizeof (ACPI_IORT_ID_MAPPING);
                 Status = AcpiDmDumpTable (Table->Length, Offset + NodeOffset,
-                    Table, IortNode->Length - NodeOffset,
+                    Table, IortNode->Length - NodeOffset - MappingByteLength,
                     AcpiDmTableInfoIort1a);
                 if (ACPI_FAILURE (Status))
                 {


### PR DESCRIPTION
The disassembly of the optional padding field resulted in dumping
the remainder of the length in the subtable. This is problematic
when there are mappings that are describes after the padding field.

The length of the mappings are a part of the subtable length. When
dumping the optional padding field, the mapping length should be
subtracted from the rest of the field so that the proper length of
padding should be dumped.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>