### PR TITLE
iASL: add more details to External resolution error message

### DIFF
--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -381,6 +381,7 @@ const char                      *AslCompilerMsgs [] =
 /*    ASL_MSG_DUPLICATE_EXTERN_MISMATCH */  "Type mismatch between multiple external declarations detected",
 /*    ASL_MSG_DUPLICATE_EXTERN_FOUND_HERE */"Duplicate external declaration:",
 /*    ASL_MSG_CONDREF_NEEDS_EXTERNAL_DECL */"CondRefOf parameter requires External() declaration",
+/*    ASL_MSG_EXTERNAL_FOUND_HERE */        "External declaration below ",
 };
 
 /* Table compiler */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -383,6 +383,7 @@ typedef enum
     ASL_MSG_DUPLICATE_EXTERN_MISMATCH,
     ASL_MSG_DUPLICATE_EXTERN_FOUND_HERE,
     ASL_MSG_CONDREF_NEEDS_EXTERNAL_DECL,
+    ASL_MSG_EXTERNAL_FOUND_HERE,
 
 
     /* These messages are used by the Data Table compiler only */

--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -433,6 +433,7 @@ XfNamespaceLocateBegin (
     UINT32                  i;
     ACPI_NAMESPACE_NODE     *DeclarationParentMethod;
     ACPI_PARSE_OBJECT       *ReferenceParentMethod;
+    char                    *ExternalPath;
 
 
     ACPI_FUNCTION_TRACE_PTR (XfNamespaceLocateBegin, Op);
@@ -1263,7 +1264,15 @@ XfNamespaceLocateBegin (
         Op->Asl.Parent->Asl.ParseOpcode != PARSEOP_CONDREFOF &&
         !XfRefIsGuardedByIfCondRefOf (Node, Op))
     {
-        AslError (ASL_ERROR, ASL_MSG_UNDEFINED_EXTERNAL, Op, NULL);
+        ExternalPath = AcpiNsGetNormalizedPathname (Node, TRUE);
+        sprintf (AslGbl_MsgBuffer, "full path of external object: %s",
+            ExternalPath);
+        AslDualParseOpError (ASL_ERROR, ASL_MSG_UNDEFINED_EXTERNAL, Op, NULL,
+            ASL_MSG_EXTERNAL_FOUND_HERE, Node->Op, AslGbl_MsgBuffer);
+        if (ExternalPath)
+        {
+            ACPI_FREE (ExternalPath);
+        }
     }
 
     /* 5) Check for a connection object */


### PR DESCRIPTION
This change will print the line of the external declaration that was
used when iASL generated the error. In addition, this change prints
the full namepath of the object that was declared external.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>