### PR TITLE
Enable sleep button on ACPI legacy wake

### DIFF
--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -464,6 +464,16 @@ AcpiHwLegacyWake (
             AcpiGbl_FixedEventInfo[ACPI_EVENT_POWER_BUTTON].StatusRegisterId,
             ACPI_CLEAR_STATUS);
 
+    /* Enable sleep button */
+
+	(void) AcpiWriteBitRegister (
+            AcpiGbl_FixedEventInfo[ACPI_EVENT_SLEEP_BUTTON].EnableRegisterId,
+            ACPI_ENABLE_EVENT);
+
+	(void) AcpiWriteBitRegister (
+            AcpiGbl_FixedEventInfo[ACPI_EVENT_SLEEP_BUTTON].StatusRegisterId,
+            ACPI_CLEAR_STATUS);
+
     AcpiHwExecuteSleepMethod (METHOD_PATHNAME__SST, ACPI_SST_WORKING);
     return_ACPI_STATUS (Status);
 }


### PR DESCRIPTION
Hibernation (S4) is triggered in a guest when it recieves a sleep
trigger from the hypervisor. When the guest resumes from this power
state, it does not see the SleepEnabled bit. In otherwords, the sleep
button is not enabled on waking from an S4 state. This causes
subsequent invocation of sleep state to fail in the guest.

Fix this problem by enabling the sleep button in ACPI legacy wake.

Signed-off-by: Anchal Agarwal <anchalag@amazon.com>
Reviewed-by: Balbir Singh <sblbir@amazon.com>
Reviewed-by: Frank van der Linden <fllinden@amazon.com>
[ ek: changelog]
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>