### PR TITLE
ACPI 6.3: HMAT updates

### DIFF
--- a/source/common/dmtbinfo1.c
+++ b/source/common/dmtbinfo1.c
@@ -1121,7 +1121,7 @@ ACPI_DMTABLE_INFO           AcpiDmTableInfoHmat0[] =
     {ACPI_DMT_UINT16,   ACPI_HMAT0_OFFSET (Flags),                  "Flags (decoded below)", 0},
     {ACPI_DMT_FLAG0,    ACPI_HMAT0_FLAG_OFFSET (Flags,0),           "Processor Proximity Domain Valid", 0},
     {ACPI_DMT_UINT16,   ACPI_HMAT0_OFFSET (Reserved1),              "Reserved1", 0},
-    {ACPI_DMT_UINT32,   ACPI_HMAT0_OFFSET (ProcessorPD),            "Processor Proximity Domain", 0},
+    {ACPI_DMT_UINT32,   ACPI_HMAT0_OFFSET (InitiatorPD),            "Attached Initiator Proximity Domain", 0},
     {ACPI_DMT_UINT32,   ACPI_HMAT0_OFFSET (MemoryPD),               "Memory Proximity Domain", 0},
     {ACPI_DMT_UINT32,   ACPI_HMAT0_OFFSET (Reserved2),              "Reserved2", 0},
     {ACPI_DMT_UINT64,   ACPI_HMAT0_OFFSET (Reserved3),              "Reserved3", 0},

--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -1767,8 +1767,7 @@ typedef struct acpi_hest_ia_deferred_check
 
 /*******************************************************************************
  *
- * HMAT - Heterogeneous Memory Attributes Table (ACPI 6.2)
- *        Version 1
+ * HMAT - Heterogeneous Memory Attributes Table (ACPI 6.3)
  *
  ******************************************************************************/
 
@@ -1810,7 +1809,7 @@ typedef struct acpi_hmat_proximity_domain
     ACPI_HMAT_STRUCTURE     Header;
     UINT16                  Flags;
     UINT16                  Reserved1;
-    UINT32                  ProcessorPD;            /* Processor proximity domain */
+    UINT32                  InitiatorPD;            /* Attached Initiator proximity domain */
     UINT32                  MemoryPD;               /* Memory proximity domain */
     UINT32                  Reserved2;
     UINT64                  Reserved3;
@@ -1820,9 +1819,7 @@ typedef struct acpi_hmat_proximity_domain
 
 /* Masks for Flags field above */
 
-#define ACPI_HMAT_PROCESSOR_PD_VALID    (1)     /* 1: ProcessorPD field is valid */
-#define ACPI_HMAT_MEMORY_PD_VALID       (1<<1)  /* 1: MemoryPD field is valid */
-#define ACPI_HMAT_RESERVATION_HINT      (1<<2)  /* 1: Reservation hint */
+#define ACPI_HMAT_INITIATOR_PD_VALID    (1)     /* 1: InitiatorPD field is valid */
 
 
 /* 1: System locality latency and bandwidth information */


### PR DESCRIPTION
- rename Processor to Attached Initiator
- drop deprecated bits from Memory Proximity Domain flag
- bump ACPI version in HMAT comment

Signed-off-by: Michal Biesek <michal.biesek@intel.com>