### PR TITLE
Remove extreaneous "the" in comments and changes.txt

### DIFF
--- a/documents/changes.txt
+++ b/documents/changes.txt
@@ -3707,7 +3707,7 @@ iASL compiler, all ACPICA utilities, and the test suites.
 Events: Introduce ACPI_GPE_DISPATCH_RAW_HANDLER to fix GPE storm issues.
 A raw gpe handling mechanism was created to allow better handling of GPE
 storms that aren't easily managed by the normal handler. The raw handler
-allows disabling/renabling of the the GPE so that interrupt storms can be
+allows disabling/renabling of the GPE so that interrupt storms can be
 avoided in cases where events cannot be timely serviced. In this 
 scenario, handlers should use the AcpiSetGpe() API to disable/enable the 
 GPE. This API will leave the reference counts undisturbed, thereby 

--- a/source/compiler/aslbtypes.c
+++ b/source/compiler/aslbtypes.c
@@ -672,7 +672,7 @@ AnMapObjTypeToBtype (
  *
  * PARAMETERS:  Btype               - Bitfield of ACPI types
  *
- * RETURN:      The Etype corresponding the the Btype
+ * RETURN:      The Etype corresponding the Btype
  *
  * DESCRIPTION: Convert a bitfield type to an encoded type
  *

--- a/source/compiler/aslcodegen.c
+++ b/source/compiler/aslcodegen.c
@@ -700,7 +700,7 @@ CgUpdateHeader (
 
     Checksum = (UINT8) (0 - Sum);
 
-    /* Re-write the the checksum byte */
+    /* Re-write the checksum byte */
 
     FlSeekFile (ASL_FILE_AML_OUTPUT, Op->Asl.FinalAmlOffset +
         ACPI_OFFSET (ACPI_TABLE_HEADER, Checksum));

--- a/source/include/accommon.h
+++ b/source/include/accommon.h
@@ -155,7 +155,7 @@
 /*
  * Common set of includes for all ACPICA source files.
  * We put them here because we don't want to duplicate them
- * in the the source code again and again.
+ * in the source code again and again.
  *
  * Note: The order of these include files is important.
  */


### PR DESCRIPTION
There are several ocurrances of "the the", remove the extraneous
"the".

Signed-off-by: Colin Ian King <colin.king@canonical.com>