### PR TITLE
Make AcpiProtocolLengths static

### DIFF
--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -167,7 +167,7 @@
 #define ACPI_INVALID_PROTOCOL_ID        0x80
 #define ACPI_MAX_PROTOCOL_ID            0x0F
 
-const UINT8     AcpiProtocolLengths[] =
+static const UINT8      AcpiProtocolLengths[] =
 {
     ACPI_INVALID_PROTOCOL_ID,   /* 0 - reserved */
     ACPI_INVALID_PROTOCOL_ID,   /* 1 - reserved */


### PR DESCRIPTION
A linux-based static analyzer (sparse) caught this as a warning.
Making this variable static will result in better optimizations and
ensure that this variable does not get used outside of this file.

Signed-off-by: Yue Haibing <yuehaibing@huawei.com>
[ek: commit message]
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>