### PR TITLE
Move AcpiGbl_NextCmdNum definition to acglobal.h

### DIFF
--- a/source/common/acgetline.c
+++ b/source/common/acgetline.c
@@ -189,8 +189,6 @@ AcpiAcClearLine (
 #define _ASCII_LEFT_ARROW           'D'
 #define _ASCII_NEWLINE              '\n'
 
-extern UINT32               AcpiGbl_NextCmdNum;
-
 /* Erase a single character on the input command line */
 
 #define ACPI_CLEAR_CHAR() \

--- a/source/components/debugger/dbhistry.c
+++ b/source/components/debugger/dbhistry.c
@@ -175,7 +175,6 @@ static HISTORY_INFO         AcpiGbl_HistoryBuffer[HISTORY_SIZE];
 static UINT16               AcpiGbl_LoHistory = 0;
 static UINT16               AcpiGbl_NumHistory = 0;
 static UINT16               AcpiGbl_NextHistoryIndex = 0;
-UINT32                      AcpiGbl_NextCmdNum = 1;
 
 
 /*******************************************************************************

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -436,6 +436,7 @@ ACPI_GLOBAL (ACPI_EXTERNAL_FILE *,      AcpiGbl_ExternalFileList);
 #ifdef ACPI_DEBUGGER
 ACPI_INIT_GLOBAL (BOOLEAN,              AcpiGbl_AbortMethod, FALSE);
 ACPI_INIT_GLOBAL (ACPI_THREAD_ID,       AcpiGbl_DbThreadId, ACPI_INVALID_THREAD_ID);
+ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_NextCmdNum, 1);
 
 ACPI_GLOBAL (BOOLEAN,                   AcpiGbl_DbOpt_NoIniMethods);
 ACPI_GLOBAL (BOOLEAN,                   AcpiGbl_DbOpt_NoRegionSupport);


### PR DESCRIPTION
This commit cleans up the code by moving the global definition out of
a .c file to a more approperiate acglobal.h file.

Reported-by: Hulk Robot <hulkci@huawei.com>
Suggested-by: Jason Yan <yanaijie@huawei.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>