### PR TITLE
acpixtract: fix AX_IS_TABLE_BLOCK_HEADER macro

### DIFF
--- a/source/tools/acpixtract/acpixtract.h
+++ b/source/tools/acpixtract/acpixtract.h
@@ -194,8 +194,8 @@
 #define AX_LINE_BUFFER_SIZE         256
 #define AX_MIN_BLOCK_HEADER_LENGTH  6   /* strlen ("DSDT @") */
 #define AX_HEX_DATA_LENGTH          49  /*  (3 * 16) + 1 for the colon delimiter */
-#define AX_IS_TABLE_BLOCK_HEADER    (strlen (Gbl_LineBuffer) < AX_HEX_DATA_LENGTH) && \
-                                    (strstr (Gbl_LineBuffer, " @ "))
+#define AX_IS_TABLE_BLOCK_HEADER    (strlen (Gbl_LineBuffer) < AX_HEX_DATA_LENGTH && \
+                                    strstr (Gbl_LineBuffer, " @ "))
 
 
 typedef struct AxTableInfo


### PR DESCRIPTION
This macro needs to be surrounded by parens. Otherwise, a logical
statement that applies a logical not operator to this macros could
result in a computation that applies the operator to the left side of
the logical and but not the right.

Reported-by: John Levon <john.levon@joyent.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>