### PR TITLE
Prevent disassembler from spilling error messages to output file

### DIFF
--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -156,6 +156,7 @@
 #include "acnamesp.h"
 #include "acparser.h"
 #include "acapps.h"
+#include "acconvert.h"
 
 
 #define _COMPONENT          ACPI_TOOLS
@@ -488,6 +489,10 @@ AdDisassembleOneTable (
 
         return (AE_OK);
     }
+
+    /* Initialize the converter output file */
+
+    ASL_CV_INIT_FILETREE(Table, File);
 
     /*
      * This is an AML table (DSDT or SSDT).

--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -380,8 +380,6 @@ AdAmlDisassemble (
             Status = AE_ERROR;
             goto Cleanup;
         }
-
-        AcpiOsRedirectOutput (File);
     }
 
     *OutFilename = DisasmFilename;
@@ -468,6 +466,11 @@ AdDisassembleOneTable (
 
     if (!AcpiGbl_ForceAmlDisassembly && !AcpiUtIsAmlTable (Table))
     {
+        if (File)
+        {
+            AcpiOsRedirectOutput (File);
+        }
+
         AdDisassemblerHeader (Filename, ACPI_IS_DATA_TABLE);
 
         /* This is a "Data Table" (non-AML table) */
@@ -504,6 +507,13 @@ AdDisassembleOneTable (
         AcpiOsPrintf ("Could not parse ACPI tables, %s\n",
             AcpiFormatException (Status));
         return (Status);
+    }
+
+    /* Redirect output for code generation and debugging output */
+
+    if (File)
+    {
+        AcpiOsRedirectOutput (File);
     }
 
     /* Debug output, namespace and parse tree */

