### PR TITLE
acpiexec: add fields command

### DIFF
--- a/source/components/debugger/dbinput.c
+++ b/source/components/debugger/dbinput.c
@@ -208,6 +208,7 @@ enum AcpiExDebuggerCommands
     CMD_EVALUATE,
     CMD_EXECUTE,
     CMD_EXIT,
+    CMD_FIELDS,
     CMD_FIND,
     CMD_GO,
     CMD_HANDLERS,
@@ -287,6 +288,7 @@ static const ACPI_DB_COMMAND_INFO   AcpiGbl_DbCommands[] =
     {"EVALUATE",     1},
     {"EXECUTE",      1},
     {"EXIT",         0},
+    {"FIELDS",       1},
     {"FIND",         1},
     {"GO",           0},
     {"HANDLERS",     0},
@@ -360,6 +362,7 @@ static const ACPI_DB_COMMAND_HELP   AcpiGbl_DbCommandHelp[] =
     {1, "  Find <AcpiName> (? is wildcard)",    "Find ACPI name(s) with wildcards\n"},
     {1, "  Integrity",                          "Validate namespace integrity\n"},
     {1, "  Methods",                            "Display list of loaded control methods\n"},
+    {1, "  Fields <AddressSpaceId>",            "Display list of loaded field units by space ID\n"},
     {1, "  Namespace [Object] [Depth]",         "Display loaded namespace tree/subtree\n"},
     {1, "  Notify <Object> <Value>",            "Send a notification on Object\n"},
     {1, "  Objects [ObjectType]",               "Display summary of all objects or just given type\n"},
