### PR TITLE
acpiexec: add support for simple types in InitFile

### DIFF
--- a/source/components/debugger/dbinput.c
+++ b/source/components/debugger/dbinput.c
@@ -686,6 +686,22 @@ AcpiDbGetNextToken (
         }
         break;
 
+    case '{':
+
+        /* This is the start of a field unit, scan until closing brace */
+
+        String++;
+        Start = String;
+        Type = ACPI_TYPE_FIELD_UNIT;
+
+        /* Find end of buffer */
+
+        while (*String && (*String != '}'))
+        {
+            String++;
+        }
+        break;
+
     case '[':
 
         /* This is the start of a package, scan until closing bracket */

--- a/source/components/debugger/dbnames.c
+++ b/source/components/debugger/dbnames.c
@@ -776,6 +776,11 @@ AcpiDbWalkForFields (
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
     AcpiEvaluateObject (ObjHandle, NULL, NULL, &Buffer);
 
+    /*
+     * Since this is a field unit, surround the field unit in braces
+     */
+    AcpiOsPrintf ("{");
+
     RetValue = (ACPI_OBJECT *) Buffer.Pointer;
     switch (RetValue->Type)
     {
@@ -795,7 +800,7 @@ AcpiDbWalkForFields (
             break;
     }
 
-    AcpiOsPrintf ("\n");
+    AcpiOsPrintf ("}\n");
 
     ACPI_FREE (Buffer.Pointer);
     return (AE_OK);

--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -434,7 +434,6 @@ AcpiDsGetFieldNames (
     ACPI_PARSE_OBJECT       *Child;
 
 #ifdef ACPI_EXEC_APP
-    UINT64                  Value = 0;
     ACPI_OPERAND_OBJECT     *ResultDesc;
     ACPI_OPERAND_OBJECT     *ObjDesc;
     char                    *NamePath;
@@ -576,8 +575,7 @@ AcpiDsGetFieldNames (
                     }
 #ifdef ACPI_EXEC_APP
                     NamePath = AcpiNsGetExternalPathname (Info->FieldNode);
-                    ObjDesc = AcpiUtCreateIntegerObject (Value);
-                    if (ACPI_SUCCESS (AeLookupInitFileEntry (NamePath, &Value)))
+                    if (ACPI_SUCCESS (AeLookupInitFileEntry (NamePath, &ObjDesc)))
                     {
                         AcpiExWriteDataToField (ObjDesc,
                             AcpiNsGetAttachedObject (Info->FieldNode),

--- a/source/tools/acpiexec/aecommon.h
+++ b/source/tools/acpiexec/aecommon.h
@@ -195,7 +195,8 @@ typedef struct ae_debug_regions
 typedef struct init_file_entry
 {
     char                    *Name;
-    UINT64                  Value;
+    ACPI_OPERAND_OBJECT     *ObjDesc;
+
 } INIT_FILE_ENTRY;
 
 extern BOOLEAN              AcpiGbl_UseLocalFaultHandler;
@@ -356,7 +357,7 @@ AeSetupConfiguration (
 ACPI_STATUS
 AeLookupInitFileEntry (
     char                    *Pathname,
-    UINT64                  *Value);
+    ACPI_OPERAND_OBJECT     **ObjDesc);
 
 /* aeexec */
 

--- a/source/tools/acpiexec/aeinitfile.c
+++ b/source/tools/acpiexec/aeinitfile.c
@@ -224,9 +224,13 @@ AeProcessInitFile(
     void)
 {
     ACPI_WALK_STATE         *WalkState;
-    int                     i;
     UINT64                  idx;
     ACPI_STATUS             Status;
+    char                    *Token;
+    char                    *ObjectBuffer;
+    char                    *TempNameBuffer;
+    ACPI_OBJECT_TYPE        Type;
+    ACPI_OBJECT             TempObject;
 
 
     if (!InitFile)
@@ -249,26 +253,44 @@ AeProcessInitFile(
         AcpiOsAllocate (sizeof (INIT_FILE_ENTRY) * AcpiGbl_InitFileLineCount);
     for (idx = 0; fgets (LineBuffer, AE_FILE_BUFFER_SIZE, InitFile); ++idx)
     {
-        if (sscanf (LineBuffer, "%s %s\n",
-                &NameBuffer[1], ValueBuffer) != 2)
+
+        TempNameBuffer = AcpiDbGetNextToken (LineBuffer, &Token, &Type);
+        if (LineBuffer[0] == '\\')
         {
-            goto CleanupAndExit;
+            strcpy (NameBuffer, TempNameBuffer);
         }
-
-        /* Add a root prefix if not present in the string */
-
-        i = 0;
-        if (NameBuffer[1] == '\\')
+        else
         {
-            i = 1;
+            /* Add a root prefix if not present in the string */
+
+            strcpy (NameBuffer + 1, TempNameBuffer);
         }
 
         AcpiGbl_InitEntries[idx].Name =
-            AcpiOsAllocateZeroed (strnlen (NameBuffer + i, AE_FILE_BUFFER_SIZE) + 1);
+            AcpiOsAllocateZeroed (strnlen (NameBuffer, AE_FILE_BUFFER_SIZE) + 1);
 
-        strcpy (AcpiGbl_InitEntries[idx].Name, NameBuffer + i);
+        strcpy (AcpiGbl_InitEntries[idx].Name, NameBuffer);
 
-        Status = AcpiUtStrtoul64 (ValueBuffer, &AcpiGbl_InitEntries[idx].Value);
+        ObjectBuffer = AcpiDbGetNextToken (Token, &Token, &Type);
+
+        if (Type == ACPI_TYPE_FIELD_UNIT)
+        {
+            Status = AcpiDbConvertToObject (ACPI_TYPE_BUFFER, ObjectBuffer,
+                &TempObject);
+        }
+        else
+        {
+            Status = AcpiDbConvertToObject (Type, ObjectBuffer, &TempObject);
+        }
+
+        Status = AcpiUtCopyEobjectToIobject (&TempObject,
+            &AcpiGbl_InitEntries[idx].ObjDesc);
+
+        if (Type == ACPI_TYPE_BUFFER || Type == ACPI_TYPE_FIELD_UNIT)
+        {
+            ACPI_FREE (TempObject.Buffer.Pointer);
+        }
+
         if (ACPI_FAILURE (Status))
         {
             AcpiOsPrintf ("%s %s\n", ValueBuffer,
@@ -276,7 +298,16 @@ AeProcessInitFile(
             goto CleanupAndExit;
         }
 
-        AeEnterInitFileEntry (AcpiGbl_InitEntries[idx], WalkState);
+        /*
+         * Special case for field units. Field units are dependent on the
+         * parent region. This parent region has yet to be created so defer the
+         * initialization until the dispatcher. For all other types, initialize
+         * the namespace node with the value found in the init file.
+         */
+        if (Type != ACPI_TYPE_FIELD_UNIT)
+        {
+            AeEnterInitFileEntry (AcpiGbl_InitEntries[idx], WalkState);
+        }
     }
 
     /* Cleanup */
@@ -309,14 +340,12 @@ AeEnterInitFileEntry (
     ACPI_WALK_STATE         *WalkState)
 {
     char                    *Pathname = InitEntry.Name;
-    UINT64                  Value = InitEntry.Value;
-    ACPI_OPERAND_OBJECT     *ObjDesc;
+    ACPI_OPERAND_OBJECT     *ObjDesc = InitEntry.ObjDesc;
     ACPI_NAMESPACE_NODE     *NewNode;
     ACPI_STATUS             Status;
 
 
-    AcpiOsPrintf ("Initializing namespace element: %s\n", Pathname);
-    Status = AcpiNsLookup (NULL, Pathname, ACPI_TYPE_INTEGER,
+    Status = AcpiNsLookup (NULL, Pathname, ObjDesc->Common.Type,
         ACPI_IMODE_LOAD_PASS2, ACPI_NS_ERROR_IF_FOUND | ACPI_NS_NO_UPSEARCH |
         ACPI_NS_EARLY_INIT, NULL, &NewNode);
     if (ACPI_FAILURE (Status))
@@ -327,15 +356,10 @@ AeEnterInitFileEntry (
         return;
     }
 
-    ObjDesc = AcpiUtCreateIntegerObject (Value);
-
-    AcpiOsPrintf ("New value: 0x%8.8X%8.8X\n",
-        ACPI_FORMAT_UINT64 (Value));
-
     /* Store pointer to value descriptor in the Node */
 
     Status = AcpiNsAttachObject (NewNode, ObjDesc,
-         ACPI_TYPE_INTEGER);
+         ObjDesc->Common.Type);
     if (ACPI_FAILURE (Status))
     {
         ACPI_EXCEPTION ((AE_INFO, Status,
@@ -366,7 +390,7 @@ AeEnterInitFileEntry (
 ACPI_STATUS
 AeLookupInitFileEntry (
     char                    *Pathname,
-    UINT64                  *Value)
+    ACPI_OPERAND_OBJECT     **ObjDesc)
 {
     UINT32                  i;
 
@@ -379,7 +403,7 @@ AeLookupInitFileEntry (
     {
         if (!strcmp(AcpiGbl_InitEntries[i].Name, Pathname))
         {
-            *Value = AcpiGbl_InitEntries[i].Value;
+            *ObjDesc = AcpiGbl_InitEntries[i].ObjDesc;
             return AE_OK;
         }
     }

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -841,8 +841,8 @@ NormalExit:
 
 ErrorExit:
     AeLateTest ();
+    AcpiOsFree (AcpiGbl_InitEntries);
     (void) AcpiTerminate ();
     AcDeleteTableList (ListHead);
-    AcpiOsFree (AcpiGbl_InitEntries);
     return (ExitCode);
 }


### PR DESCRIPTION
acpiexec allows the user to run the AML interpreter with a file
containging a mapping of name segments with a value to initialize the
named object. Using custom initialization files, acpiexec could simulate
AML execution more accurately.

Previously, initfile only supported integers. This change adds support
for Buffers, Strings, and Packages to these files.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>