### PR TITLE
ASLTS: Replace inaccurate language

### DIFF
--- a/tests/aslts/src/runtime/collections/bdemo/ACPICA/0239_ACTION_REQUIRED/MAIN.asl
+++ b/tests/aslts/src/runtime/collections/bdemo/ACPICA/0239_ACTION_REQUIRED/MAIN.asl
@@ -59,7 +59,7 @@ DefinitionBlock(
 
 		Store(1, Local0)
 		if (arg2) {
-			/* Slave threads */
+			/* Worker threads */
 			Store(0, Local0)
 		} else {
 			/* Control thread */

--- a/tests/aslts/src/runtime/collections/bdemo/ACPICA/0240_ACTION_REQUIRED/MAIN.asl
+++ b/tests/aslts/src/runtime/collections/bdemo/ACPICA/0240_ACTION_REQUIRED/MAIN.asl
@@ -59,7 +59,7 @@ DefinitionBlock(
 
 		Store(1, Local0)
 		if (arg2) {
-			/* Slave threads */
+			/* Worker threads */
 			Store(0, Local0)
 		} else {
 			/* Control thread */

--- a/tests/aslts/src/runtime/collections/mt/mutex/MAIN.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/MAIN.asl
@@ -37,7 +37,7 @@ DefinitionBlock ("mt_mutex", "DSDT", 2, "Intel", "Many", 0x00000001)
     Include ("../../../../runtime/collections/mt/mutex/mutex.asl")
     Include ("../../../../runtime/collections/mt/mutex/mxs.asl")
     Include ("../../../../runtime/collections/mt/mutex/example0.asl")
-    Include ("../../../../runtime/collections/mt/mutex/slave_thr.asl")
+    Include ("../../../../runtime/collections/mt/mutex/worker_thr.asl")
     /*
      * Arguments passed to MAIN method are:
      *

--- a/tests/aslts/src/runtime/collections/mt/mutex/SPEC
+++ b/tests/aslts/src/runtime/collections/mt/mutex/SPEC
@@ -1,6 +1,6 @@
 Descriptions of tests
 
-Thread means below the Slave thread
+Thread means below the Worker thread
 (if another is not specified explicitly).
 
 Active agents of subject of mt-testing
@@ -45,7 +45,7 @@ The 0-th thread, so-called Control Thread, is not counted in this entry.
 # ===  TEST 001 (mf01)  === #
 # ========================= #
 
-FUNCTION OF EACH SLAVE THREAD:
+FUNCTION OF EACH WORKER THREAD:
 
    Acquire one mutex of i-th level, Sleep, then Release it.
    Check the mutually exclusive ownership of mutex.
@@ -63,7 +63,7 @@ THR-NUMBER: arbitrary, all threads do the same
 DETAILS:
 
 1. The Control thread resets all flags and counters of all mutexes.
-2. The Slave threads do the same actions with each of the same N mutexes of i-th level:
+2. The Worker threads do the same actions with each of the same N mutexes of i-th level:
    - acquire the mutex
    - check that flag of the mutex is zero (not set up yet)
    - set up flag of the mutex to the index of this thread
@@ -74,11 +74,11 @@ DETAILS:
      while this one was sleeping
    - reset flag of the mutex
    - release mutex
-3. Control thread after all the slave threads complete with all N mutexes of i-th level:
+3. Control thread after all the worker threads complete with all N mutexes of i-th level:
    - checks that the counter of each relevant mutex is correct
-   - report errors detected by Slave threads
+   - report errors detected by Worker threads
    - report other errors
-4. Control thread initiates and Slave threads fulfill actions (2)
+4. Control thread initiates and Worker threads fulfill actions (2)
    for mutexes of all levels one after another from 0 up to 15
    (and GL too).
 
@@ -86,7 +86,7 @@ DETAILS:
 # ===  TEST 002 (mf02)  === #
 # ========================= #
 
-FUNCTION OF EACH SLAVE THREAD:
+FUNCTION OF EACH WORKER THREAD:
 
    Acquire mutexes of all levels then Release them in the inverse order.
 
@@ -103,7 +103,7 @@ THR-NUMBER: arbitrary, all threads do the same
 
 DETAILS:
 
-1. The Slave threads do the same actions described below:
+1. The Worker threads do the same actions described below:
    - acquire one by one mutexes of all levels from 0 up to 15 (N mutexes per level)
    - after acquiring the mutex of 15-th level start releaseng them in the inverse order
    - do the control actions with the flags and counters of mutexes (see comment to mf01)

--- a/tests/aslts/src/runtime/collections/mt/mutex/common.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/common.asl
@@ -41,7 +41,7 @@
      *   the test.
      *
      * Control Thread - the thread with index equal to 0
-     * Slave Threads  - all other threads with the non-zero index
+     * Worker Threads  - all other threads with the non-zero index
      *
      * Number of threads (total) -
      *    the value passed to AcpiExec Threads command
@@ -82,16 +82,16 @@
      */
     Name (VB00, 0x00) /* (0) common messages */
     Name (VB02, 0x01) /* (1) trace Control thread */
-    Name (VB03, 0x00) /* (0) trace Slave threads */
+    Name (VB03, 0x00) /* (0) trace Worker threads */
     Name (VB04, 0x01) /* (1) report statistics */
-    Name (VB05, 0x00) /* (0) report warnings by slave-threads */
-    Name (VB06, 0x01) /* (1) report errors by slave-threads */
+    Name (VB05, 0x00) /* (0) report warnings by worker-threads */
+    Name (VB06, 0x01) /* (1) report errors by worker-threads */
     /*
      * Multi-conditional switches of the verbal mode
      *
      * 0 - silent
      * 1 - allow only for Control Thread to report
-     * 2 - allow only for Slave Threads to report
+     * 2 - allow only for Worker Threads to report
      * 3 - allow for all threads to report
      *
      * mc-flags
@@ -100,17 +100,17 @@
     /* Sleep mode */
 
     Name (SL00, 0x32) /* Default milliseconds to sleep for Control thread */
-    Name (SL01, 0x32) /* Default milliseconds to sleep for Slave threads */
+    Name (SL01, 0x32) /* Default milliseconds to sleep for Worker threads */
     /*
      * Default milliseconds to sleep for Control thread
-     * before to check hang status of slave threads on
+     * before to check hang status of worker threads on
      * operations.
      */
     Name (SL02, 0x01F4)
     /* How many times maximum to repeat sl02 sleeping */
 
     Name (SL03, 0x01)
-    Name (SLM0, 0x00)   /* Sleeping mode for slave threads */
+    Name (SLM0, 0x00)   /* Sleeping mode for worker threads */
     /* Milliseconds to sleep for non-zero slm0 */
 
     Name (I100, 0x32)
@@ -122,7 +122,7 @@
     Name (I106, 0x96)
     Name (I107, 0xFA)
     Name (I108, 0x012C)
-    /* Commands for slaves */
+    /* Commands for workers */
 
     Name (C100, 0xF0) /* Idle thread */
     Name (C101, 0xF1) /* Exit the infinite loop */
@@ -136,22 +136,22 @@
     Name (C109, 0xF9) /* Invoke Serialized method */
     Name (C10A, 0xFA) /* Invoke non-Serialized method, use Mutex for exclusive access to critical section */
     Name (C10B, 0xFB) /* Non-serialized method is grabbed simultaneously */
-    /* Responds of slave threads (not intersect with 'Commands for slaves') */
+    /* Responds of worker threads (not intersect with 'Commands for workers') */
 
     Name (RS00, 0x97) /* "I see zero do00" */
     /* Common use strategies provided by the Control thread */
 
-    Name (CM01, 0x01) /* all slaves to exit the infinite loop */
-    Name (CM02, 0x02) /* all slaves to sleep for the specified period */
+    Name (CM01, 0x01) /* all workers to exit the infinite loop */
+    Name (CM02, 0x02) /* all workers to sleep for the specified period */
     /*
      * This buffer is to be filled by the control thread.
      * It is filed with the commands to be fulfilled by the
-     * slave threads.
+     * worker threads.
      *
      * The thread of i-th index takes the command from the
      * i-th element of Buffer.
      *
-     * It is read-only for slave threads.
+     * It is read-only for worker threads.
      */
     Name (BS00, Buffer (0x01)
     {
@@ -159,7 +159,7 @@
     })
     /*
      * This buffer is zeroed by the control thread and then to be
-     * filled by the slave threads with the commands they have been
+     * filled by the worker threads with the commands they have been
      * fulfilled.
      */
     Name (BS01, Buffer (0x01)
@@ -168,9 +168,9 @@
     })
     /*
      * This buffer is zeroed by the control thread and then to be
-     * filled by the slave threads when they see that do00 is zero.
+     * filled by the worker threads when they see that do00 is zero.
      *
-     * The control thread uses it to check that all the slave threads
+     * The control thread uses it to check that all the worker threads
      * saw zero do00 (are idle) before to start the next command.
      */
     Name (BS02, Buffer (0x01)
@@ -179,7 +179,7 @@
     })
     /*
      * This buffer is zeroed by the control thread and then to
-     * be filled by the idle slave threads.
+     * be filled by the idle worker threads.
      */
     Name (BS03, Buffer (0x01)
     {
@@ -187,7 +187,7 @@
     })
     /*
      * This buffer is zeroed by the control thread and then to be
-     * set up by the slave threads when they complete.
+     * set up by the worker threads when they complete.
      */
     Name (BS04, Buffer (0x01)
     {
@@ -198,7 +198,7 @@
      */
     /*
      * These package are zeroed by the control thread,
-     * the slave threads accumulate there:
+     * the worker threads accumulate there:
      * - errors
      * - number of errors
      * - warnings
@@ -239,7 +239,7 @@
      * non-zero enables to fulfill the commands specified by bs00.
      */
     Name (DO00, 0x00)
-    /* Opcodes of errors reported by slave threads */
+    /* Opcodes of errors reported by worker threads */
 
     Name (ER00, 0x01) /* Acquire failed */
     Name (ER01, 0x02) /* Flag of mutex is already non-zero (set up by some thread(s)) */
@@ -255,18 +255,18 @@
     Name (ER11, 0x0800) /* Serialized method doesn't provide exclusive call */
     Name (ER12, 0x1000) /* Non-serialized method thr-1 didn't get into method */
     Name (ER13, 0x2000) /* Non-serialized method thr-N didn't get into method */
-    /* Opcodes of warnings reported by slave threads */
+    /* Opcodes of warnings reported by worker threads */
 
     Name (WN00, 0x01) /* Acquire repeatedly the same mutex by thread which already owns it */
     /*
      * These packages are to be filled by the control thread.
      * They are filed with the arguments of commands specified
-     * for the slave threads.
+     * for the worker threads.
      *
      * The thread of i-th index takes the arguments from the
      * i-th elements of Packages.
      *
-     * These are read-only for slave threads.
+     * These are read-only for worker threads.
      *
      * For Acquire/Release:
      *
@@ -352,14 +352,14 @@
     Name (FLG3, 0x00)
     /*
      * The Control Thread manages and controls the specified testing strategy
-     * to be fulfilled by the Slave Threads.
+     * to be fulfilled by the Worker Threads.
      *
      * arg0 - number of threads
      * arg1 - ID of current thread (0, can be used for control only)
      * arg2 - Index of current thread
      * arg3 - cammand - index of the test strategy to be
      *        managed and controlled by the Control Thread
-     *        and fulfilled by the Slave Threads (Slaves).
+     *        and fulfilled by the Worker Threads (Workers).
      *
      * Arguments of the command arg3:
      *
@@ -369,19 +369,19 @@
      */
     Method (M100, 7, Serialized)
     {
-        /* Prohibits activity of all the slave threads */
+        /* Prohibits activity of all the worker threads */
 
         Switch (Arg3)
         {
             Case (0x01)
             {
-                /* CM01: All slaves to exit the infinite loop */
+                /* CM01: All workers to exit the infinite loop */
 
                 M10C (Arg0)
             }
             Case (0x02)
             {
-                /* CM02: All slaves to sleep for the specified period */
+                /* CM02: All workers to sleep for the specified period */
 
                 M10D (Arg0)
             }
@@ -469,14 +469,14 @@
     }
 
     /*
-     * Control thread waits for all the slave threads to
+     * Control thread waits for all the worker threads to
      * fulfill the specified for them buffer of commands.
      *
      * arg0 - number of threads
      */
     Method (M103, 1, Serialized)
     {
-        /* Wait for all Slave threads and check their statuses */
+        /* Wait for all Worker threads and check their statuses */
 
         Name (B000, Buffer (Arg0){})
         Name (B001, Buffer (Arg0){})
@@ -650,7 +650,7 @@
     }
 
     /*
-     * Report errors detected by the slave threads
+     * Report errors detected by the worker threads
      *
      * arg0 - name of test
      * arg1 - number of threads
@@ -750,26 +750,26 @@
      */
     Method (M108, 4, NotSerialized)
     {
-        /* all slaves to exit the infinite loop */
+        /* all workers to exit the infinite loop */
 
         M100 (Arg1, Arg2, Arg3, CM01, 0x00, 0x00, 0x00)
-        /* Report errors detected by the slave threads */
+        /* Report errors detected by the worker threads */
 
         M106 (Arg0, Arg1)
     }
 
     /*
-     * CM01: all slaves to exit the infinite loop
+     * CM01: all workers to exit the infinite loop
      *
      * arg0 - number of threads
      */
     Method (M10C, 1, Serialized)
     {
-        /* All slaves to exit the infinite loop */
+        /* All workers to exit the infinite loop */
 
         M200 (BS00, Arg0, C101) /* cmd: Exit the infinite loop */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         Name (B000, Buffer (Arg0){})
         Name (B001, Buffer (Arg0){})
@@ -779,23 +779,23 @@
     }
 
     /*
-     * CM02: all slaves to sleep for the specified period
+     * CM02: all workers to sleep for the specified period
      *
      * arg0 - number of threads
      */
     Method (M10D, 1, NotSerialized)
     {
-        /* All slaves to sleep for the specified period */
+        /* All workers to sleep for the specified period */
 
         M200 (BS00, Arg0, C102) /* cmd: Sleep for the specified number of Milliseconds */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
 
     /*
-     * Control thread checks that the specified set of slave threads
+     * Control thread checks that the specified set of worker threads
      * hang on the specified operations or completed the operations.
      *
      * arg0 - number of threads
@@ -892,7 +892,7 @@
     }
 
     /*
-     * Control thread waits for all the slave threads to
+     * Control thread waits for all the worker threads to
      * fulfill the specified for them buffer of commands.
      *
      * arg0 - number of threads (total)
@@ -912,7 +912,7 @@
         Name (IDL0, 0x00)
         Name (QUIT, 0x00)
         /*
-         * Check that all the slave threads saw my
+         * Check that all the worker threads saw my
          * non-zero do00 and fulfilled the proper command.
          */
         While (0x01)
@@ -1057,7 +1057,7 @@
         }
 
         /*
-         * Set do00 to zero and check that all the slave threads
+         * Set do00 to zero and check that all the worker threads
          * saw my zero do00 (if only it is not the EXIT command).
          */
         M200 (BS02, Arg0, 0x00)
@@ -1122,7 +1122,7 @@
              */
             Sleep (SL00)
         }
-        /* All the slave threads are ready for any next command */
+        /* All the worker threads are ready for any next command */
     }
 
     /*
@@ -1233,7 +1233,7 @@
     }
 
     /*
-     * Control thread initiates execution of commands by the slave threads
+     * Control thread initiates execution of commands by the worker threads
      *
      * arg0 - number of threads (total)
      */

--- a/tests/aslts/src/runtime/collections/mt/mutex/mt_access.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/mt_access.asl
@@ -35,7 +35,7 @@
  *
  * Notations:
  *
- * Leading thread - the slave thread #1 which plays in the relevant test
+ * Leading thread - the worker thread #1 which plays in the relevant test
  *                  some control role.
  */
 
@@ -45,16 +45,16 @@ Name(b900, Buffer(){0,0,0,0,0,0,0,0})
 
 /*
  * This buffer is zeroed by the leading thread and then to
- * be filled by other slave threads, some non-zero respond to
+ * be filled by other worker threads, some non-zero respond to
  * the leading thread.
  */
 Name(b901, Buffer(){0,0,0,0,0,0,0,0})
 
 /*
  * This buffer is zeroed by the leading thread and then to be
- * filled by other slave threads when they see that i900 is zero.
+ * filled by other worker threads when they see that i900 is zero.
  *
- * The leading thread uses it to check that all the slave threads
+ * The leading thread uses it to check that all the worker threads
  * saw zero i900 before to start the next command.
  */
 Name(b902, Buffer(){0,0,0,0,0,0,0,0})
@@ -66,7 +66,7 @@ Name(c900, 0x31) //
 /*
  * Test #.
  *
- * Leading thread (thread #1) is a controlling thread other are slave threads here.
+ * Leading thread (thread #1) is a controlling thread other are worker threads here.
  *
  * arg0 - number of threads
  * arg1 - ID of current thread
@@ -104,7 +104,7 @@ Method(m900, 1)
 
 			Store(c900, Local0)
 
-			/* Control thread allows for slave threads to fulfill their commands */
+			/* Control thread allows for worker threads to fulfill their commands */
 			if (i900) {
 				Store(DerefOf(Index(b901, arg2)), Local1)
 				/* This thread doesn't yet fulfill its command */
@@ -131,11 +131,11 @@ Method(m900, 1)
 }
 
 /*
- * Thread 1 waits for all the slave threads to
+ * Thread 1 waits for all the worker threads to
  * fulfill the specified for them the buffer of commands.
  *
  * arg0 - number of threads
- * arg1 - flag if to check that all the slave threads saw my zero do00
+ * arg1 - flag if to check that all the worker threads saw my zero do00
  */
 Method(m9ff, 2)
 {
@@ -144,7 +144,7 @@ Method(m9ff, 2)
 	Name(find, 0)
 
 	/*
-	 * Check that all the slave threads saw my
+	 * Check that all the worker threads saw my
 	 * non-zero do00 and fulfilled the proper command.
 	 */
 	While (1) {
@@ -179,7 +179,7 @@ Method(m9ff, 2)
 	}
 
 	/*
-	 * Check that all the slave threads saw my zero do00
+	 * Check that all the worker threads saw my zero do00
 	 * (if only it is not the EXIT command).
 	 * Note: assumed that EXIT command is specified for all
 	 *       the threads simultaneously, so only.
@@ -225,6 +225,6 @@ Method(m9ff, 2)
 			Sleep(sl00)
 		}
 
-		/* All the slave threads are ready for any next command */
+		/* All the worker threads are ready for any next command */
 	}
 }

--- a/tests/aslts/src/runtime/collections/mt/mutex/mutex.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/mutex.asl
@@ -34,8 +34,8 @@
      SEE:
      ??????????????????????????????????????????
      1) See sleeping mode ... and m209
-     3) remove all mf0X - slaves only once go into
-     } else { // Slave Threads
+     3) remove all mf0X - workers only once go into
+     } else { // Worker Threads
      m101(arg0, arg1, arg2, 0)
      }
      and Ctl Thread do mf00()
