### PR TITLE
Iasl trivial fixes and code movement

### DIFF
--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1237,8 +1237,8 @@ UtDumpBasicOp (
     ACPI_PARSE_OBJECT       *Op,
     UINT32                  Level);
 
-void *
-UtGetParentMethod (
+ACPI_NAMESPACE_NODE *
+UtGetParentMethodNode (
     ACPI_NAMESPACE_NODE     *Node);
 
 BOOLEAN

--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1174,10 +1174,6 @@ ACPI_STATUS
 XfCrossReferenceNamespace (
     void);
 
-ACPI_PARSE_OBJECT *
-XfGetParentMethod (
-    ACPI_PARSE_OBJECT       *Op);
-
 
 /*
  * aslxrefout
@@ -1240,6 +1236,10 @@ UtDumpBasicOp (
 ACPI_NAMESPACE_NODE *
 UtGetParentMethodNode (
     ACPI_NAMESPACE_NODE     *Node);
+
+ACPI_PARSE_OBJECT *
+UtGetParentMethodOp (
+    ACPI_PARSE_OBJECT       *Op);
 
 BOOLEAN
 UtNodeIsDescendantOf (

--- a/source/compiler/aslexternal.c
+++ b/source/compiler/aslexternal.c
@@ -193,21 +193,22 @@ ExDoExternal (
     ACPI_PARSE_OBJECT       *Next;
     ACPI_PARSE_OBJECT       *ArgCountOp;
     ACPI_PARSE_OBJECT       *TypeOp;
+    ACPI_PARSE_OBJECT       *ExternTypeOp = Op->Asl.Child->Asl.Next;
     UINT32                  ExternType;
 
 
-    ExternType = AnMapObjTypeToBtype (Op->Asl.Child->Asl.Next);
+    ExternType = AnMapObjTypeToBtype (ExternTypeOp);
 
     /*
      * The parser allows optional parameter return types regardless of the
      * type. Check object type keyword emit error if optional parameter/return
      * types exist
      */
-    if (ExternType != ACPI_TYPE_METHOD)
+    if (ExternType != ACPI_BTYPE_METHOD)
     {
         /* Check the parameter return type */
 
-        TypeOp = Op->Asl.Child->Asl.Next->Asl.Next;
+        TypeOp = ExternTypeOp->Asl.Next;
         if (TypeOp->Asl.ParseOpcode != PARSEOP_DEFAULT_ARG ||
             (TypeOp->Asl.ParseOpcode == PARSEOP_DEFAULT_ARG && TypeOp->Asl.Child))
         {

--- a/source/compiler/aslmethod.c
+++ b/source/compiler/aslmethod.c
@@ -750,7 +750,7 @@ MtCheckStaticOperationRegionInMethod(
     AddressOp = Op->Asl.Child->Asl.Next->Asl.Next;
     LengthOp = Op->Asl.Child->Asl.Next->Asl.Next->Asl.Next;
 
-    if (XfGetParentMethod (Op) &&
+    if (UtGetParentMethodOp (Op) &&
         AddressOp->Asl.ParseOpcode == PARSEOP_INTEGER &&
         LengthOp->Asl.ParseOpcode == PARSEOP_INTEGER)
     {

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -298,7 +298,7 @@ UtNodeIsDescendantOf (
 
 /*******************************************************************************
  *
- * FUNCTION:    UtGetParentMethod
+ * FUNCTION:    UtGetParentMethodNode
  *
  * PARAMETERS:  Node                    - Namespace node for any object
  *
@@ -309,8 +309,8 @@ UtNodeIsDescendantOf (
  *
  ******************************************************************************/
 
-void *
-UtGetParentMethod (
+ACPI_NAMESPACE_NODE *
+UtGetParentMethodNode (
     ACPI_NAMESPACE_NODE     *Node)
 {
     ACPI_NAMESPACE_NODE     *ParentNode;

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -340,6 +340,41 @@ UtGetParentMethodNode (
 
 /*******************************************************************************
  *
+ * FUNCTION:    UtGetParentMethodOp
+ *
+ * PARAMETERS:  Op                      - Parse Op to be checked
+ *
+ * RETURN:      Control method Op if found. NULL otherwise
+ *
+ * DESCRIPTION: Find the control method parent of a parse op. Returns NULL if
+ *              the input Op is not within a control method.
+ *
+ ******************************************************************************/
+
+ACPI_PARSE_OBJECT *
+UtGetParentMethodOp (
+    ACPI_PARSE_OBJECT       *Op)
+{
+    ACPI_PARSE_OBJECT       *NextOp;
+
+
+    NextOp = Op->Asl.Parent;
+    while (NextOp)
+    {
+        if (NextOp->Asl.AmlOpcode == AML_METHOD_OP)
+        {
+            return (NextOp);
+        }
+
+        NextOp = NextOp->Asl.Parent;
+    }
+
+    return (NULL); /* No parent method found */
+}
+
+
+/*******************************************************************************
+ *
  * FUNCTION:    UtDisplaySupportedTables
  *
  * PARAMETERS:  None

--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -378,41 +378,6 @@ XfCheckFieldRange (
 
 /*******************************************************************************
  *
- * FUNCTION:    XfGetParentMethod
- *
- * PARAMETERS:  Op                      - Parse Op to be checked
- *
- * RETURN:      Control method Op if found. NULL otherwise
- *
- * DESCRIPTION: Find the control method parent of a parse op. Returns NULL if
- *              the input Op is not within a control method.
- *
- ******************************************************************************/
-
-ACPI_PARSE_OBJECT *
-XfGetParentMethod (
-    ACPI_PARSE_OBJECT       *Op)
-{
-    ACPI_PARSE_OBJECT       *NextOp;
-
-
-    NextOp = Op->Asl.Parent;
-    while (NextOp)
-    {
-        if (NextOp->Asl.AmlOpcode == AML_METHOD_OP)
-        {
-            return (NextOp);
-        }
-
-        NextOp = NextOp->Asl.Parent;
-    }
-
-    return (NULL); /* No parent method found */
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    XfNamespaceLocateBegin
  *
  * PARAMETERS:  ASL_WALK_CALLBACK
@@ -535,7 +500,7 @@ XfNamespaceLocateBegin (
     {
         /* Find parent method Op */
 
-        NextOp = XfGetParentMethod (Op);
+        NextOp = UtGetParentMethodOp (Op);
         if (!NextOp)
         {
             return_ACPI_STATUS (AE_OK);
@@ -572,7 +537,7 @@ XfNamespaceLocateBegin (
     {
         /* Find parent method Op */
 
-        NextOp = XfGetParentMethod (Op);
+        NextOp = UtGetParentMethodOp (Op);
         if (!NextOp)
         {
             return_ACPI_STATUS (AE_OK);
@@ -811,7 +776,7 @@ XfNamespaceLocateBegin (
          * and should be reported as a compiler error.
          */
         DeclarationParentMethod = UtGetParentMethodNode (Node);
-        ReferenceParentMethod = XfGetParentMethod (Op);
+        ReferenceParentMethod = UtGetParentMethodOp (Op);
 
         /* case 1: declaration and refrence are both outside of method */
 
@@ -1333,7 +1298,7 @@ XfNamespaceLocateEnd (
  *                                      execution of A)
  *
  * NOTES:
- *      A null pointer returned by either XfGetParentMethod or
+ *      A null pointer returned by either UtGetParentMethodOp or
  *      UtGetParentMethodNode indicates that the parameter object is not
  *      within a control method.
  *
@@ -1367,7 +1332,7 @@ XfValidateCrossReference (
      * 1) Search upwards in parse tree for owner of the referencing object
      * 2) Search upwards in namespace to find the owner of the referenced object
      */
-    ReferencingMethodOp = XfGetParentMethod (Op);
+    ReferencingMethodOp = UtGetParentMethodOp (Op);
     ReferencedMethodNode = UtGetParentMethodNode (Node);
 
     if (!ReferencingMethodOp && !ReferencedMethodNode)

--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -810,7 +810,7 @@ XfNamespaceLocateBegin (
          * same method or outside of any method, this is a forward reference
          * and should be reported as a compiler error.
          */
-        DeclarationParentMethod = UtGetParentMethod (Node);
+        DeclarationParentMethod = UtGetParentMethodNode (Node);
         ReferenceParentMethod = XfGetParentMethod (Op);
 
         /* case 1: declaration and refrence are both outside of method */
@@ -1334,7 +1334,7 @@ XfNamespaceLocateEnd (
  *
  * NOTES:
  *      A null pointer returned by either XfGetParentMethod or
- *      UtGetParentMethod indicates that the parameter object is not
+ *      UtGetParentMethodNode indicates that the parameter object is not
  *      within a control method.
  *
  *      Five cases are handled: Case(Op, Node)
@@ -1368,7 +1368,7 @@ XfValidateCrossReference (
      * 2) Search upwards in namespace to find the owner of the referenced object
      */
     ReferencingMethodOp = XfGetParentMethod (Op);
-    ReferencedMethodNode = UtGetParentMethod (Node);
+    ReferencedMethodNode = UtGetParentMethodNode (Node);
 
     if (!ReferencingMethodOp && !ReferencedMethodNode)
     {


### PR DESCRIPTION
This pull request fixes logic to use ACPI_BTYPE instead of ACPI_TYPE. This pull request also moves functions intended to get objects that represent the parent method to aslutils.c and renames them.