### PR TITLE
iASL: prevent return types and parameter types in non-method externals

### DIFF
--- a/source/compiler/aslexternal.c
+++ b/source/compiler/aslexternal.c
@@ -192,13 +192,49 @@ ExDoExternal (
     ACPI_PARSE_OBJECT       *Prev;
     ACPI_PARSE_OBJECT       *Next;
     ACPI_PARSE_OBJECT       *ArgCountOp;
+    ACPI_PARSE_OBJECT       *TypeOp;
+    UINT32                  ExternType;
 
 
-    ArgCountOp = Op->Asl.Child->Asl.Next->Asl.Next;
-    ArgCountOp->Asl.AmlOpcode = AML_RAW_DATA_BYTE;
-    ArgCountOp->Asl.ParseOpcode = PARSEOP_BYTECONST;
-    ArgCountOp->Asl.Value.Integer = 0;
-    UtSetParseOpName (ArgCountOp);
+    ExternType = AnMapObjTypeToBtype (Op->Asl.Child->Asl.Next);
+
+    /*
+     * The parser allows optional parameter return types regardless of the
+     * type. Check object type keyword emit error if optional parameter/return
+     * types exist
+     */
+    if (ExternType != ACPI_TYPE_METHOD)
+    {
+        /* Check the parameter return type */
+
+        TypeOp = Op->Asl.Child->Asl.Next->Asl.Next;
+        if (TypeOp->Asl.ParseOpcode != PARSEOP_DEFAULT_ARG ||
+            (TypeOp->Asl.ParseOpcode == PARSEOP_DEFAULT_ARG && TypeOp->Asl.Child))
+        {
+            sprintf (AslGbl_MsgBuffer, "Found type [%s]", AcpiUtGetTypeName(ExternType));
+            AslError (ASL_ERROR, ASL_MSG_EXTERN_INVALID_RET_TYPE, TypeOp,
+                AslGbl_MsgBuffer);
+        }
+
+        /* Check the parameter types */
+
+        TypeOp = TypeOp->Asl.Next;
+        if (TypeOp->Asl.ParseOpcode != PARSEOP_DEFAULT_ARG ||
+            (TypeOp->Asl.ParseOpcode == PARSEOP_DEFAULT_ARG && TypeOp->Asl.Child))
+        {
+            sprintf (AslGbl_MsgBuffer, "Found type [%s]", AcpiUtGetTypeName(ExternType));
+            AslError (ASL_ERROR, ASL_MSG_EXTERN_INVALID_PARAM_TYPE, TypeOp,
+                AslGbl_MsgBuffer);
+        }
+    }
+    else
+    {
+        ArgCountOp = Op->Asl.Child->Asl.Next->Asl.Next;
+        ArgCountOp->Asl.AmlOpcode = AML_RAW_DATA_BYTE;
+        ArgCountOp->Asl.ParseOpcode = PARSEOP_BYTECONST;
+        ArgCountOp->Asl.Value.Integer = 0;
+        UtSetParseOpName (ArgCountOp);
+    }
 
     /* Create new list node of arbitrary type */
 

--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -370,7 +370,9 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_INVALID_PROCESSOR_UID */      "_UID inside processor declaration must be an integer",
 /*    ASL_MSG_LEGACY_PROCESSOR_OP */        "Legacy Processor() keyword detected. Use Device() keyword instead.",
 /*    ASL_MSG_NAMESTRING_LENGTH */          "NameString contains too many NameSegs (>255)",
-/*    ASL_MSG_CASE_FOUND_HERE */            "Original Case value below:"
+/*    ASL_MSG_CASE_FOUND_HERE */            "Original Case value below:",
+/*    ASL_MSG_EXTERN_INVALID_RET_TYPE */    "Return type is only allowed for Externals declared as MethodObj",
+/*    ASL_MSG_EXTERN_INVALID_PARAM_TYPE */  "Parameter type is only allowed for Externals declared as MethodObj"
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -373,6 +373,9 @@ typedef enum
     ASL_MSG_LEGACY_PROCESSOR_OP,
     ASL_MSG_NAMESTRING_LENGTH,
     ASL_MSG_CASE_FOUND_HERE,
+    ASL_MSG_EXTERN_INVALID_RET_TYPE,
+    ASL_MSG_EXTERN_INVALID_PARAM_TYPE,
+
 
     /* These messages are used by the Data Table compiler only */
 


### PR DESCRIPTION
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>