### PR TITLE
Disassembler: create buffer fields in ACPI_PARSE_LOAD_PASS1

### DIFF
--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -543,7 +543,6 @@ AdParseTable (
     }
 
     WalkState->ParseFlags &= ~ACPI_PARSE_DELETE_TREE;
-    WalkState->ParseFlags |= ACPI_PARSE_DISASSEMBLE;
 
     Status = AcpiPsParseAml (WalkState);
     if (ACPI_FAILURE (Status))

--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -413,7 +413,7 @@ Cleanup:
  * FUNCTION:    AcpiDsGetFieldNames
  *
  * PARAMETERS:  Info            - CreateField info structure
- *  `           WalkState       - Current method state
+ *              WalkState       - Current method state
  *              Arg             - First parser arg for the field name list
  *
  * RETURN:      Status

--- a/source/components/dispatcher/dswload.c
+++ b/source/components/dispatcher/dswload.c
@@ -567,6 +567,28 @@ AcpiDsLoad1EndOp (
     Op = WalkState->Op;
     ACPI_DEBUG_PRINT ((ACPI_DB_DISPATCH, "Op=%p State=%p\n", Op, WalkState));
 
+    /*
+     * Disassembler: handle create field operators here.
+     *
+     * CreateBufferField is a deferred op that is typically processed in load
+     * pass 2. However, disassembly of control method contents walk the parse
+     * tree with ACPI_PARSE_LOAD_PASS1 and AML_CREATE operators are processed
+     * in a later walk. This is a problem when there is a control method that
+     * has the same name as the AML_CREATE object. In this case, any use of the
+     * name segment will be detected as a method call rather than a reference
+     * to a buffer field.
+     *
+     * This earlier creation during disassembly solves this issue by inserting
+     * the named object in the ACPI namespace so that references to this name
+     * would be a name string rather than a method call.
+     */
+    if ((WalkState->ParseFlags & ACPI_PARSE_DISASSEMBLE) &&
+        (WalkState->OpInfo->Flags & AML_CREATE))
+    {
+        Status = AcpiDsCreateBufferField (Op, WalkState);
+        return_ACPI_STATUS (Status);
+    }
+
     /* We are only interested in opcodes that have an associated name */
 
     if (!(WalkState->OpInfo->Flags & (AML_NAMED | AML_FIELD)))


### PR DESCRIPTION
CreateBufferField is a deferred op that is typically processed in
load pass 2. However, disassembly of control method contents walk the
parse tree with ACPI_PARSE_LOAD_PASS1 and AML_CREATE operators are
processed in a later walk. This is a problem when there is a control
method that has the same name as the AML_CREATE object. In this case,
any use of the name segment will be detected as a method call rather
than a reference to a buffer field. If this is detected as a method
call, it can result in a mal-formed parse tree if the control methods
have parameters.

This change in processing AML_CREATE ops earlier solves this issue by
inserting the named object in the ACPI namespace so that references
to this name would be detected as a name string rather than a method
call.

Reported-by: Elia Geretto <elia.f.geretto@gmail.com>
Tested-by: Elia Geretto <elia.f.geretto@gmail.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>