### PR TITLE
psparse: Do not parse if DSDT AML has zero size

### DIFF
--- a/source/components/parser/psparse.c
+++ b/source/components/parser/psparse.c
@@ -579,6 +579,13 @@ AcpiPsParseAml (
         return_ACPI_STATUS (AE_BAD_ADDRESS);
     }
 
+    /* If size of AML is zero, we succeeded. There is nothing to do */
+
+    if (!WalkState->ParserState.AmlSize)
+    {
+        return_ACPI_STATUS (AE_OK);
+    }
+
     /* Create and initialize a new thread state */
 
     Thread = AcpiUtCreateThreadState ();


### PR DESCRIPTION
Bypasses a page fault when the DSDT is present but has empty aml.

Linux seems to not experience a fault from this, perhaps there is a workaround in Linux for this (?)

In any case, it seems like a waste of cpu cycles to attempt parsing an empty AML.

Signed-off-by: Damien Zammit <damien@zamaudio.com>