### PR TITLE
iASL: use correct macro name for error message and other trivial fixes

### DIFF
--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1174,6 +1174,10 @@ ACPI_STATUS
 XfCrossReferenceNamespace (
     void);
 
+ACPI_PARSE_OBJECT *
+XfGetParentMethod (
+    ACPI_PARSE_OBJECT       *Op);
+
 
 /*
  * aslxrefout

--- a/source/compiler/aslmethod.c
+++ b/source/compiler/aslmethod.c
@@ -759,7 +759,7 @@ MtCheckStaticOperationRegionInMethod(
          * control method has been found. Throw a warning because this is
          * highly inefficient.
          */
-        AslError(ASL_WARNING, ASL_MSG_STATIC_ARG_OPERATION_REGION, Op, NULL);
+        AslError(ASL_WARNING, ASL_MSG_STATIC_OPREGION_IN_METHOD, Op, NULL);
     }
 
     return;

--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -180,10 +180,6 @@ XfValidateCrossReference (
     const ACPI_OPCODE_INFO  *OpInfo,
     ACPI_NAMESPACE_NODE     *Node);
 
-static ACPI_PARSE_OBJECT *
-XfGetParentMethod (
-    ACPI_PARSE_OBJECT       *Op);
-
 static BOOLEAN
 XfObjectExists (
     char                    *Name);
@@ -393,7 +389,7 @@ XfCheckFieldRange (
  *
  ******************************************************************************/
 
-static ACPI_PARSE_OBJECT *
+ACPI_PARSE_OBJECT *
 XfGetParentMethod (
     ACPI_PARSE_OBJECT       *Op)
 {


### PR DESCRIPTION
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>