### PR TITLE
Replace one-element array with flexible-array

### DIFF
--- a/source/components/utilities/utids.c
+++ b/source/components/utilities/utids.c
@@ -435,7 +435,7 @@ AcpiUtExecute_CID (
      * 3) Size of the actual CID strings
      */
     CidListSize = sizeof (ACPI_PNP_DEVICE_ID_LIST) +
-        ((Count - 1) * sizeof (ACPI_PNP_DEVICE_ID)) +
+        (Count * sizeof (ACPI_PNP_DEVICE_ID)) +
         StringAreaSize;
 
     CidList = ACPI_ALLOCATE_ZEROED (CidListSize);

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1379,7 +1379,7 @@ typedef struct acpi_pnp_device_id_list
 {
     UINT32                          Count;              /* Number of IDs in Ids array */
     UINT32                          ListSize;           /* Size of list, including ID strings */
-    ACPI_PNP_DEVICE_ID              Ids[1];             /* ID array */
+    ACPI_PNP_DEVICE_ID              Ids[];              /* ID array */
 
 } ACPI_PNP_DEVICE_ID_LIST;
 


### PR DESCRIPTION
The current codebase makes use of one-element arrays in the following
form:

struct something {
    int length;
    u8 data[1];
};

struct something *instance;

instance = kmalloc(sizeof(*instance) + size, GFP_KERNEL);
instance->length = size;
memcpy(instance->data, source, size);

but the preferred mechanism to declare variable-length types such as
these ones is a flexible array member[1][2], introduced in C99:

struct foo {
        int stuff;
        struct boo array[];
};

By making use of the mechanism above, we will get a compiler warning
in case the flexible array does not occur last in the structure,
which will help us prevent some kind of undefined behavior bugs from
being inadvertently introduced[3] to the linux codebase from now on.

This issue was found with the help of Coccinelle and audited _manually_.

[1] https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html
[2] https://github.com/KSPP/linux/issues/21
[3] commit 76497732932f ("cxgb3/l2t: Fix undefined behaviour")

Signed-off-by: Gustavo A. R. Silva <gustavoars@kernel.org>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>