@@ -73,7 +73,7 @@
 
         M204 ("mf01", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -88,7 +88,7 @@
             /* Open testing */
 
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Acquire/Sleep/Release for all 0-15 levels and GL */
@@ -121,7 +121,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -153,7 +153,7 @@
 
         M204 ("mf02", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -161,7 +161,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /*
@@ -177,7 +177,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -209,7 +209,7 @@
 
         M204 ("mf03", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -217,7 +217,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /*
@@ -231,7 +231,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -263,7 +263,7 @@
 
         M204 ("mf04", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -271,7 +271,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf04) */
@@ -283,7 +283,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -315,7 +315,7 @@
 
         M204 ("mf05", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -323,7 +323,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf05) */
@@ -335,7 +335,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -367,7 +367,7 @@
 
         M204 ("mf06", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -375,7 +375,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf06) */
@@ -387,7 +387,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -419,7 +419,7 @@
 
         M204 ("mf07", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -427,7 +427,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf07) */
@@ -439,7 +439,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -471,7 +471,7 @@
 
         M204 ("mf08", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -479,7 +479,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf08) */
@@ -491,7 +491,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -523,7 +523,7 @@
 
         M204 ("mf09", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -531,7 +531,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf09) */
@@ -543,7 +543,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -575,7 +575,7 @@
 
         M204 ("mf10", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -583,7 +583,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf10) */
@@ -595,7 +595,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -627,7 +627,7 @@
 
         M204 ("mf11", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -635,7 +635,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf11) */
@@ -647,7 +647,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -679,7 +679,7 @@
 
         M204 ("mf12", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -687,7 +687,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf12) */
@@ -699,7 +699,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -731,7 +731,7 @@
 
         M204 ("mf13", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -739,7 +739,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf13) */
@@ -751,7 +751,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -783,7 +783,7 @@
 
         M204 ("mf14", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -791,7 +791,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf14) */
@@ -803,7 +803,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -835,7 +835,7 @@
 
         M204 ("mf15", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -843,7 +843,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf15) */
@@ -855,7 +855,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -887,7 +887,7 @@
 
         M204 ("mf16", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -895,7 +895,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf16) */
@@ -907,7 +907,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -939,7 +939,7 @@
 
         M204 ("mf17", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -947,7 +947,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf17) */
@@ -959,7 +959,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -991,7 +991,7 @@
 
         M204 ("mf18", Arg0, Arg1, Arg2)
         /*
-         * The Slave Threads loop forever executing strategies
+         * The Worker Threads loop forever executing strategies
          * specified and controlled by the Control Thread.
          */
         If ((Arg2 == 0x00))
@@ -999,7 +999,7 @@
             /* Control Thread */
             /* Open testing */
             M102 (Arg0)
-            /* All slaves to sleep */
+            /* All workers to sleep */
 
             M100 (Arg0, Arg1, Arg2, CM02, 0x00, 0x00, 0x00)
             /* Test (see SPEC for mf18) */
@@ -1011,7 +1011,7 @@
         }
         Else
         {
-            /* Slave Threads */
+            /* Worker Threads */
 
             M101 (Arg0, Arg1, Arg2, 0x00)
         }
@@ -1029,8 +1029,8 @@
             /* Sleeping mode */
 
             SL00 = 0x0A /* default milliseconds to sleep for Control thread */
-            SL01 = 0x0A /* default milliseconds to sleep for Slave threads */
-            SLM0 = 0x00  /* sleeping mode for slave threads */
+            SL01 = 0x0A /* default milliseconds to sleep for Worker threads */
+            SLM0 = 0x00  /* sleeping mode for worker threads */
         }
 
         If (!Y251)
