### PR TITLE
iASL: DT: allocate from cache to facilitate memory reclamation

### DIFF
--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1638,7 +1638,7 @@ DtCompileSlit (
     DtInsertSubtable (ParentTable, Subtable);
 
     Localities = *ACPI_CAST_PTR (UINT32, Subtable->Buffer);
-    LocalityBuffer = UtLocalCalloc (Localities);
+    LocalityBuffer = (UINT8 *) UtLocalCacheCalloc (Localities);
     LocalityListLength = 0;
 
     /* Compile each locality buffer */


### PR DESCRIPTION
Fixes: c22c0b1 ("Data table compiler: Add error messages for SLIT locality buffers")
Reported-by: Colin Ian King <colin.king@canonical.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>