### PR TITLE
Change PlatformCommChannel ASL keyword to PCC

### DIFF
--- a/source/compiler/aslcompiler.l
+++ b/source/compiler/aslcompiler.l
@@ -692,7 +692,7 @@ NamePathTail                [.]{NameSeg}
 "IPMI"                      { count (0); return (PARSEOP_REGIONSPACE_IPMI); }
 "GeneralPurposeIo"          { count (0); return (PARSEOP_REGIONSPACE_GPIO); }       /* ACPI 5.0 */
 "GenericSerialBus"          { count (0); return (PARSEOP_REGIONSPACE_GSBUS); }      /* ACPI 5.0 */
-"PlatformCommChannel"       { count (0); return (PARSEOP_REGIONSPACE_PCC); }        /* ACPI 5.0 */
+"PCC"                       { count (0); return (PARSEOP_REGIONSPACE_PCC); }        /* ACPI 5.0 */
 "FFixedHW"                  { count (0); return (PARSEOP_REGIONSPACE_FFIXEDHW); }
 
     /* ResourceTypeKeyword: Resource Usage - Resource Descriptors */

--- a/source/components/utilities/utdecode.c
+++ b/source/components/utilities/utdecode.c
@@ -224,7 +224,7 @@ const char        *AcpiGbl_RegionTypes[ACPI_NUM_PREDEFINED_REGIONS] =
     "IPMI",              /* 0x07 */
     "GeneralPurposeIo",  /* 0x08 */
     "GenericSerialBus",  /* 0x09 */
-    "PlatformCommChannel"/* 0x0A */
+    "PCC"                /* 0x0A */
 };
 
 

--- a/tests/aslts/src/runtime/collections/functional/region/regionfield.asl
+++ b/tests/aslts/src/runtime/collections/functional/region/regionfield.asl
@@ -47068,7 +47068,7 @@ printf ("BINT: %o %o %o %o\n", Arg2, Local6, Local7, Local2)
     {
         Name (OLEN, 16) // Length of the operation region
         Name (CLEN, 8) // Length of FLGS, LNGT, COMD, COSP
-        OperationRegion (PCC1, PlatformCommChannel, 0x1, OLEN)
+        OperationRegion (PCC1, PCC, 0x1, OLEN)
         Field (PCC1, AnyAcc, NoLock, Preserve)
         {
             Offset(4),  // 4 bytes
@@ -47123,7 +47123,7 @@ printf ("BINT: %o %o %o %o\n", Arg2, Local6, Local7, Local2)
         Name (OLEN, 26) // Length of the operation region
         Name (CLEN, 16) // Length of FLGS, LNGT, COMD, COSP
 
-        OperationRegion (PCC3, PlatformCommChannel, 0x3, OLEN)
+        OperationRegion (PCC3, PCC, 0x3, OLEN)
         Field (PCC3, AnyAcc, NoLock, Preserve)
         {
             Offset(4),  // 4 bytes


### PR DESCRIPTION
The former was proposed during specification discussions but it was
dropped. This keyword was introduced to the ACPICA code base by
mistake so this commit changes the keyword representing Platform
Communication Channel to be PCC.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>