@@ -1051,7 +1051,7 @@
                 }
 
                 VB04 = 0x00 /* don't print statistics */
-                CTL0 = 0x01 /* Slave threads - go! */
+                CTL0 = 0x01 /* Worker threads - go! */
                 SRMT ("mt_mutex_tests")
             }
 

--- a/tests/aslts/src/runtime/collections/mt/mutex/mxs.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/mxs.asl
@@ -625,14 +625,14 @@
     }
 
     /*
-     * Control thread initiates slaves to Acquire
+     * Control thread initiates workers to Acquire
      * specified set of mutexes - on each specified
      * level - one mutex of Index which is equal to
      * ((Index of thread) - 1).
      *
-     * When all slaves complete that operation checks up
+     * When all workers complete that operation checks up
      * the state of execution of operation provided by
-     * slaves.
+     * workers.
      *
      * arg0 - number of threads (total)
      * arg1 - number of threads (threads actually in work)
@@ -659,7 +659,7 @@
 
         M210 (BS00, Arg0, C106, 0x00, Arg1, 0x01, C102) /* cmd: Acquire specified set of mutexes */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -675,12 +675,12 @@
     }
 
     /*
-     * Control thread initiates slaves to Release
+     * Control thread initiates workers to Release
      * specified set of mutexes - on each specified
      * level - one mutex of Index which is equal to
      * ((Index of thread) - 1).
      *
-     * Control thread initiates slaves to Release
+     * Control thread initiates workers to Release
      * specified set of mutexes.
      *
      * arg0 - number of threads (total)
@@ -699,13 +699,13 @@
 
         M210 (BS00, Arg0, C107, 0x00, Arg1, 0x01, C102) /* cmd: Release specified set of mutexes */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
 
     /*
-     * Control thread checks that the specified set of slave threads
+     * Control thread checks that the specified set of worker threads
      * hang on the specified operations or completed the operations.
      *
      * See m10e for args:
@@ -727,7 +727,7 @@
     }
 
     /*
-     * Run command for the specified set of slaves
+     * Run command for the specified set of workers
      *
      * arg0 - number of threads
      * arg1 - specificator of elements (see m20a)
@@ -737,13 +737,13 @@
     {
         M20A (BS00, Arg0, Arg2, Arg1) /* cmd */
         M114 (Arg0)
