### PR TITLE
iASL: nest optional parameter types inside a default arg node

### DIFF
--- a/source/compiler/aslrules.y
+++ b/source/compiler/aslrules.y
@@ -422,13 +422,14 @@ ParameterTypePackage
 ParameterTypePackageList
     :                               {$$ = NULL;}
     | ObjectTypeKeyword             {$$ = $1;}
-    | '{' ParameterTypePackage '}'  {$$ = $2;}
+    | '{' ParameterTypePackage '}'  {$$ = TrLinkOpChildren (
+                                        TrCreateLeafOp (PARSEOP_DEFAULT_ARG),1,$2);}
     ;
 
+
 OptionalParameterTypePackage
-    :                               {$$ = TrCreateLeafOp (PARSEOP_DEFAULT_ARG);}
-    | ',' ParameterTypePackageList  {$$ = TrLinkOpChildren (
-                                        TrCreateLeafOp (PARSEOP_DEFAULT_ARG),1,$2);}
+    :                               {$$ = NULL;}
+    | ',' ParameterTypePackageList  {$$ = $2;}
     ;
 
     /* Rules for specifying the types for method arguments */
@@ -442,13 +443,13 @@ ParameterTypesPackage
 ParameterTypesPackageList
     :                               {$$ = NULL;}
     | ObjectTypeKeyword             {$$ = $1;}
-    | '{' ParameterTypesPackage '}' {$$ = $2;}
+    | '{' ParameterTypesPackage '}' {$$ = TrLinkOpChildren (
+                                        TrCreateLeafOp (PARSEOP_DEFAULT_ARG),1,$2);}
     ;
 
 OptionalParameterTypesPackage
-    :                               {$$ = TrCreateLeafOp (PARSEOP_DEFAULT_ARG);}
-    | ',' ParameterTypesPackageList {$$ = TrLinkOpChildren (
-                                        TrCreateLeafOp (PARSEOP_DEFAULT_ARG),1,$2);}
+    :                               {$$ = NULL;}
+    | ',' ParameterTypesPackageList {$$ = $2;}
     ;
 
 /*


### PR DESCRIPTION
The ASL grammar allows methods to be declared with a list of
parameter types. Each parameter type can have a list of optional
types.

For example the following method declaration returns an integer and
has 3 parameters: Arg0 is a string type, Arg1 is either integer or
string, and Arg2 is an integer.

Method (EXAM, 2, NotSerialized, 3, IntObj, {StrObj, {IntObj, StrObj}, IntObj})
{
    // Code here....
}

Previously, the parse tree that represented the parameter list
contained a list of types without any information on alternate types
such as Arg1 in the above example. In other words, the parse tree of
the parameter type list in the above method declaration looked like
this:

StrObj -> IntObj -> StrObj -> IntObj

In order to signify that Arg1 is supposed to be either an integer or
string, this change will nest parameter types inside of a DEFAULT_ARG
parse node. The parse tree of the parameter type list looks like the
following:

StrObj -> DEFAULT_ARG -> IntObj
              |
              |
              +---> IntObj -> StrObj

By doing so, the rest of the code base is able to understand that the
second parameter has an optional list of types.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>