### PR TITLE
iASL: use Op->Asl.Nameseg to prevent segfault during method analysis

### DIFF
--- a/source/compiler/aslmethod.c
+++ b/source/compiler/aslmethod.c
@@ -753,9 +753,9 @@ MtCheckNamedObjectInMethod (
 
         /* No error for compiler temp variables (name starts with "_T_") */
 
-        if ((Op->Asl.Node->Name.Ascii[0] != '_') &&
-            (Op->Asl.Node->Name.Ascii[1] != 'T') &&
-            (Op->Asl.Node->Name.Ascii[2] != '_'))
+        if ((Op->Asl.NameSeg[0] != '_') &&
+            (Op->Asl.NameSeg[1] != 'T') &&
+            (Op->Asl.NameSeg[2] != '_'))
         {
             AslError (ASL_REMARK, ASL_MSG_NAMED_OBJECT_CREATION, Op,
                 ExternalPath);


### PR DESCRIPTION
At this point, some named objects may not have a namespace node and
cause the compiler to crash. Instead of using the namespace node to
find the NameSeg, this change uses the parse object's NameSeg
field.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>