### PR TITLE
Disassembler: set integer width for AML indicated by the table revision

### DIFF
--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -508,6 +508,8 @@ AdParseTable (
     AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
     ASL_CV_INIT_FILETREE(Table, AmlStart, AmlLength);
 
+    AcpiUtSetIntegerWidth (Table->Revision);
+
     /* Create the root object */
 
     AcpiGbl_ParseOpRoot = AcpiPsCreateScopeOp (AmlStart);


### PR DESCRIPTION
By setting the integer width, the disassembler no longer trucates 64-
bit integers in AML tables with revision 2 or higher.

Reported-by: Elia Geretto <elia.f.geretto@gmail.com>
Tested-by: Elia Geretto <elia.f.geretto@gmail.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>