### PR TITLE
iASL: fix forward reference analysis for field declarations

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -279,9 +279,8 @@ LdLoadFieldElements (
     if (SourceRegion)
     {
         Status = AcpiNsLookup (WalkState->ScopeInfo,
-            SourceRegion->Asl.Value.String,
-            AmlType, ACPI_IMODE_EXECUTE,
-            ACPI_NS_DONT_OPEN_SCOPE, NULL, &Node);
+            SourceRegion->Asl.Value.String, AmlType, ACPI_IMODE_EXECUTE,
+            ACPI_NS_SEARCH_PARENT | ACPI_NS_DONT_OPEN_SCOPE, NULL, &Node);
         if (Status == AE_NOT_FOUND)
         {
             /*


### PR DESCRIPTION
Fixes forward reference analysis for field declarations by searching
the parent scope for the named object when the object is not present
in the current scope.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>