### PR TITLE
iASL: move opcode walk and transformation

### DIFF
--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -282,25 +282,6 @@ CmDoCompile (
 
     LsDumpParseTree ();
 
-    OpcGetIntegerWidth (AslGbl_ParseTreeRoot->Asl.Child);
-    UtEndEvent (Event);
-
-    /* Pre-process parse tree for any operator transforms */
-
-    Event = UtBeginEvent ("Parse tree transforms");
-    DbgPrint (ASL_DEBUG_OUTPUT, "\nParse tree transforms\n\n");
-    TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_TWICE,
-        TrAmlTransformWalkBegin, TrAmlTransformWalkEnd, NULL);
-    UtEndEvent (Event);
-
-    /* Generate AML opcodes corresponding to the parse tokens */
-
-    Event = UtBeginEvent ("Generate AML opcodes");
-    DbgPrint (ASL_DEBUG_OUTPUT, "Generating AML opcodes\n\n");
-    TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_UPWARD, NULL,
-        OpcAmlOpcodeWalk, NULL);
-    UtEndEvent (Event);
-
     UtEndEvent (FullCompile);
     return (AE_OK);
 
@@ -329,6 +310,25 @@ CmDoAslMiddleAndBackEnd (
 {
     UINT8                   Event;
     ACPI_STATUS             Status;
+
+
+    OpcGetIntegerWidth (AslGbl_ParseTreeRoot->Asl.Child);
+
+    /* Pre-process parse tree for any operator transforms */
+
+    Event = UtBeginEvent ("Parse tree transforms");
+    DbgPrint (ASL_DEBUG_OUTPUT, "\nParse tree transforms\n\n");
+    TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_TWICE,
+        TrAmlTransformWalkBegin, TrAmlTransformWalkEnd, NULL);
+    UtEndEvent (Event);
+
+    /* Generate AML opcodes corresponding to the parse tokens */
+
+    Event = UtBeginEvent ("Generate AML opcodes");
+    DbgPrint (ASL_DEBUG_OUTPUT, "Generating AML opcodes\n\n");
+    TrWalkParseTree (AslGbl_ParseTreeRoot, ASL_WALK_VISIT_UPWARD,
+        NULL, OpcAmlOpcodeWalk, NULL);
+    UtEndEvent (Event);
 
 
     /* Interpret and generate all compile-time constants */


### PR DESCRIPTION
This change fixes the opcode walk and the transformation walk to only
traverse the parse tree after the entire parse tree has been formed.
parse tree. Walking the entire tree any earlier would require repeated
calls to walk the parse tree and results in longer execution time.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>