-        /* Wait for Slave threads */
+        /* Wait for Worker threads */
 
         M103 (Arg0)
     }
 
     /*
-     * Control thread initiates commands for slaves to be fulfilled.
+     * Control thread initiates commands for workers to be fulfilled.
      * After commands execution checks the statuses of all threads.
      *
      * It should be one of the following:
@@ -768,17 +768,17 @@
      *        buffer/Integer, per-thread commands to be fulfilled
      *        Integer:
      *          0        - undefined
-     *          non-zero - the same command for all slave threads
+     *          non-zero - the same command for all worker threads
      *        Buffer (elements of buffer):
      *          0        - undefined
-     *          non-zero - command for the relevant slave thread
+     *          non-zero - command for the relevant worker thread
      *
      * arg2 - Exceptional conditions flags (buffer/Integer)
      *
      *        buffer/Integer, per-thread flags of exceptional conditions
      *        Integer:
      *          - non-zero means that we generate the same
-     *            exceptional condition for all slave threads
+     *            exceptional condition for all worker threads
      *        Buffer (elements of buffer):
      *          0        - exception is not expected
      *          non-zero - means that we generate exceptional condition
@@ -809,7 +809,7 @@
      *
      *        buffer/Integer, per-thread levels of mutexes
      *        Integer:
-     *          - the same level of mutex for all slave threads
+     *          - the same level of mutex for all worker threads
      *            (number of levels is 1)
      *        Buffer (elements of buffer):
      *        Pairs:
@@ -820,7 +820,7 @@
      *
      *        buffer/Integer, per-thread indexes of mutexes
      *        Integer:
-     *          - the same index of mutex for all slave threads
+     *          - the same index of mutex for all worker threads
      *            (number of mutexes of the same level is 1)
      *        Buffer (elements of buffer):
      *        Pairs:
@@ -832,20 +832,20 @@
      *        buffer/Integer, per-thread commands to check for completion
      *        Integer:
      *          0        - do nothing
-     *          non-zero - the same command for all slave threads
+     *          non-zero - the same command for all worker threads
      *        Buffer (elements of buffer):
      *          0        - do nothing
-     *          non-zero - command for the relevant slave thread
+     *          non-zero - command for the relevant worker thread
      *
      * arg6 - Expected hang statuses (the same semantics as Commands) (buffer/Integer).
      *
      *        buffer/Integer, per-thread commands to check for hang
      *        Integer:
      *          0        - do nothing
-     *          non-zero - the same command for all slave threads
+     *          non-zero - the same command for all worker threads
      *        Buffer (elements of buffer):
      *          0        - do nothing
-     *          non-zero - command for the relevant slave thread
+     *          non-zero - command for the relevant worker thread
      *
      *        Note: non-zero 0-th element of the buffer means the
      *              number of hanging threads expected to wake up
@@ -888,7 +888,7 @@
          * Note: not specified elements of buffers are not touched.
          */
         HAS1 = M340 (NTH1, Arg1, Arg2, Arg3, Arg4)
