### PR TITLE
IVRS table: fix potentially uninitialized variable warning

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -528,8 +528,10 @@ AcpiDmDumpIvrs (
                 DeviceEntry = ACPI_ADD_PTR (ACPI_IVRS_DE_HEADER, Subtable,
                     sizeof (ACPI_IVRS_HARDWARE1));
             }
-            else if (Subtable->Type == ACPI_IVRS_TYPE_HARDWARE2)
+            else
             {
+                /* ACPI_IVRS_TYPE_HARDWARE2 subtable type */
+
                 EntryOffset = Offset + sizeof (ACPI_IVRS_HARDWARE2);
                 DeviceEntry = ACPI_ADD_PTR (ACPI_IVRS_DE_HEADER, Subtable,
                     sizeof (ACPI_IVRS_HARDWARE2));


### PR DESCRIPTION
Some compilers catch potential uninitialized variables. This is done
by examining branches of if/else statements. This change replaces an
"else if" with an "else" to fix the uninitialized variable warning.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>