### PR TITLE
Introduce AcpiAnyGpeStatusSet ()

### DIFF
--- a/source/components/events/evxfgpe.c
+++ b/source/components/events/evxfgpe.c
@@ -1065,6 +1065,44 @@ AcpiEnableAllWakeupGpes (
 ACPI_EXPORT_SYMBOL (AcpiEnableAllWakeupGpes)
 
 
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiAnyGpeStatusSet
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Whether or not the status bit is set for any GPE
+ *
+ * DESCRIPTION: Check the status bits of all enabled GPEs and return TRUE if any
+ *              of them is set or FALSE otherwise.
+ *
+ ******************************************************************************/
+
+UINT32
+AcpiAnyGpeStatusSet (
+    void)
+{
+    ACPI_STATUS                Status;
+    UINT8                      Ret;
+
+
+    ACPI_FUNCTION_TRACE (AcpiAnyGpeStatusSet);
+
+    Status = AcpiUtAcquireMutex (ACPI_MTX_EVENTS);
+    if (ACPI_FAILURE (Status))
+    {
+        return (FALSE);
+    }
+
+    Ret = AcpiHwCheckAllGpes ();
+    (void) AcpiUtReleaseMutex (ACPI_MTX_EVENTS);
+
+    return (Ret);
+}
+
+ACPI_EXPORT_SYMBOL(AcpiAnyGpeStatusSet)
+
+
 /*******************************************************************************
  *
  * FUNCTION:    AcpiInstallGpeBlock

--- a/source/components/hardware/hwgpe.c
+++ b/source/components/hardware/hwgpe.c
@@ -637,6 +637,58 @@ AcpiHwEnableWakeupGpeBlock (
 
 /******************************************************************************
  *
+ * FUNCTION:    AcpiHwGetGpeBlockStatus
+ *
+ * PARAMETERS:  GpeXruptInfo    - GPE Interrupt info
+ *              GpeBlock        - Gpe Block info
+ *
+ * RETURN:      Success
+ *
+ * DESCRIPTION: Produce a combined GPE status bits mask for the given block.
+ *
+ ******************************************************************************/
+
+static ACPI_STATUS
+AcpiHwGetGpeBlockStatus(
+    ACPI_GPE_XRUPT_INFO     *GpeXruptInfo,
+    ACPI_GPE_BLOCK_INFO     *GpeBlock,
+    void *RetPtr)
+{
+    ACPI_GPE_REGISTER_INFO  *GpeRegisterInfo;
+    UINT64                  InEnable;
+    UINT64                  InStatus;
+    ACPI_STATUS             Status;
+    UINT8                   *Ret = RetPtr;
+    UINT32                  i;
+
+
+    /* Examine each GPE Register within the block */
+
+    for (i = 0; i < GpeBlock->RegisterCount; i++)
+    {
+        GpeRegisterInfo = &GpeBlock->RegisterInfo[i];
+
+        Status = AcpiHwRead (&InEnable, &GpeRegisterInfo->EnableAddress);
+        if (ACPI_FAILURE (Status))
+        {
+            continue;
+        }
+
+        Status = AcpiHwRead (&InStatus, &GpeRegisterInfo->StatusAddress);
+        if (ACPI_FAILURE (Status))
+        {
+            continue;
+        }
+
+        *Ret |= InEnable & InStatus;
+    }
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
  * FUNCTION:    AcpiHwDisableAllGpes
  *
  * PARAMETERS:  None
@@ -713,6 +765,33 @@ AcpiHwEnableAllWakeupGpes (
 
     Status = AcpiEvWalkGpeList (AcpiHwEnableWakeupGpeBlock, NULL);
     return_ACPI_STATUS (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiHwCheckAllGpes
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Combined status of all GPEs
+ *
+ * DESCRIPTION: Check all enabled GPEs in all GPE blocks and return TRUE if the
+ *              status bit is set for at least one of them of FALSE otherwise.
+ *
+ ******************************************************************************/
+
+UINT8
+AcpiHwCheckAllGpes (
+    void)
+{
+    UINT8                      Ret = 0;
+
+
+    ACPI_FUNCTION_TRACE (AcpiHwCheckAllGpes);
+
+    (void) AcpiEvWalkGpeList (AcpiHwGetGpeBlockStatus, &Ret);
+    return (Ret != 0);
 }
 
 #endif /* !ACPI_REDUCED_HARDWARE */

--- a/source/include/achware.h
+++ b/source/include/achware.h
@@ -315,6 +315,10 @@ ACPI_STATUS
 AcpiHwEnableAllWakeupGpes (
     void);
 
+UINT8
+AcpiHwCheckAllGpes (
+    void);
+
 ACPI_STATUS
 AcpiHwEnableRuntimeGpeBlock (
     ACPI_GPE_XRUPT_INFO     *GpeXruptInfo,

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -1109,6 +1109,10 @@ ACPI_STATUS
 AcpiEnableAllWakeupGpes (
     void))
 
+ACPI_HW_DEPENDENT_RETURN_UINT32 (
+    UINT32                  AcpiAnyGpeStatusSet (
+    void))
+
 ACPI_HW_DEPENDENT_RETURN_STATUS (
 ACPI_STATUS
 AcpiGetGpeDevice (


### PR DESCRIPTION
Introduce a new helper function, AcpiAnyGpeStatusSet(), for
checking the status bits of all enabled GPEs in one go.

It is needed to distinguish spurious SCIs from genuine ones when
deciding whether or not to wake up the system from suspend-to-idle.

Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>