-        /* Allow slaves to execute their commands */
+        /* Allow workers to execute their commands */
 
         M114 (NTH0)
         /* 2) Check status of execution of commands */
@@ -907,7 +907,7 @@
          * Local1 - expectations of hang
          * Local2 - idle
          */
-        /* Wait for all Slave threads and check their statuses */
+        /* Wait for all Worker threads and check their statuses */
         M110 (NTH0, Local0, Local1, Local2)
         /* Reset exception expectation */
 

--- a/tests/aslts/src/runtime/collections/mt/mutex/service.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/service.asl
@@ -176,7 +176,7 @@
             }
             Case (0x02)
             {
-                /* allow only for Slave Threads to report */
+                /* allow only for Worker Threads to report */
 
                 If (Arg0)
                 {

--- a/tests/aslts/src/runtime/collections/mt/mutex/tests.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/tests.asl
@@ -27,13 +27,13 @@
      */
     /*
      * The test strategies to be managed and controlled by the
-     * Control Thread and fulfilled by the Slave Threads (Slaves).
+     * Control Thread and fulfilled by the Worker Threads (Workers).
      */
     Name (Z152, 0x98)
     /*
      * Acquire/Sleep/Release
      *
-     * All slaves:
+     * All workers:
      * - Acquire the same mutex
      * - increment global counter
      * - set up another global to its Index
@@ -63,7 +63,7 @@
 
         M210 (BS00, Arg0, C103, 0x00, NUMW, 0x01, C102) /* cmd: Acquire/Sleep/Release */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexes */
@@ -103,7 +103,7 @@
 
         M210 (BS00, Arg0, C104, 0x00, NUMW, 0x01, C102) /* cmd: <Acquire/Sleep>(0-15 levels)/Release(15-0 levels) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -150,7 +150,7 @@
 
         M210 (BS00, Arg0, C105, 0x00, NUMW, 0x01, C102) /* cmd: Example 0 */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
@@ -183,7 +183,7 @@
         M208 (BS00, THR, C106)  /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -207,7 +207,7 @@
         M208 (BS00, THR, C106)  /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -234,7 +234,7 @@
             M200 (BS00, Arg0, C102) /* cmd: Sleep */
             M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
             M114 (Arg0)
-            /* Wait for all Slave threads */
+            /* Wait for all Worker threads */
 
             M103 (Arg0)
         }
@@ -248,7 +248,7 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         If (Arg1)
@@ -262,7 +262,7 @@
             M200 (BS00, Arg0, C102) /* cmd: Sleep */
             M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
             M114 (Arg0)
-            /* Wait for all Slave threads */
+            /* Wait for all Worker threads */
 
             M103 (Arg0)
         }
