### PR TITLE
compiler/aslanalyze: Fix test condition on 2nd char for GPE method

### DIFF
--- a/source/compiler/aslanalyze.c
+++ b/source/compiler/aslanalyze.c
@@ -587,7 +587,7 @@ ApCheckForGpeNameConflict (
      * 3rd/4th chars must be a hex number
      */
     if ((Name[0] != '_') ||
-       ((Name[1] != 'L') && (Name[1] != 'E')))
+        !((Name[1] == 'L') || (Name[1] == 'E')))
     {
         return;
     }


### PR DESCRIPTION
The test '((Name[1] != 'L') && (Name[1] != 'E'))' is always false.
As the 2nd char must be L or E, we would use:
if !((Name[1] == 'L') || (Name[1] == 'E'))
	return;

Signed-off-by: Elyes HAOUAS <ehaouas@noos.fr>