### PR TITLE
iASL: abort with an error when current file is not found

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -864,11 +864,6 @@ static void AslInitEnode (
         }
 
         FileNode = FlGetCurrentFileNode ();
-        if (!FileNode)
-        {
-            return;
-        }
-
         Enode->SourceFilename =
             FileNode->Files[ASL_FILE_SOURCE_OUTPUT].Filename;
     }

--- a/source/compiler/aslfiles.c
+++ b/source/compiler/aslfiles.c
@@ -420,8 +420,22 @@ ASL_GLOBAL_FILE_NODE *
 FlGetCurrentFileNode (
     void)
 {
-    return (FlGetFileNode (
-        ASL_FILE_INPUT,AslGbl_Files[ASL_FILE_INPUT].Filename));
+    ASL_GLOBAL_FILE_NODE    *FileNode =
+        FlGetFileNode (ASL_FILE_INPUT,AslGbl_Files[ASL_FILE_INPUT].Filename);
+
+
+    if (!FileNode)
+    {
+        /*
+         * If the current file node does not exist after initializing the file
+         * node structures, something went wrong and this is an unrecoverable
+         * condition.
+         */
+        FlFileError (ASL_FILE_INPUT, ASL_MSG_COMPILER_INTERNAL);
+        AslAbort ();
+    }
+
+    return (FileNode);
 }
 
 

--- a/source/compiler/aslstartup.c
+++ b/source/compiler/aslstartup.c
@@ -457,10 +457,6 @@ AslDoOneFile (
     }
 
     FileNode = FlGetCurrentFileNode();
-    if (!FileNode)
-    {
-        return (AE_ERROR);
-    }
 
     FileNode->OriginalInputFileSize = FlGetFileSize (ASL_FILE_INPUT);
 

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -567,11 +567,6 @@ UtDisplayOneSummary (
     /* Summary of main input and output files */
 
     FileNode = FlGetCurrentFileNode ();
-    if (!FileNode)
-    {
-        fprintf (stderr, "Summary could not be generated");
-        return;
-    }
 
     if (FileNode->ParserErrorDetected)
     {

--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -261,18 +261,11 @@ DtDoCompile (
     UtEndEvent (Event);
 
     FileNode = FlGetCurrentFileNode ();
-    if (!FileNode)
-    {
-        fprintf (stderr, "Summary for %s could not be generated",
-            AslGbl_Files[ASL_FILE_INPUT].Filename);
-    }
-    else
-    {
-        FileNode->TotalLineCount = AslGbl_CurrentLineNumber;
-        FileNode->OriginalInputFileSize = AslGbl_InputByteCount;
-        DbgPrint (ASL_PARSE_OUTPUT, "Line count: %u input file size: %u\n",
-                FileNode->TotalLineCount, FileNode->OriginalInputFileSize);
-    }
+
+    FileNode->TotalLineCount = AslGbl_CurrentLineNumber;
+    FileNode->OriginalInputFileSize = AslGbl_InputByteCount;
+    DbgPrint (ASL_PARSE_OUTPUT, "Line count: %u input file size: %u\n",
+            FileNode->TotalLineCount, FileNode->OriginalInputFileSize);
 
     if (ACPI_FAILURE (Status))
     {


### PR DESCRIPTION
In iASL, not being able to find the internal representation of an
input file is an unrecoverable condition. Instead of returning NULL
for this case, it's better to simply abort iASL instead of continuing
the compilation.

Reported-by: Colin Ian King <colin.king@canonical.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>