### PR TITLE
debugger: fix spelling mistake "adress" -> "address"

### DIFF
--- a/source/components/debugger/dbinput.c
+++ b/source/components/debugger/dbinput.c
@@ -1019,7 +1019,7 @@ AcpiDbCommandDispatch (
         if (ACPI_FAILURE (Status) || Temp64 >= ACPI_NUM_PREDEFINED_REGIONS)
         {
             AcpiOsPrintf (
-                "Invalid adress space ID: must be between 0 and %u inclusive\n",
+                "Invalid address space ID: must be between 0 and %u inclusive\n",
                 ACPI_NUM_PREDEFINED_REGIONS - 1);
             return (AE_OK);
         }


### PR DESCRIPTION
There is a spelling mistake in an error message. Fix it.

Signed-off-by: Colin Ian King <colin.king@canonical.com>