### PR TITLE
ACPICA: Makefile: replace HOST with ACPI_HOST

### DIFF
--- a/generate/efi/Makefile.common
+++ b/generate/efi/Makefile.common
@@ -56,6 +56,6 @@ veryclean:	FORCE
 
 machine:	FORCE
 	@echo "Target architecture: $(TARGET)";
-	@echo "Host architecture: $(HOST)";
+	@echo "Host architecture: $(ACPI_HOST)";
 
 FORCE:

--- a/generate/efi/Makefile.config
+++ b/generate/efi/Makefile.config
@@ -39,7 +39,7 @@
 # Common defines
 #
 PROGS =  acpidump efihello
-HOST =   $(shell uname -m | sed s,i[3456789]86,ia32,)
+ACPI_HOST =   $(shell uname -m | sed s,i[3456789]86,ia32,)
 TARGET = $(shell uname -m | sed s,i[3456789]86,ia32,)
 OBJDIR = obj
 BINDIR = bin
@@ -182,11 +182,11 @@ EFIINC =    /usr/include/efi
 ifeq ($(TARGET),ia32)
 
 CFLAGS +=   -DACPI_MACHINE_WIDTH=32
-ifeq ($(HOST),x86_64)
+ifeq ($(ACPI_HOST),x86_64)
 EFILIB =    /usr/lib32
 CFLAGS +=   -m32
 LDFLAGS	+=  -melf_i386
-else # HOST eq ia32
+else # ACPI_HOST eq ia32
 EFILIB =    /usr/lib
 endif
 
@@ -195,11 +195,11 @@ else # TARGET eq x86_64
 CFLAGS += \
 	-DEFI_FUNCTION_WRAPPER\
 	-DACPI_MACHINE_WIDTH=64
-ifeq ($(HOST),ia32)
+ifeq ($(ACPI_HOST),ia32)
 EFILIB =    /usr/lib64
 CFLAGS +=   -m64
 LDFLAGS	+=  -melf_x86_64
-else # HOST eq x86_64
+else # ACPI_HOST eq x86_64
 EFILIB =    /usr/lib
 endif
 

--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -26,15 +26,15 @@
 # Notes:
 #   gcc should be version 4 or greater, otherwise some of the options
 #     used will not be recognized.
-#   Optional: Set HOST to an appropriate value (_LINUX, _FreeBSD, _APPLE, _CYGWIN, etc.)
+#   Optional: Set ACPI_HOST to an appropriate value (_LINUX, _FreeBSD, _APPLE, _CYGWIN, etc.)
 #     See include/platform/acenv.h for supported values.
-#     Note: HOST is not nearly as important for applications as it
+#     Note: ACPI_HOST is not nearly as important for applications as it
 #     is for the kernel-resident version of ACPICA, and it may
 #     not be necessary to change it.
 #
 .SUFFIXES :
 PROGS = acpibin acpidump acpiexamples acpiexec acpihelp acpinames acpisrc acpixtract iasl
-HOST ?= _CYGWIN
+ACPI_HOST ?= _CYGWIN
 CC ?=    gcc
 
 #
@@ -52,26 +52,26 @@ UNAME_S := $(shell uname -s)
 # Host detection and configuration
 #
 ifeq ($(UNAME_S), Darwin)  # Mac OS X
-HOST =       _APPLE
+ACPI_HOST =       _APPLE
 endif
 
 ifeq ($(UNAME_S), DragonFly)
-HOST =       _DragonFly
+ACPI_HOST =       _DragonFly
 endif
 
 ifeq ($(UNAME_S), FreeBSD)
-HOST =       _FreeBSD
+ACPI_HOST =       _FreeBSD
 endif
 
 ifeq ($(UNAME_S), NetBSD)
-HOST =       _NetBSD
+ACPI_HOST =       _NetBSD
 endif
 
 ifeq ($(UNAME_S), QNX)
-HOST =       _QNX
+ACPI_HOST =       _QNX
 endif
 
-ifeq ($(HOST), _APPLE)
+ifeq ($(ACPI_HOST), _APPLE)
 INSTALL  =   cp
 INSTALLFLAGS ?= -f
 else
@@ -183,7 +183,7 @@ OPT_CFLAGS += -D_FORTIFY_SOURCE=2
 endif
 
 CFLAGS += \
-    -D$(HOST)\
+    -D$(ACPI_HOST)\
     -D_GNU_SOURCE\
     -I$(ACPICA_INCLUDE)
 
@@ -191,7 +191,7 @@ CFLAGS += \
 # QNX requires __EXT to enable most functions in its C library, analogous
 # to _GNU_SOURCE.
 #
-ifeq ($(HOST), _QNX)
+ifeq ($(ACPI_HOST), _QNX)
     CFLAGS+=-D__EXT
 endif
 
@@ -231,11 +231,11 @@ CWARNINGFLAGS += \
 #
 # Per-host flags and exclusions
 #
-ifneq ($(HOST), _FreeBSD)
+ifneq ($(ACPI_HOST), _FreeBSD)
     CWARNINGFLAGS += \
         -Wempty-body
 
-    ifneq ($(HOST), _APPLE)
+    ifneq ($(ACPI_HOST), _APPLE)
         CWARNINGFLAGS += \
             -Woverride-init\
             -Wlogical-op\

--- a/generate/unix/acpidump/Makefile
+++ b/generate/unix/acpidump/Makefile
@@ -54,19 +54,19 @@ OBJECTS = \
 #
 # Per-host interfaces
 #
-ifeq ($(HOST), _DragonFly)
+ifeq ($(ACPI_HOST), _DragonFly)
 HOST_FAMILY = BSD
 endif
 
-ifeq ($(HOST), _FreeBSD)
+ifeq ($(ACPI_HOST), _FreeBSD)
 HOST_FAMILY = BSD
 endif
 
-ifeq ($(HOST), _NetBSD)
+ifeq ($(ACPI_HOST), _NetBSD)
 HOST_FAMILY = BSD
 endif
 
-ifeq ($(HOST), _QNX)
+ifeq ($(ACPI_HOST), _QNX)
 HOST_FAMILY = BSD
 endif
 

--- a/generate/unix/acpiexec/Makefile
+++ b/generate/unix/acpiexec/Makefile
@@ -255,12 +255,12 @@ CFLAGS += \
     -DACPI_CHECKSUM_ABORT=TRUE
 endif
 
-ifneq ($(HOST),_QNX)
+ifneq ($(ACPI_HOST),_QNX)
 LDFLAGS += -lpthread
 endif
 
-ifneq ($(HOST),_APPLE)
-ifneq ($(HOST),_QNX)
+ifneq ($(ACPI_HOST),_APPLE)
+ifneq ($(ACPI_HOST),_QNX)
 LDFLAGS += -lrt
 endif
 endif


### PR DESCRIPTION
Some machines may be using HOST in their environment to represent the
host name for their machines. Avoid this problem by renaming to
ACPI_HOST.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>