### PR TITLE
iASL: emit error on duplicate named objects rather than a warning

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -357,7 +357,7 @@ LdLoadFieldElements (
                      * The name already exists in this scope
                      * But continue processing the elements
                      */
-                    AslDualParseOpError (ASL_WARNING, ASL_MSG_NAME_EXISTS, Child,
+                    AslDualParseOpError (ASL_ERROR, ASL_MSG_NAME_EXISTS, Child,
                         Child->Asl.Value.String, ASL_MSG_FOUND_HERE, Node->Op,
                         Node->Op->Asl.ExternalName);
                 }


### PR DESCRIPTION
Signed-off-by: Erik Schmauss <erik.schmauss@intel.com>