### PR TITLE
utilities: fix sprintf()

### DIFF
--- a/source/components/utilities/utprint.c
+++ b/source/components/utilities/utprint.c
@@ -565,7 +565,7 @@ vsnprintf (
     if (Size != ACPI_UINT32_MAX) {
         End = String + Size;
     } else {
-        End = (char *)(uintptr_t)ACPI_UINT32_MAX;
+        End = ACPI_CAST_PTR(char, ACPI_UINT32_MAX):
     }
 
     for (; *Format; ++Format)

--- a/source/components/utilities/utprint.c
+++ b/source/components/utilities/utprint.c
@@ -560,7 +560,13 @@ vsnprintf (
 
 
     Pos = String;
-    End = String + Size;
+
+
+    if (Size != ACPI_UINT32_MAX) {
+        End = String + Size;
+    } else {
+        End = (char *)(uintptr_t)ACPI_UINT32_MAX;
+    }
 
     for (; *Format; ++Format)
     {


### PR DESCRIPTION
On 32-bit, the provided sprintf() is non-functional: with a size of
ACPI_UINT32_MAX, String + Size will wrap, meaning End < Start, and
AcpiUtBoundStringOutput() will never output anything as a result.

The symptom we saw of this was acpixtract failing to output anything.

Signed-off-by: John Levon <john.levon@joyent.com>