### PR TITLE
fix required parameters for _NIG and _NIH

### DIFF
--- a/source/include/acpredef.h
+++ b/source/include/acpredef.h
@@ -769,10 +769,10 @@ const ACPI_PREDEFINED_INFO          AcpiGbl_PredefinedMethods[] =
     {{"_NIC",   METHOD_0ARGS,                          /* ACPI 6.3 */
                 METHOD_RETURNS (ACPI_RTYPE_BUFFER)}},
 
-    {{"_NIG",   METHOD_1ARGS (ACPI_TYPE_BUFFER),       /* ACPI 6.3 */
+    {{"_NIG",   METHOD_0ARGS,                          /* ACPI 6.3 */
                 METHOD_RETURNS (ACPI_RTYPE_BUFFER)}},
 
-    {{"_NIH",   METHOD_0ARGS,                          /* ACPI 6.3 */
+    {{"_NIH",   METHOD_1ARGS (ACPI_TYPE_BUFFER),       /* ACPI 6.3 */
                 METHOD_RETURNS (ACPI_RTYPE_BUFFER)}},
 
     {{"_NTT",   METHOD_0ARGS,


### PR DESCRIPTION
Previously, there was a mixup where _NIG required one parameter and
_NIH required zero parameters. This changes swaps these parameter
requirements. Now this change requires _NIH to be called with one
parameter and _NIG requires zero.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>