@@ -316,7 +316,7 @@
         M208 (BS00, THR, C106)  /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -343,7 +343,7 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Reset exception expectation */
@@ -359,7 +359,7 @@
         M208 (BS00, THR, C106)  /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -386,7 +386,7 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Reset exception expectation */
@@ -405,7 +405,7 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Reset exception expectation */
@@ -421,7 +421,7 @@
         M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* 10. Thread_2 Releases its mutexes */
@@ -433,7 +433,7 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR, C107)  /* cmd: Release specified set of mutexes */
         M114 (Arg0)
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
@@ -623,7 +623,7 @@
                  * 3. Acquire mutexes from 0 to (N-1) levels:
                  *	- Set up per-thread set of mutexes
                  *	- Acquire specified set of mutexes
-                 *	- Wait for all Slave threads
+                 *	- Wait for all Worker threads
                  *	- Check up the values of counters of all Mutexs
                  */
                 M337 (Arg0, NUMW, 0x00, LPC0, 0x01, 0x00)
@@ -631,7 +631,7 @@
                  * 4. Release mutexes from 0 to (N-1) levels:
                  *	- Set up per-thread set of mutexes
                  *	- Release specified set of mutexes
-                 *	- Wait for all Slave threads
+                 *	- Wait for all Worker threads
                  */
                 M338 (Arg0, NUMW, 0x00, LPC0)
                 /* Reset all counters (cnt0) and flags (fl00) corresponding to all Mutexes */
