### PR TITLE
Preserve memory opregion mappings

### DIFF
--- a/source/components/events/evrgnini.c
+++ b/source/components/events/evrgnini.c
@@ -183,6 +183,7 @@ AcpiEvSystemMemoryRegionSetup (
 {
     ACPI_OPERAND_OBJECT     *RegionDesc = (ACPI_OPERAND_OBJECT *) Handle;
     ACPI_MEM_SPACE_CONTEXT  *LocalRegionContext;
+    ACPI_MEM_MAPPING        *Mm;
 
 
     ACPI_FUNCTION_TRACE (EvSystemMemoryRegionSetup);
@@ -194,12 +195,14 @@ AcpiEvSystemMemoryRegionSetup (
         {
             LocalRegionContext = (ACPI_MEM_SPACE_CONTEXT *) *RegionContext;
 
-            /* Delete a cached mapping if present */
+            /* Delete memory mappings if present */
 
-            if (LocalRegionContext->MappedLength)
+            while (LocalRegionContext->FirstMm)
             {
-                AcpiOsUnmapMemory (LocalRegionContext->MappedLogicalAddress,
-                    LocalRegionContext->MappedLength);
+                Mm = LocalRegionContext->FirstMm;
+                LocalRegionContext->FirstMm = Mm->NextMm;
+                AcpiOsUnmapMemory(Mm->LogicalAddress, Mm->Length);
+                ACPI_FREE(Mm);
             }
             ACPI_FREE (LocalRegionContext);
             *RegionContext = NULL;

--- a/source/components/executer/exregion.c
+++ b/source/components/executer/exregion.c
@@ -188,6 +188,7 @@ AcpiExSystemMemorySpaceHandler (
     ACPI_STATUS             Status = AE_OK;
     void                    *LogicalAddrPtr = NULL;
     ACPI_MEM_SPACE_CONTEXT  *MemInfo = RegionContext;
+    ACPI_MEM_MAPPING        *Mm = MemInfo->CurMm;
     UINT32                  Length;
     ACPI_SIZE               MapLength;
     ACPI_SIZE               PageBoundaryMapLength;
@@ -247,21 +248,46 @@ AcpiExSystemMemorySpaceHandler (
      * Is 1) Address below the current mapping? OR
      *    2) Address beyond the current mapping?
      */
-    if ((Address < MemInfo->MappedPhysicalAddress) ||
-        (((UINT64) Address + Length) >
-            ((UINT64)
-            MemInfo->MappedPhysicalAddress + MemInfo->MappedLength)))
+    if (!Mm || (Address < Mm->PhysicalAddress) ||
+        ((UINT64) Address + Length > (UINT64) Mm->PhysicalAddress + Mm->Length))
     {
         /*
-         * The request cannot be resolved by the current memory mapping;
-         * Delete the existing mapping and create a new one.
+         * The request cannot be resolved by the current memory mapping.
+         *
+         * Look for an existing saved mapping covering the address range
+         * at hand. If found, save it as the current one and carry out
+         * the access.
          */
-        if (MemInfo->MappedLength)
+        for (Mm = MemInfo->FirstMm; Mm; Mm = Mm->NextMm)
         {
-            /* Valid mapping, delete it */
+            if (Mm == MemInfo->CurMm)
+            {
+                continue;
+            }
 
-            AcpiOsUnmapMemory (MemInfo->MappedLogicalAddress,
-                MemInfo->MappedLength);
+            if (Address < Mm->PhysicalAddress)
+            {
+                continue;
+            }
+
+            if ((UINT64) Address + Length > (UINT64) Mm->PhysicalAddress + Mm->Length)
+            {
+                continue;
+            }
+
+            MemInfo->CurMm = Mm;
+            goto access;
+        }
+
+        /* Create a new mappings list entry */
+
+        Mm = ACPI_ALLOCATE_ZEROED(sizeof(*Mm));
+        if (!Mm)
+        {
+            ACPI_ERROR((AE_INFO,
+                "Unable to save memory mapping at 0x%8.8X%8.8X, size %u",
+                ACPI_FORMAT_UINT64(Address), Length));
+            return_ACPI_STATUS(AE_NO_MEMORY);
         }
 
         /*
@@ -297,28 +323,38 @@ AcpiExSystemMemorySpaceHandler (
 
         /* Create a new mapping starting at the address given */
 
-        MemInfo->MappedLogicalAddress = AcpiOsMapMemory (Address, MapLength);
-        if (!MemInfo->MappedLogicalAddress)
+        LogicalAddrPtr = AcpiOsMapMemory(Address, MapLength);
+        if (!LogicalAddrPtr)
         {
             ACPI_ERROR ((AE_INFO,
                 "Could not map memory at 0x%8.8X%8.8X, size %u",
                 ACPI_FORMAT_UINT64 (Address), (UINT32) MapLength));
-            MemInfo->MappedLength = 0;
+            ACPI_FREE(Mm);
             return_ACPI_STATUS (AE_NO_MEMORY);
         }
 
         /* Save the physical address and mapping size */
 
-        MemInfo->MappedPhysicalAddress = Address;
-        MemInfo->MappedLength = MapLength;
+        Mm->LogicalAddress = LogicalAddrPtr;
+        Mm->PhysicalAddress = Address;
+        Mm->Length = MapLength;
+
+        /*
+         * Add the new entry to the mappigs list and save it as the
+         * current mapping.
+         */
+        Mm->NextMm = MemInfo->FirstMm;
+        MemInfo->FirstMm = Mm;
+        MemInfo->CurMm = Mm;
     }
 
+access:
     /*
      * Generate a logical pointer corresponding to the address we want to
      * access
      */
-    LogicalAddrPtr = MemInfo->MappedLogicalAddress +
-        ((UINT64) Address - (UINT64) MemInfo->MappedPhysicalAddress);
+    LogicalAddrPtr = Mm->LogicalAddress +
+        ((UINT64) Address - (UINT64) Mm->PhysicalAddress);
 
     ACPI_DEBUG_PRINT ((ACPI_DB_INFO,
         "System-Memory (width %u) R/W %u Address=%8.8X%8.8X\n",

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1440,13 +1440,21 @@ typedef struct acpi_pci_id
 
 } ACPI_PCI_ID;
 
+typedef struct acpi_mem_mapping
+{
+    ACPI_PHYSICAL_ADDRESS           PhysicalAddress;
+    UINT8                           *LogicalAddress;
+    ACPI_SIZE                       Length;
+    struct acpi_mem_mapping         *NextMm;
+
+} ACPI_MEM_MAPPING;
+
 typedef struct acpi_mem_space_context
 {
     UINT32                          Length;
     ACPI_PHYSICAL_ADDRESS           Address;
-    ACPI_PHYSICAL_ADDRESS           MappedPhysicalAddress;
-    UINT8                           *MappedLogicalAddress;
-    ACPI_SIZE                       MappedLength;
+    ACPI_MEM_MAPPING                *CurMm;
+    ACPI_MEM_MAPPING                *FirstMm;
 
 } ACPI_MEM_SPACE_CONTEXT;
 


### PR DESCRIPTION
The ACPICA's strategy with respect to the handling of memory mappings
associated with memory operation regions is to avoid mapping the
entire region at once which may be problematic at least in principle
(for example, it may lead to conflicts with overlapping mappings
having different attributes created by drivers).  It may also be
wasteful, because memory opregions on some systems take up vast
chunks of address space while the fields in those regions actually
accessed by AML are sparsely distributed.

For this reason, a one-page "window" is mapped for a given opregion
on the first memory access through it and if that "window" does not
cover an address range accessed through that opregion subsequently,
it is unmapped and a new "window" is mapped to replace it.  Next,
if the new "window" is not sufficient to acess memory through the
opregion in question in the future, it will be replaced with yet
another "window" and so on.  That may lead to a suboptimal sequence
of memory mapping and unmapping operations, for example if two fields
in one opregion separated from each other by a sufficiently wide
chunk of unused address space are accessed in an alternating pattern.

The situation may still be suboptimal if the deferred unmapping
introduced previously is supported by the OS layer.  For instance,
the alternating memory access pattern mentioned above may produce
a relatively long list of mappings to release with substantial
duplication among the entries in it, which could be avoided if
AcpiExSystemMemorySpaceHandler() did not release the mapping
used by it previously as soon as the current access was not covered
by it.

In order to improve that, modify AcpiExSystemMemorySpaceHandler()
to preserve all of the memory mappings created by it until the memory
regions associated with them go away.

Accordingly, update AcpiEvSystemMemoryRegionSetup() to unmap all
memory associated with memory opregions that go away.

Reported-by: Dan Williams <dan.j.williams@intel.com>
Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>