### PR TITLE
acpibin: rename local variable Buffer to DataBuffer to avoid name sha…

### DIFF
--- a/source/tools/acpibin/abcompare.c
+++ b/source/tools/acpibin/abcompare.c
@@ -619,7 +619,7 @@ AbGetFile (
 {
     FILE                    *File;
     UINT32                  Size;
-    char                    *Buffer = NULL;
+    char                    *DataBuffer = NULL;
     size_t                  Actual;
 
 
@@ -643,8 +643,8 @@ AbGetFile (
 
     /* Allocate a buffer for the entire file */
 
-    Buffer = calloc (Size, 1);
-    if (!Buffer)
+    DataBuffer = calloc (Size, 1);
+    if (!DataBuffer)
     {
         printf ("Could not allocate buffer of size %u\n", Size);
         goto ErrorExit;
@@ -652,12 +652,12 @@ AbGetFile (
 
     /* Read the entire file */
 
-    Actual = fread (Buffer, 1, Size, File);
+    Actual = fread (DataBuffer, 1, Size, File);
     if (Actual != Size)
     {
         printf ("Could not read the input file %s\n", Filename);
-        free (Buffer);
-        Buffer = NULL;
+        free (DataBuffer);
+        DataBuffer = NULL;
         goto ErrorExit;
     }
 
@@ -665,7 +665,7 @@ AbGetFile (
 
 ErrorExit:
     fclose (File);
-    return (Buffer);
+    return (DataBuffer);
 }
 
 


### PR DESCRIPTION
…dowing

The local variable Buffer is shadowing another variable called
buffer that also declared in the same source file. Avoid any accidental
name shadowing confusion by renaming the local variable. Cleans up
cppcheck static analysis warning:

source/tools/acpibin/abcompare.c:622:30: style: Local variable 'Buffer'
shadows outer variable [shadowVariable]
    char                    *Buffer = NULL;

source/tools/acpibin/abcompare.c:159:29: note: Shadowed declaration
char                        Buffer[BUFFER_SIZE];

source/tools/acpibin/abcompare.c:622:30: note: Shadow variable
    char                    *Buffer = NULL;

Signed-off-by: Colin Ian King <colin.king@canonical.com>