### PR TITLE
iASL: save parameter count of external control method calls for analysis

### DIFF
--- a/source/compiler/asldefine.h
+++ b/source/compiler/asldefine.h
@@ -222,11 +222,11 @@
 
 /* Misc */
 
-#define ASL_EXTERNAL_METHOD         255
-#define ASL_ABORT                   TRUE
-#define ASL_NO_ABORT                FALSE
-#define ASL_EOF                     ACPI_UINT32_MAX
-#define ASL_IGNORE_LINE            (ACPI_UINT32_MAX -1)
+#define ASL_EXTERNAL_METHOD_UNKNOWN_PARAMS  255
+#define ASL_ABORT                           TRUE
+#define ASL_NO_ABORT                        FALSE
+#define ASL_EOF                             ACPI_UINT32_MAX
+#define ASL_IGNORE_LINE                     (ACPI_UINT32_MAX -1)
 
 
 /* Listings */

--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -986,12 +986,19 @@ FinishNode:
     Op->Asl.Node = Node;
     Node->Op = Op;
 
-    /* Set the actual data type if appropriate (EXTERNAL term only) */
-
+    /*
+     * Set the actual data type if appropriate (EXTERNAL term only)
+     * As of 11/19/2019, ASL External() does not support parameter
+     * counts. When an External method is loaded, the parameter count is
+     * unknown setting Node->Value to ASL_EXTERNAL_METHOD_UNKNOWN_PARAMS
+     * indicates that the parameter count for this method is unknown.
+     * This information is used in ASL cross reference to help determine the
+     * parameter count through method calls.
+     */
     if (ActualObjectType != ACPI_TYPE_ANY)
     {
         Node->Type = (UINT8) ActualObjectType;
-        Node->Value = ASL_EXTERNAL_METHOD;
+        Node->Value = ASL_EXTERNAL_METHOD_UNKNOWN_PARAMS;
     }
 
     if (Op->Asl.ParseOpcode == PARSEOP_METHOD)


### PR DESCRIPTION
As of now, iASL does not keep track of parameter counts for external
declarations of methods. In order to determine the parameter count of
external control methods, iASL looks at the first method and saves
the parameter count in AML. However, this information is not present
during namespace cross reference.

This allows code like this to compile without errors:

DefinitionBlock ("", "DSDT", 2, "", "", 0x01)
{
    External (DS01, MethodObj)
    DS01(0x2,0x2) // DS01 is called with 2 parameters
    DS01()        // DS01 is called with 0 parameters
}

This change saves the parameter count of the first method call and
uses it to analyze subsequent method calls. This ensure that a method
that is declared external is called with the same amount of
parameters each time.

Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>