### PR TITLE
WSMT: Fix typo, no functional change

### DIFF
--- a/source/common/ahtable.c
+++ b/source/common/ahtable.c
@@ -258,7 +258,7 @@ const AH_TABLE      AcpiGbl_SupportedTables[] =
     {ACPI_SIG_WDDT, "Watchdog Description Table"},
     {ACPI_SIG_WDRT, "Watchdog Resource Table"},
     {ACPI_SIG_WPBT, "Windows Platform Binary Table"},
-    {ACPI_SIG_WSMT, "Windows SMM Security Migrations Table"},
+    {ACPI_SIG_WSMT, "Windows SMM Security Mitigations Table"},
     {ACPI_SIG_XENV, "Xen Environment table"},
     {ACPI_SIG_XSDT, "Extended System Description Table"},
     {NULL,          NULL}

--- a/source/common/dmtbinfo3.c
+++ b/source/common/dmtbinfo3.c
@@ -691,7 +691,7 @@ ACPI_DMTABLE_INFO           AcpiDmTableInfoWpbt0[] =
 
 /*******************************************************************************
  *
- * WSMT - Windows SMM Security Migrations Table
+ * WSMT - Windows SMM Security Mitigations Table
  *
  ******************************************************************************/
 

--- a/source/include/actbl3.h
+++ b/source/include/actbl3.h
@@ -183,7 +183,7 @@
 #define ACPI_SIG_WDDT           "WDDT"      /* Watchdog Timer Description Table */
 #define ACPI_SIG_WDRT           "WDRT"      /* Watchdog Resource Table */
 #define ACPI_SIG_WPBT           "WPBT"      /* Windows Platform Binary Table */
-#define ACPI_SIG_WSMT           "WSMT"      /* Windows SMM Security Migrations Table */
+#define ACPI_SIG_WSMT           "WSMT"      /* Windows SMM Security Mitigations Table */
 #define ACPI_SIG_XENV           "XENV"      /* Xen Environment table */
 #define ACPI_SIG_XXXX           "XXXX"      /* Intermediate AML header for ASL/ASL+ converter */
 
@@ -904,10 +904,10 @@ typedef struct acpi_table_wpbt
 
 /*******************************************************************************
  *
- * WSMT - Windows SMM Security Migrations Table
+ * WSMT - Windows SMM Security Mitigations Table
  *        Version 1
  *
- * Conforms to "Windows SMM Security Migrations Table",
+ * Conforms to "Windows SMM Security Mitigations Table",
  * Version 1.0, April 18, 2016
  *
  ******************************************************************************/


### PR DESCRIPTION
The table signature WSMT stands for "Windows SMM Mitigations Table".
It is not "Windows SMM Migrations Table".

Reported-by: Laszlo Ersek <lersek@redhat.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>