@@ -877,6 +880,7 @@ AcpiDbCommandDispatch (
     ACPI_PARSE_OBJECT       *Op)
 {
     UINT32                  Temp;
+    UINT64                  Temp64;
     UINT32                  CommandIndex;
     UINT32                  ParamCount;
     char                    *CommandLine;
@@ -990,6 +994,21 @@ AcpiDbCommandDispatch (
     case CMD_FIND:
 
         Status = AcpiDbFindNameInNamespace (AcpiGbl_DbArgs[1]);
+        break;
+
+    case CMD_FIELDS:
+
+        Status = AcpiUtStrtoul64 (AcpiGbl_DbArgs[1], &Temp64);
+
+        if (ACPI_FAILURE (Status) || Temp64 >= ACPI_NUM_PREDEFINED_REGIONS)
+        {
+            AcpiOsPrintf (
+                "Invalid adress space ID: must be between 0 and %u inclusive\n",
+                ACPI_NUM_PREDEFINED_REGIONS - 1);
+            return (AE_OK);
+        }
+
+        Status = AcpiDbDisplayFields ((UINT32) Temp64);
         break;
 
     case CMD_GO:

--- a/source/components/debugger/dbnames.c
+++ b/source/components/debugger/dbnames.c
@@ -154,6 +154,7 @@
 #include "acnamesp.h"
 #include "acdebug.h"
 #include "acpredef.h"
+#include "acinterp.h"
 
 
 #define _COMPONENT          ACPI_CA_DEBUGGER
@@ -724,6 +725,86 @@ AcpiDbWalkForObjectCounts (
 
 /*******************************************************************************
  *
+ * FUNCTION:    AcpiDbWalkForFields
+ *
+ * PARAMETERS:  Callback from WalkNamespace
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Display short info about objects in the namespace
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiDbWalkForFields (
+    ACPI_HANDLE             ObjHandle,
+    UINT32                  NestingLevel,
+    void                    *Context,
+    void                    **ReturnValue)
+{
+    ACPI_OBJECT             *RetValue;
+    ACPI_REGION_WALK_INFO   *Info = (ACPI_REGION_WALK_INFO *) Context;
+    ACPI_BUFFER             Buffer;
+    ACPI_STATUS             Status;
+    ACPI_NAMESPACE_NODE     *Node = AcpiNsValidateHandle (ObjHandle);
+
+
+    if (!Node)
+    {
+       return (AE_OK);
+    }
+    if (Node->Object->Field.RegionObj->Region.SpaceId != Info->AddressSpaceId)
+    {
+       return (AE_OK);
+    }
+
+    Info->Count++;
+
+    /* Get and display the full pathname to this object */
+
+    Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
+    Status = AcpiNsHandleToPathname (ObjHandle, &Buffer, TRUE);
+    if (ACPI_FAILURE (Status))
+    {
+        AcpiOsPrintf ("Could Not get pathname for object %p\n", ObjHandle);
+        return (AE_OK);
+    }
+
+    AcpiOsPrintf ("%s ", (char *) Buffer.Pointer);
+    ACPI_FREE (Buffer.Pointer);
+
+    Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
+    AcpiEvaluateObject (ObjHandle, NULL, NULL, &Buffer);
+
+    RetValue = (ACPI_OBJECT *) Buffer.Pointer;
+    switch (RetValue->Type)
+    {
+        case ACPI_TYPE_INTEGER:
+
+            AcpiOsPrintf ("%lx", RetValue->Integer.Value);
+            break;
+
+        case ACPI_TYPE_BUFFER:
+
+            AcpiUtDumpBuffer (RetValue->Buffer.Pointer,
+                RetValue->Buffer.Length, DB_DISPLAY_DATA_ONLY | DB_BYTE_DISPLAY, 0);
+            break;
+
+        default:
+
+            break;
+    }
+    AcpiOsPrintf ("\n");
+
+    ACPI_FREE (Buffer.Pointer);
+
+    return (AE_OK);
+}
+
+
+
+/*******************************************************************************
+ *
  * FUNCTION:    AcpiDbWalkForSpecificObjects
  *
  * PARAMETERS:  Callback from WalkNamespace
@@ -853,6 +934,42 @@ AcpiDbDisplayObjects (
         Info.Count, AcpiUtGetTypeName (Type));
 
     AcpiDbSetOutputDestination (ACPI_DB_CONSOLE_OUTPUT);
+    return (AE_OK);
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbDisplayFields
+ *
+ * PARAMETERS:  ObjTypeArg          - Type of object to display
+ *              DisplayCountArg     - Max depth to display
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Display objects in the namespace of the requested type
+ *
+ ******************************************************************************/
+
+ACPI_STATUS
+AcpiDbDisplayFields (
+    UINT32                  AddressSpaceId)
+{
+    ACPI_REGION_WALK_INFO  Info;
+
+
+    Info.Count = 0;
+    Info.OwnerId = ACPI_OWNER_ID_MAX;
+    Info.DebugLevel = ACPI_UINT32_MAX;
+    Info.DisplayType = ACPI_DISPLAY_SUMMARY | ACPI_DISPLAY_SHORT;
+    Info.AddressSpaceId = AddressSpaceId;
+
+    /* Walk the namespace from the root */
+
+    (void) AcpiWalkNamespace (ACPI_TYPE_LOCAL_REGION_FIELD, ACPI_ROOT_OBJECT,
+          ACPI_UINT32_MAX, AcpiDbWalkForFields, NULL,
+          (void *) &Info, NULL);
+
     return (AE_OK);
 }
 

--- a/source/components/utilities/utbuffer.c
+++ b/source/components/utilities/utbuffer.c
@@ -186,8 +186,10 @@ AcpiUtDumpBuffer (
     UINT32                  j;
     UINT32                  Temp32;
     UINT8                   BufChar;
+    UINT32                  DisplayDataOnly = Display & DB_DISPLAY_DATA_ONLY;
 
 
+    Display &= ~DB_DISPLAY_DATA_ONLY;
     if (!Buffer)
     {
         AcpiOsPrintf ("Null Buffer Pointer in DumpBuffer!\n");
@@ -205,7 +207,10 @@ AcpiUtDumpBuffer (
     {
         /* Print current offset */
 
-        AcpiOsPrintf ("%8.4X: ", (BaseOffset + i));
+        if (!DisplayDataOnly)
+        {
+            AcpiOsPrintf ("%8.4X: ", (BaseOffset + i));
+        }
 
         /* Print 16 hex chars */
 
@@ -257,38 +262,41 @@ AcpiUtDumpBuffer (
          * Print the ASCII equivalent characters but watch out for the bad
          * unprintable ones (printable chars are 0x20 through 0x7E)
          */
-        AcpiOsPrintf (" ");
-        for (j = 0; j < 16; j++)
+        if (!DisplayDataOnly)
         {
-            if (i + j >= Count)
+            AcpiOsPrintf (" ");
+            for (j = 0; j < 16; j++)
             {
-                AcpiOsPrintf ("\n");
-                return;
+                if (i + j >= Count)
+                {
+                    AcpiOsPrintf ("\n");
+                    return;
+                }
+
+                /*
+                 * Add comment characters so rest of line is ignored when
+                 * compiled
+                 */
+                if (j == 0)
+                {
+                    AcpiOsPrintf ("// ");
+                }
+
+                BufChar = Buffer[(ACPI_SIZE) i + j];
+                if (isprint (BufChar))
+                {
+                    AcpiOsPrintf ("%c", BufChar);
+                }
+                else
+                {
+                    AcpiOsPrintf (".");
+                }
             }
 
-            /*
-             * Add comment characters so rest of line is ignored when
-             * compiled
-             */
-            if (j == 0)
-            {
-                AcpiOsPrintf ("// ");
-            }
+            /* Done with that line. */
 
-            BufChar = Buffer[(ACPI_SIZE) i + j];
-            if (isprint (BufChar))
-            {
-                AcpiOsPrintf ("%c", BufChar);
-            }
-            else
-            {
-                AcpiOsPrintf (".");
-            }
+            AcpiOsPrintf ("\n");
         }
-
-        /* Done with that line. */
-
-        AcpiOsPrintf ("\n");
         i += 16;
     }
 

--- a/source/include/acdebug.h
+++ b/source/include/acdebug.h
@@ -392,6 +392,10 @@ void
 AcpiDbGetBusInfo (
     void);
 
+ACPI_STATUS
+AcpiDbDisplayFields (
+    UINT32                  AddressSpaceId);
+
 
 /*
  * dbdisply - debug display commands

--- a/source/include/acstruct.h
+++ b/source/include/acstruct.h
@@ -357,6 +357,19 @@ typedef struct acpi_device_walk_info
 } ACPI_DEVICE_WALK_INFO;
 
 
+/* Info used by Acpi  AcpiDbDisplayFields */
+
+typedef struct acpi_region_walk_info
+{
+    UINT32                          DebugLevel;
+    UINT32                          Count;
+    ACPI_OWNER_ID                   OwnerId;
+    UINT8                           DisplayType;
+    UINT32                          AddressSpaceId;
+
+} ACPI_REGION_WALK_INFO;
+
+
 /* TBD: [Restructure] Merge with struct above */
 
 typedef struct acpi_walk_info

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -290,10 +290,11 @@ typedef struct acpi_pkg_info
 
 /* AcpiUtDumpBuffer */
 
-#define DB_BYTE_DISPLAY     1
-#define DB_WORD_DISPLAY     2
-#define DB_DWORD_DISPLAY    4
-#define DB_QWORD_DISPLAY    8
+#define DB_BYTE_DISPLAY      0x01
+#define DB_WORD_DISPLAY      0x02
+#define DB_DWORD_DISPLAY     0x04
+#define DB_QWORD_DISPLAY     0x08
+#define DB_DISPLAY_DATA_ONLY 0x10
 
 
 /*


### PR DESCRIPTION
This command dumps the name segment and values contained within field units of a particular operation region subtype.