### PR TITLE
iASL: do not optimize namepaths under CondRefOf operator

### DIFF
--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -821,9 +821,24 @@ XfNamespaceLocateBegin (
         Node->Flags |= ANOBJ_IS_REFERENCED;
     }
 
-    /* Attempt to optimize the NamePath */
-
-    OptOptimizeNamePath (Op, OpInfo->Flags, WalkState, Path, Node);
+    /*
+     * Attempt to optimize the NamePath
+     *
+     * One special case: CondRefOf operator - not all AML interpreter
+     * implementations expect optimized namepaths as a parameter to this
+     * operator. They require relative name paths with prefix operators or
+     * namepaths starting with the root scope.
+     *
+     * Other AML interpreter implementations do not perform the namespace
+     * search that starts at the current scope and recursively searching the
+     * parent scope until the root scope. The lack of search is only known to
+     * occur for the namestring parameter for the CondRefOf operator.
+     */
+    if ((Op->Asl.Parent) &&
+        (Op->Asl.Parent->Asl.ParseOpcode != PARSEOP_CONDREFOF))
+    {
+        OptOptimizeNamePath (Op, OpInfo->Flags, WalkState, Path, Node);
+    }
 
     /*
      * 1) Dereference an alias (A name reference that is an alias)


### PR DESCRIPTION
Some AML interpreter implementations do not search the parent scope
during the execution of the CondRefOf operator. They require
pathnames with parent prefixes (^) or full namestrings. This change
prevents the namepath optimization that results from cross-
referencing the CondRefOf parameter introduced in commit 9091f8909
(iASL: cross-reference namestring parameter of CondRefOf operator).

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>