### PR TITLE
iASL: fix insertion of external method parameter count

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -1007,6 +1007,13 @@ FinishNode:
          */
         Node->Value = (UINT32) Op->Asl.Extra;
     }
+    else if (Op->Asl.ParseOpcode == PARSEOP_EXTERNAL &&
+        Node->Type == ACPI_TYPE_METHOD &&
+        (Node->Flags & ANOBJ_IS_EXTERNAL))
+    {
+        Node->Value =
+            (UINT32) Op->Asl.Child->Asl.Next->Asl.Next->Asl.Value.Integer;
+    }
 
     return_ACPI_STATUS (Status);
 }


### PR DESCRIPTION
This fixes a regression that occurred in the following commit:
e47525c99de25a95861abdf9184e8424b7ea5d67
iASL: fix incorrect type override of namespace nodes during namespace load

The previous commit unintentionally removed the code to insert
external method parameter count.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>