--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -506,7 +506,7 @@ AdParseTable (
 
     AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
     AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
-    ASL_CV_INIT_FILETREE(Table, AmlStart, AmlLength);
+    ASL_CV_INIT_FILETREE(Table);
 
     AcpiUtSetIntegerWidth (Table->Revision);
 

--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -506,7 +506,6 @@ AdParseTable (
 
     AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
     AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
-    ASL_CV_INIT_FILETREE(Table);
 
     AcpiUtSetIntegerWidth (Table->Revision);
 

--- a/source/compiler/cvparser.c
+++ b/source/compiler/cvparser.c
@@ -230,6 +230,7 @@ CvIsFilename (
  * FUNCTION:    CvInitFileTree
  *
  * PARAMETERS:  Table      - input table
+ *              RootFile   - Output file that defines the DefinitionBlock
  *
  * RETURN:      None
  *
@@ -240,7 +241,8 @@ CvIsFilename (
 
 void
 CvInitFileTree (
-    ACPI_TABLE_HEADER       *Table)
+    ACPI_TABLE_HEADER       *Table,
+    FILE                    *RootFile)
 {
     UINT8                   *TreeAml;
     UINT8                   *FileEnd;
@@ -275,7 +277,7 @@ CvInitFileTree (
 
     /* Set the root file to the current open file */
 
-    AcpiGbl_FileTreeRoot->File = AcpiGbl_OutputFile;
+    AcpiGbl_FileTreeRoot->File = RootFile;
 
     /*
      * Set this to true because we don't need to output

--- a/source/compiler/cvparser.c
+++ b/source/compiler/cvparser.c
@@ -230,8 +230,6 @@ CvIsFilename (
  * FUNCTION:    CvInitFileTree
  *
  * PARAMETERS:  Table      - input table
- *              AmlStart   - Address of the starting point of the AML.
- *              AmlLength  - Length of the AML file.
  *
  * RETURN:      None
  *
@@ -242,9 +240,7 @@ CvIsFilename (
 
 void
 CvInitFileTree (
-    ACPI_TABLE_HEADER       *Table,
-    UINT8                   *AmlStart,
-    UINT32                  AmlLength)
+    ACPI_TABLE_HEADER       *Table)
 {
     UINT8                   *TreeAml;
     UINT8                   *FileEnd;
@@ -252,6 +248,8 @@ CvInitFileTree (
     char                    *PreviousFilename = NULL;
     char                    *ParentFilename = NULL;
     char                    *ChildFilename = NULL;
+    UINT8                   *AmlStart;
+    UINT32                  AmlLength;
 
 
     if (!AcpiGbl_CaptureComments)
@@ -259,9 +257,13 @@ CvInitFileTree (
         return;
     }
 
+
+    AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
+    AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
+
     CvDbgPrint ("AmlLength: %x\n", AmlLength);
     CvDbgPrint ("AmlStart:  %p\n", AmlStart);
-    CvDbgPrint ("AmlEnd?:   %p\n", AmlStart+AmlLength);
+    CvDbgPrint ("AmlEnd:    %p\n", AmlStart+AmlLength);
 
     AcpiGbl_FileTreeRoot = AcpiOsAcquireObject (AcpiGbl_FileCache);
 

--- a/source/include/acconvert.h
+++ b/source/include/acconvert.h
@@ -236,7 +236,8 @@ CgWriteAmlComment (
  */
 void
 CvInitFileTree (
-    ACPI_TABLE_HEADER       *Table);
+    ACPI_TABLE_HEADER       *Table,
+    FILE                    *RootFile);
 
 void
 CvClearOpComments (

--- a/source/include/acconvert.h
+++ b/source/include/acconvert.h
@@ -236,9 +236,7 @@ CgWriteAmlComment (
  */
 void
 CvInitFileTree (
-    ACPI_TABLE_HEADER       *Table,
-    UINT8                   *AmlStart,
-    UINT32                  AmlLength);
+    ACPI_TABLE_HEADER       *Table);
 
 void
 CvClearOpComments (

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -625,7 +625,7 @@
 #define ASL_CV_PRINT_ONE_COMMENT(a,b,c,d) CvPrintOneCommentType (a,b,c,d);
 #define ASL_CV_PRINT_ONE_COMMENT_LIST(a,b) CvPrintOneCommentList (a,b);
 #define ASL_CV_FILE_HAS_SWITCHED(a)       CvFileHasSwitched(a)
-#define ASL_CV_INIT_FILETREE(a,b,c)      CvInitFileTree(a,b,c);
+#define ASL_CV_INIT_FILETREE(a)      CvInitFileTree(a);
 
 #else
 
@@ -640,7 +640,7 @@
 #define ASL_CV_PRINT_ONE_COMMENT(a,b,c,d)
 #define ASL_CV_PRINT_ONE_COMMENT_LIST(a,b)
 #define ASL_CV_FILE_HAS_SWITCHED(a)       0
-#define ASL_CV_INIT_FILETREE(a,b,c)
+#define ASL_CV_INIT_FILETREE(a)
 
 #endif
 

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -625,7 +625,7 @@
 #define ASL_CV_PRINT_ONE_COMMENT(a,b,c,d) CvPrintOneCommentType (a,b,c,d);
 #define ASL_CV_PRINT_ONE_COMMENT_LIST(a,b) CvPrintOneCommentList (a,b);
 #define ASL_CV_FILE_HAS_SWITCHED(a)       CvFileHasSwitched(a)
-#define ASL_CV_INIT_FILETREE(a)      CvInitFileTree(a);
+#define ASL_CV_INIT_FILETREE(a,b)      CvInitFileTree(a,b);
 
 #else
 
@@ -640,7 +640,7 @@
 #define ASL_CV_PRINT_ONE_COMMENT(a,b,c,d)
 #define ASL_CV_PRINT_ONE_COMMENT_LIST(a,b)
 #define ASL_CV_FILE_HAS_SWITCHED(a)       0
-#define ASL_CV_INIT_FILETREE(a)
+#define ASL_CV_INIT_FILETREE(a,b)
 
 #endif
 


### PR DESCRIPTION
Error messages generated by the AML parser during disassembly are
emitted to the output file. This is a problem because these messages
do not belong as a part of the output file. If these messages are
emitted in the output file, the user must first delete these messages
before the .dsl file can be re-compiled.

This change refactors existing code and moves the call to redirect
AcpiOsPrintf() after the AML parser has built the parse tree to fix
this problem.
