### PR TITLE
Do not increment OperationRegion reference counts for field units

### DIFF
--- a/source/components/executer/exprep.c
+++ b/source/components/executer/exprep.c
@@ -651,10 +651,6 @@ AcpiExPrepFieldValue (
             }
         }
 
-        /* An additional reference for the container */
-
-        AcpiUtAddReference (ObjDesc->Field.RegionObj);
-
         ACPI_DEBUG_PRINT ((ACPI_DB_BFIELD,
             "RegionField: BitOff %X, Off %X, Gran %X, Region %p\n",
             ObjDesc->Field.StartFieldBitOffset,

--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -749,11 +749,6 @@ AcpiUtUpdateObjectReference (
             NextObject = Object->BufferField.BufferObj;
             break;
 
-        case ACPI_TYPE_LOCAL_REGION_FIELD:
-
-            NextObject = Object->Field.RegionObj;
-            break;
-
         case ACPI_TYPE_LOCAL_BANK_FIELD:
 
             NextObject = Object->BankField.BankObj;
@@ -789,6 +784,7 @@ AcpiUtUpdateObjectReference (
             }
             break;
 
+        case ACPI_TYPE_LOCAL_REGION_FIELD:
         case ACPI_TYPE_REGION:
         default:
 


### PR DESCRIPTION
Object reference counts are used as a part of ACPICA's garbage
collection mechanism. This mechanism keeps track of references to
heap-allocated structures such as the ACPI operand objects.

Recent server firmware has revealed that this reference count can
overflow on large servers that declare many field units under the
same OperationRegion. This occurs because each field unit declaration
will add a reference count to the source OperationRegion.

This change solves the reference count overflow for OperationRegions
objects by preventing fieldunits from incrementing their
OperationRegion's reference count. Each OperationRegion's reference
count will not be changed by named objects declared under the Field
operator. During namespace deletion, the OperationRegion namespace
node will be deleted and each fieldunit will be deleted without
touching the deleted OperationRegion object.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>