@@ -660,7 +660,7 @@
                  * 8. Acquire mutexes from (N+1) to 15 levels
                  *	- Set up per-thread set of mutexes
                  *	- Acquire specified set of mutexes
-                 *	- Wait for all Slave threads
+                 *	- Wait for all Worker threads
                  *	- Check up the values of counters of all Mutexs
                  */
                 Local0 = (LPC0 + 0x01)
@@ -672,7 +672,7 @@
              * 9. Release all mutexes (starting with lpC0 up to 15 level):
              *	- Set up per-thread set of mutexes
              *	- Release specified set of mutexes
-             *	- Wait for all Slave threads
+             *	- Wait for all Worker threads
              */
             Local1 = (MAX0 - LPC0) /* \M807.LPC0 */
             M338 (Arg0, NUMW, LPC0, Local1)
@@ -685,7 +685,7 @@
                  * 10. Acquire mutexes from 0 to (N-1) levels:
                  *	- Set up per-thread set of mutexes
                  *	- Acquire specified set of mutexes
-                 *	- Wait for all Slave threads
+                 *	- Wait for all Worker threads
                  *	- Check up the values of counters of all Mutexs
                  */
                 M337 (Arg0, NUMW, 0x00, LPC0, 0x01, 0x00)
@@ -693,7 +693,7 @@
                  * 11. Release mutexes (from 0 to (N-1) levels):
                  *	- Set up per-thread set of mutexes
                  *	- Release specified set of mutexes
-                 *	- Wait for all Slave threads
+                 *	- Wait for all Worker threads
                  */
                 M338 (Arg0, NUMW, 0x00, LPC0)
                 /* Reset all counters (cnt0) and flags (fl00) corresponding to all Mutexes */
@@ -2070,7 +2070,7 @@
         M208 (BS00, THR2, C106) /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -2102,7 +2102,7 @@
         M214 (Arg0, Arg0, TOV1) /* TimeOutValue equal to 1 msec */
         M20F (Arg0, EX0D, 0x00)    /* Init the exceptional conditions flags (FAIL) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* 3. Thread thr-N terminates */
@@ -2111,7 +2111,7 @@
         M208 (BS00, THR2, C108) /* cmd: Terminate thread */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
@@ -2129,7 +2129,7 @@
         M208 (BS00, THR1, C106) /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* 5. Thread thr-1 Releases all mutexes */
@@ -2138,7 +2138,7 @@
         M208 (BS00, THR1, C107) /* cmd: Release specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
@@ -2179,7 +2179,7 @@
         M208 (BS00, THR2, C106) /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /* Check up the values of counters of all Mutexs */
@@ -2211,7 +2211,7 @@
         M214 (Arg0, Arg0, TOV1) /* TimeOutValue equal to 1 msec */
         M20F (Arg0, EX0D, 0x00)    /* Init the exceptional conditions flags (FAIL) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
@@ -2227,7 +2227,7 @@
         M208 (BS00, THR1, C106) /* cmd: Acquire specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         Name (CP00, Buffer (Arg0){})
         Name (HG00, Buffer (Arg0){})
@@ -2244,7 +2244,7 @@
         M208 (BS00, THR2, C108) /* cmd: Terminate thread */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         Name (CP01, Buffer (Arg0){})
         Name (HG01, Buffer (Arg0){})
