### PR TITLE
Dispatcher: always generate buffer objects for ASL CreateField() oper…

### DIFF
--- a/source/components/dispatcher/dsopcode.c
+++ b/source/components/dispatcher/dsopcode.c
@@ -374,6 +374,7 @@ AcpiDsInitBufferField (
     }
 
     ObjDesc->BufferField.BufferObj = BufferDesc;
+    ObjDesc->BufferField.IsCreateField = AmlOpcode == AML_CREATE_FIELD_OP;
 
     /* Reference count for BufferDesc inherits ObjDesc count */
 

--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -246,7 +246,8 @@ AcpiExGetProtocolBufferLength (
  * RETURN:      Status
  *
  * DESCRIPTION: Read from a named field. Returns either an Integer or a
- *              Buffer, depending on the size of the field.
+ *              Buffer, depending on the size of the field and whether if a
+ *              field is created by the CreateField() operator.
  *
  ******************************************************************************/
 
@@ -310,12 +311,17 @@ AcpiExReadDataFromField (
      * the use of arithmetic operators on the returned value if the
      * field size is equal or smaller than an Integer.
      *
+     * However, all buffer fields created by CreateField operator needs to
+     * remain as a buffer to match other AML interpreter implementations.
+     *
      * Note: Field.length is in bits.
      */
     BufferLength = (ACPI_SIZE) ACPI_ROUND_BITS_UP_TO_BYTES (
         ObjDesc->Field.BitLength);
 
-    if (BufferLength > AcpiGbl_IntegerByteWidth)
+    if (BufferLength > AcpiGbl_IntegerByteWidth ||
+        (ObjDesc->Common.Type == ACPI_TYPE_BUFFER_FIELD &&
+        ObjDesc->BufferField.IsCreateField))
     {
         /* Field is too large for an Integer, create a Buffer instead */
 

--- a/source/include/acobject.h
+++ b/source/include/acobject.h
@@ -489,6 +489,7 @@ typedef struct acpi_object_buffer_field
 {
     ACPI_OBJECT_COMMON_HEADER
     ACPI_COMMON_FIELD_INFO
+    BOOLEAN                         IsCreateField;      /* Special case for objects created by CreateField() */
     union acpi_operand_object       *BufferObj;         /* Containing Buffer object */
 
 } ACPI_OBJECT_BUFFER_FIELD;


### PR DESCRIPTION
…ator

According to table 19-419 of the ACPI 6.3 specification, BufferFields
created using the ASL CreateField() Operator have been treated as
integers if the BufferField is small enough to fit inside of an ASL
integer (32-bits or 64-bits depending on the definition block
revision). If they are larger, buffer fields are treated as ASL
Buffer objects. However, this is not true for other AML interpreter
implementations.

It has been discovered that other AML interpreters always treat
buffer fields created by CreateField() as a buffer regardless of the
length of the buffer field.

More specifically, the Microsoft AML interpreter always treats buffer
fields created by the CreateField() operator as buffer. ACPICA
currently does this only when the field size is larger than the
maximum integer width. This causes problems with AML code shipped in
Microsoft Surface devices.

More details:

The control methods in these devices determine the success of an ASL
control method execution by examining the type resulting from storing
a buffer field created by a CreateField() operator. On success, a
Buffer object is expected, on failure an Integer containing an error
code. This buffer object is created with a dynamic size via the
CreateField() operator. Due to the difference in behavior, Buffer
values of small size are however converted to Integers and thus
interpreted by the control method as having failed, whereas in
reality it succeeded. Below is an example of a control method called
TEST that illustrates this behavior.

Method (CBUF) // Create a Buffer field
{
    /*
     * Depending on the value of RAND, ACPICA interpreter will treat
     * BF00 as an integer or buffer.
     */
    CreateField (BUFF, 0, RAND, BF00)
    return (BF00)
}

Method (TEST)
{
    /*
     * Storing the value returned by CBUF to local0 will result in
     * implicit type conversion outlined in the ACPI specification.
     *
     * ACPICA will treat local0 like an ASL integer if RAND is less
     * than or equal to 64 or 32 (depending on the DefinitionBlock
     * revision). If RAND is greater, it will be treated like an ASL
     * buffer. Other implementations treat local0 like an ASL buffer
     * regardless of the value of RAND.
     */
    local0 = CBUF()

    /*
     * ObjectType of 0x03 represents an ASL Buffer
     */
    if (ObjectType (Local0) != 0x03)
    {
        // Error on ACPICA if RAND is small enough
    }
    else
    {
        /*
         * Success on APICA if RAND is large enough
         * Other implementations always take this path because local0
         * is always treated as a buffer.
         */
    }
}

This change prohibits the previously mentioned integer conversion to
match other AML interpreter implementations (Microsoft) that do not
conform to the ACPI specification.

Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>