### PR TITLE
Bz1522

### DIFF
--- a/source/compiler/aslcompiler.l
+++ b/source/compiler/aslcompiler.l
@@ -156,7 +156,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-YYSTYPE AslCompilerlval;
 
 /*
  * Generation:  Use the following command line:

--- a/source/compiler/dtcompiler.h
+++ b/source/compiler/dtcompiler.h
@@ -461,7 +461,6 @@ DtCreateTableUnit (
 
 /* dtparser - lex/yacc files */
 
-UINT64                      DtCompilerParserResult; /* Expression return value */
 int
 DtCompilerParserparse (
     void);

--- a/source/compiler/dtcompilerparser.l
+++ b/source/compiler/dtcompilerparser.l
@@ -153,7 +153,6 @@
 #include "aslcompiler.h"
 #include "dtcompilerparser.y.h"
 
-YYSTYPE DtCompilerlval;
 
 #define _COMPONENT          ACPI_COMPILER
         ACPI_MODULE_NAME    ("dtcompilerscanner")

--- a/source/compiler/dtcompilerparser.y
+++ b/source/compiler/dtcompilerparser.y
@@ -170,7 +170,6 @@ extern char                 *DtCompilerParsertext;
 extern DT_FIELD             *AslGbl_CurrentField;
 
 extern int                  DtLabelByteOffset;
-extern UINT64               DtCompilerParserResult; /* Expression return value */
 extern UINT64               DtCompilerParserlineno; /* Current line number */
 
 extern UINT32               DtTokenFirstLine;

--- a/source/compiler/dtparser.l
+++ b/source/compiler/dtparser.l
@@ -208,7 +208,7 @@ NewLine         [\n]
 /*
  * Local support functions
  */
-YY_BUFFER_STATE         LexBuffer;
+static YY_BUFFER_STATE         LexBuffer;
 
 /******************************************************************************
  *

--- a/source/compiler/prparser.l
+++ b/source/compiler/prparser.l
@@ -224,7 +224,7 @@ Identifier      [a-zA-Z][0-9a-zA-Z]*
 /*
  * Local support functions
  */
-YY_BUFFER_STATE         LexBuffer;
+static YY_BUFFER_STATE         LexBuffer;
 
 
 /******************************************************************************

--- a/source/components/debugger/dbxface.c
+++ b/source/components/debugger/dbxface.c
@@ -594,6 +594,7 @@ AcpiInitializeDebugger (
     AcpiGbl_DbOutputFlags       = ACPI_DB_CONSOLE_OUTPUT;
 
     AcpiGbl_DbOpt_NoIniMethods  = FALSE;
+    AcpiGbl_DbOpt_NoRegionSupport = FALSE;
 
     AcpiGbl_DbBuffer = AcpiOsAllocate (ACPI_DEBUG_BUFFER_SIZE);
     if (!AcpiGbl_DbBuffer)

--- a/source/tools/acpiexec/aemain.c
+++ b/source/tools/acpiexec/aemain.c
@@ -192,7 +192,6 @@ BOOLEAN                     AcpiGbl_VerboseHandlers = FALSE;
 UINT8                       AcpiGbl_RegionFillValue = 0;
 BOOLEAN                     AcpiGbl_IgnoreErrors = FALSE;
 BOOLEAN                     AcpiGbl_AbortLoopOnTimeout = FALSE;
-BOOLEAN                     AcpiGbl_DbOpt_NoRegionSupport = FALSE;
 UINT8                       AcpiGbl_UseHwReducedFadt = FALSE;
 BOOLEAN                     AcpiGbl_DoInterfaceTests = FALSE;
 BOOLEAN                     AcpiGbl_LoadTestTables = FALSE;


### PR DESCRIPTION
This pull request contains commits that allow ACPICA to build with GCC 10 which (by default) is more strict about redundant variable declarations.