@@ -2258,13 +2258,13 @@
         M208 (BS00, THR1, C107) /* cmd: Release specified set of mutexes */
         M215 (Arg0)             /* Reset TimeOutValue and exceptional condition flags */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
 
     /*
-     * Serialized method to be executed by Slave thread
+     * Serialized method to be executed by Worker thread
      *
      * arg0 - number of threads
      * arg1 - ID of current thread
@@ -2305,7 +2305,7 @@
     }
 
     /*
-     * Non-serialized method to be executed by Slave thread,
+     * Non-serialized method to be executed by Worker thread,
      * use mutex for exclusive access to critical section.
      *
      * arg0 - number of threads
@@ -2357,7 +2357,7 @@
     }
 
     /*
-     * Non-serialized method to be executed by Slave thread
+     * Non-serialized method to be executed by Worker thread
      *
      * non-serialized method is grabbed simultaneously by several threads
      *
@@ -2421,7 +2421,7 @@
 
     /*
      * arg0 - number of threads (total)
-     * arg1 - main command for slave thread
+     * arg1 - main command for worker thread
      */
     Method (M8FB, 2, Serialized)
     {
@@ -2452,14 +2452,14 @@
         /*
          * 1. Thread thr-1 invokes method MXXX (by c109/c10a) which allows
          *    exclusive access to the critical section.
-         *    Then it calls recursively m101 (infinite loop of slave threads)
+         *    Then it calls recursively m101 (infinite loop of worker threads)
          *    so becomes identical to other threads for managing it.
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR1, Arg1) /* cmd: c109/c10a */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
@@ -2470,7 +2470,7 @@
         M208 (BS00, THR2, Arg1) /* cmd: c109/c10a */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         Name (CP00, Buffer (Arg0){})
         Name (HG00, Buffer (Arg0){})
@@ -2484,7 +2484,7 @@
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         Name (CP01, Buffer (Arg0){})
         Name (HG01, Buffer (Arg0){})
@@ -2495,12 +2495,12 @@
         M110 (Arg0, CP01, HG01, ID01)
         /*
          * 4. Thread thr-1 is directed to exit recursive (second) call to m101
-         *    (infinite loop of slave threads).
+         *    (infinite loop of worker threads).
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR1, C101) /* cmd: Exit the infinite loop */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         Name (CP02, Buffer (Arg0){})
         Name (HG02, Buffer (Arg0){})
@@ -2511,12 +2511,12 @@
         M110 (Arg0, CP02, HG02, ID02)
         /*
          * 5. Thread thr-2 is directed to exit recursive (second) call to m101
-         *    (infinite loop of slave threads).
+         *    (infinite loop of worker threads).
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR2, C101) /* cmd: Exit the infinite loop */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
     }
@@ -2576,14 +2576,14 @@
 
         /*
          * 1. Thread thr-1 invokes non-Serialized method MXXX.
-         *    Then it calls recursively m101 (infinite loop of slave threads)
+         *    Then it calls recursively m101 (infinite loop of worker threads)
          *    so becomes identical to other threads for managing it.
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR1, C10B) /* cmd: Invoke non-Serialized method */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
@@ -2592,19 +2592,19 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
          * 3. Thread thr-N invokes non-Serialized method MXXX.
-         *    Then it calls recursively m101 (infinite loop of slave threads)
+         *    Then it calls recursively m101 (infinite loop of worker threads)
          *    so becomes identical to other threads for managing it.
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR2, C10B) /* cmd: Invoke non-Serialized method */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
@@ -2613,19 +2613,19 @@
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         /*
          * 5. Both threads thr-1 and thr-N are directed to exit recursive (second) calls to m101
-         *    (infinite loops of slave threads).
+         *    (infinite loops of worker threads).
          */
         M200 (BS00, Arg0, C102) /* cmd: Sleep */
         M208 (BS00, THR1, C101) /* cmd: Exit the infinite loop */
         M208 (BS00, THR2, C101) /* cmd: Exit the infinite loop */
         M20F (Arg0, 0x00, 0x00)       /* Init (Reset) the exceptional conditions flags (SUCCESS) */
         M114 (Arg0) /* run */
-        /* Wait for all Slave threads */
+        /* Wait for all Worker threads */
 
         M103 (Arg0)
         If ((FLG2 != THR1))

--- a/tests/aslts/src/runtime/collections/mt/mutex/worker_thr.asl
+++ b/tests/aslts/src/runtime/collections/mt/mutex/worker_thr.asl
@@ -26,7 +26,7 @@
      * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
      */
     /*
-     * Run only for the Slave threads,
+     * Run only for the Worker threads,
      * they wait there for the Control
      * thread says 'all is ready',
      * 'go further'.
@@ -50,7 +50,7 @@
     }
 
     /*
-     * Infinite loop of the Slave Threads
+     * Infinite loop of the Worker Threads
      *
      * arg0 - number of threads
      * arg1 - ID of current thread
@@ -80,7 +80,7 @@ Zero)
 
         M116 (Arg2)
         /*
-         * Local0 - command for slave to be executed
+         * Local0 - command for worker to be executed
          *
          * Local7 - non-zero means to do break after
          *          confirming "I see zero do00".
@@ -97,7 +97,7 @@ Zero)
             /* Determine the command for particular thread */
 
             Local0 = C100 /* \C100 */
-            /* Control thread allows for slave threads to fulfill their commands */
+            /* Control thread allows for worker threads to fulfill their commands */
 
             If (DO00)
             {
@@ -124,7 +124,7 @@ Zero)
                 Local1 = DerefOf (BS02 [Arg2])
                 If (!Local1)
                 {
-                    /* Slave thread reports: "I see zero do00" */
+                    /* Worker thread reports: "I see zero do00" */
 
                     BS02 [Arg2] = RS00 /* \RS00 */
                     If (Local7)
@@ -141,7 +141,7 @@ Zero)
                 {
                     /* c100 (Idle thread) */
                     /*
-                     * This command is fulfilled by slave thread
+                     * This command is fulfilled by worker thread
                      * without directive of Control thread.
                      */
                     M201 (Arg2, VB03, "Sleep")


### PR DESCRIPTION
The tests/ subdirectory contains confusing (and offensive) language
that is not tied to any "external" specifications. The thread worker
naming convention is more accurately named "Worker". (The controlling
thread was already named "Controller".) Rename one file and update the
language throughout.

This removes 209 instances, leaving only the 67 that are tied to
specification language.

For background and further details on the technical and societal
rationale for these changes, please see:
https://tools.ietf.org/id/draft-knodel-terminology-01.html

Signed-off-by: Kees Cook <kees@outflux.net>