### PR TITLE
iASL: clean up loop counter mismatch with upper bound

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -1056,7 +1056,7 @@ GetModifiedLevel (
     UINT8                   Level,
     UINT16                  MessageId)
 {
-    UINT16                  i;
+    UINT32                  i;
     UINT16                  ExceptionCode;
 
 


### PR DESCRIPTION
The loop counter i is a U16 where as the upper bound is a UINT32 which
in theory could lead to an infinite loop if AslGbl_ElevatedMessagesIndex
is greater than 65535.  In practice this is probably never going to
occur, but make code fully safe by making the loop counter a UINT32.

Addresses-Coverity: ("Infinite loop")
Signed-off-by: Colin Ian King <colin.king@canonical.com>