### PR TITLE
iASL: remove unneeded NULL checks

### DIFF
--- a/source/compiler/aslfiles.c
+++ b/source/compiler/aslfiles.c
@@ -207,12 +207,6 @@ FlInitOneFile (
     NewFileNode = ACPI_CAST_PTR (ASL_GLOBAL_FILE_NODE,
         UtLocalCacheCalloc (sizeof (ASL_GLOBAL_FILE_NODE)));
 
-    if (!NewFileNode)
-    {
-        AslError (ASL_ERROR, ASL_MSG_MEMORY_ALLOCATION, NULL, NULL);
-        return (AE_NO_MEMORY);
-    }
-
     NewFileNode->ParserErrorDetected = FALSE;
     NewFileNode->Next = AslGbl_FilesList;
 

--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -269,10 +269,7 @@ DtDoCompile (
 
     if (ACPI_FAILURE (Status))
     {
-        if (FileNode)
-        {
-            FileNode->ParserErrorDetected = TRUE;
-        }
+        FileNode->ParserErrorDetected = TRUE;
 
         /* TBD: temporary error message. Msgs should come from function above */
 
@@ -299,11 +296,8 @@ DtDoCompile (
 
     /* Save the compile time statistics to the current file node */
 
-    if (FileNode)
-    {
-        FileNode->TotalFields = AslGbl_InputFieldCount;
-        FileNode->OutputByteLength = AslGbl_TableLength;
-    }
+    FileNode->TotalFields = AslGbl_InputFieldCount;
+    FileNode->OutputByteLength = AslGbl_TableLength;
 
     return (Status);
 }


### PR DESCRIPTION
They are unneeded because these functions do not return NULL. In the
case that these functions fail, they end up aborting the entire
program rather than returning NULL.

Reported-by: Colin Ian King <colin.king@canonical.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>