### PR TITLE
Add NHLT table signature

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -187,6 +187,7 @@
 #define ACPI_SIG_SBST           "SBST"      /* Smart Battery Specification Table */
 #define ACPI_SIG_SDEI           "SDEI"      /* Software Delegated Exception Interface Table */
 #define ACPI_SIG_SDEV           "SDEV"      /* Secure Devices table */
+#define ACPI_SIG_NHLT           "NHLT"      /* Non-HDAudio Link Table */
 
 
 /*


### PR DESCRIPTION
NHLT (Non-HDAudio Link Table) provides configuration of audio
endpoints for Intel SST (Smart Sound Technology) DSP products.

iASL data table compiler support will be implemented in the near
future.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>
[EK: edited commit message]
Signed-off-by: Cezary Rojewski <cezary.rojewski@intel.com>