### PR TITLE
Add support for 64 bit risc-v compilation.

### DIFF
--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -324,7 +324,8 @@
 
 #if defined(__ia64__)    || (defined(__x86_64__) && !defined(__ILP32__)) ||\
     defined(__aarch64__) || defined(__PPC64__) ||\
-    defined(__s390x__)
+    defined(__s390x__) ||\
+    (defined(__riscv) && (defined(__LP64__) || defined(_LP64)))
 #define ACPI_MACHINE_WIDTH          64
 #define COMPILER_DEPENDENT_INT64    long
 #define COMPILER_DEPENDENT_UINT64   unsigned long


### PR DESCRIPTION
Add 64 bit risc-v architecture.  Useful for acpica tools and
incorporating ACPICA into the Firmware Test Suite.

Signed-off-by: Colin Ian King <colin.king@canonical.com>