### PR TITLE
iASL: fix method parameter counting when parameterType list is omitted

### DIFF
--- a/source/compiler/aslmethod.c
+++ b/source/compiler/aslmethod.c
@@ -296,6 +296,15 @@ MtMethodAnalysisWalkBegin (
         Next = Next->Asl.Next;
 
         NextType = Next->Asl.Child;
+        if (!NextType)
+        {
+            /*
+             * The optional parameter types list was omitted  at the source
+             * level. Use the Argument count parameter instead.
+             */
+            ActualArgs = MethodInfo->NumArguments;
+        }
+
         while (NextType)
         {
             if (NextType->Asl.ParseOpcode == PARSEOP_DEFAULT_ARG)


### PR DESCRIPTION
Previous commit broke parameter counting for methods that declared
the argument count but omitted the parameterType list.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>