### PR TITLE
iASL: fix memory leak of LocalityBuffer on error return path

### DIFF
--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1662,6 +1662,7 @@ DtCompileSlit (
             "Found %u entries, must match LocalityCount: %u",
             LocalityListLength, Localities);
         DtError (ASL_ERROR, ASL_MSG_ENTRY_LIST, EndOfFieldList, AslGbl_MsgBuffer);
+        ACPI_FREE (LocalityBuffer);
         return (AE_LIMIT);
     }
 


### PR DESCRIPTION
The error return path is not free'ing previously allocated
resource LocalityBuffer and hence there is a memory leak. Fix this
by free'ing it before returning.

Fixes: c22c0b1df98c ("Data table compiler: Add error messages for SLIT locality buffers")
Signed-off-by: Colin Ian King <colin.king@canonical.com>