### PR TITLE
dispatcher: fix reference count removal

### DIFF
--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -580,8 +580,8 @@ AcpiDsGetFieldNames (
                         AcpiExWriteDataToField (ObjDesc,
                             AcpiNsGetAttachedObject (Info->FieldNode),
                             &ResultDesc);
+                        AcpiUtRemoveReference (ObjDesc);
                     }
-                    AcpiUtRemoveReference (ObjDesc);
                     ACPI_FREE (NamePath);
 #endif
                 }


### PR DESCRIPTION
The ObjDesc reference count should only be removed if we get an
actual reference to the object.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>