### PR TITLE
debugger: remove leading whitespaces when converting a string to a bu…

### DIFF
--- a/source/components/debugger/dbconvert.c
+++ b/source/components/debugger/dbconvert.c
@@ -274,6 +274,10 @@ AcpiDbConvertToBuffer (
     ACPI_STATUS             Status;
 
 
+    /* Skip all preceding white space*/
+
+    AcpiUtRemoveWhitespace (&String);
+
     /* Generate the final buffer length */
 
     for (i = 0, Length = 0; String[i];)


### PR DESCRIPTION
…ffer

By removing leading whitespaces, the conversion computes the
correct number of elements in a given buffer or field encoding that
contains leading whitespaces.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>