### PR TITLE
gitignore: ignore aslts tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ generate/linux/divergence-single.diff
 
 libraries
 
+tests/aslts/tmp
 tests/misc/grammar.aml
 tests/misc/grammar.dsl
 


### PR DESCRIPTION
The tests/aslts/tmp directory contains previous test executions.
Since these are never committed to the ACPICA repository, ignore this
directory.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>