### PR TITLE
compiler/asloptions.c : correct exit code for iasl -T ALL

### DIFF
--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -219,7 +219,7 @@ AslCommandLine (
         {
             exit (-1);
         }
-        exit (1);
+        exit (0);
     }
 
     /* Next parameter must be the input filename */


### PR DESCRIPTION
When all templates are being generated, iasl will exit with a non-zero
status even when everything works just fine.  Correct the exit() call
to exit(0) for this case, instead of exit(1).

Signed-off-by: Al Stone <ahs3@ahs3.net>