### PR TITLE
Fix exception code class checks

### DIFF
--- a/source/components/debugger/dbobject.c
+++ b/source/components/debugger/dbobject.c
@@ -201,7 +201,7 @@ AcpiDbDumpMethodInfo (
 
     /* Ignore control codes, they are not errors */
 
-    if ((Status & AE_CODE_MASK) == AE_CODE_CONTROL)
+    if (ACPI_CNTL_EXCEPTION (Status))
     {
         return;
     }

--- a/source/components/dispatcher/dsdebug.c
+++ b/source/components/dispatcher/dsdebug.c
@@ -254,7 +254,7 @@ AcpiDsDumpMethodStack (
 
     /* Ignore control codes, they are not errors */
 
-    if ((Status & AE_CODE_MASK) == AE_CODE_CONTROL)
+    if (ACPI_CNTL_EXCEPTION (Status))
     {
         return_VOID;
     }

--- a/source/components/parser/psloop.c
+++ b/source/components/parser/psloop.c
@@ -410,8 +410,7 @@ AcpiPsParseLoop (
                  */
                 WalkState->Op = NULL;
                 Status = AcpiDsGetPredicateValue (WalkState, ACPI_TO_POINTER (TRUE));
-                if (ACPI_FAILURE (Status) &&
-                    ((Status & AE_CODE_MASK) != AE_CODE_CONTROL))
+                if (ACPI_FAILURE (Status) && !ACPI_CNTL_EXCEPTION (Status))
                 {
                     if (Status == AE_AML_NO_RETURN_VALUE)
                     {

--- a/source/components/parser/psparse.c
+++ b/source/components/parser/psparse.c
@@ -533,7 +533,7 @@ AcpiPsNextParseState (
     default:
 
         Status = CallbackStatus;
-        if ((CallbackStatus & AE_CODE_MASK) == AE_CODE_CONTROL)
+        if (ACPI_CNTL_EXCEPTION (CallbackStatus))
         {
             Status = AE_OK;
         }

--- a/source/include/acexcep.h
+++ b/source/include/acexcep.h
@@ -204,11 +204,11 @@ typedef struct acpi_exception_info
 
 #define AE_OK                           (ACPI_STATUS) 0x0000
 
-#define ACPI_ENV_EXCEPTION(Status)      (Status & AE_CODE_ENVIRONMENTAL)
-#define ACPI_AML_EXCEPTION(Status)      (Status & AE_CODE_AML)
-#define ACPI_PROG_EXCEPTION(Status)     (Status & AE_CODE_PROGRAMMER)
-#define ACPI_TABLE_EXCEPTION(Status)    (Status & AE_CODE_ACPI_TABLES)
-#define ACPI_CNTL_EXCEPTION(Status)     (Status & AE_CODE_CONTROL)
+#define ACPI_ENV_EXCEPTION(Status)      (((Status) & AE_CODE_MASK) == AE_CODE_ENVIRONMENTAL)
+#define ACPI_AML_EXCEPTION(Status)      (((Status) & AE_CODE_MASK) == AE_CODE_AML)
+#define ACPI_PROG_EXCEPTION(Status)     (((Status) & AE_CODE_MASK) == AE_CODE_PROGRAMMER)
+#define ACPI_TABLE_EXCEPTION(Status)    (((Status) & AE_CODE_MASK) == AE_CODE_ACPI_TABLES)
+#define ACPI_CNTL_EXCEPTION(Status)     (((Status) & AE_CODE_MASK) == AE_CODE_CONTROL)
 
 
 /*


### PR DESCRIPTION
Fixes exception code class checks in `acexcep.h`.

Currently, the exception code class check macros are broken. For example, `ACPI_ENV_EXCEPTION(Status)` will always evaluate to zero, whereas `ACPI_AML_EXCEPTION(Status)` will evaluate to non-zero for `AE_CODE_PROGRAMMER`, `AE_CODE_ACPI_TABLES`, as well as `AE_CODE_AML`. The other macros have similar problems.

This issue likely has not been detected before as these classification macros do currently not see much use.

The first commit in this PR fixes those macros, the second commit cleans up existing checks of the form `((Status & AE_CODE_MAKS) == <class>)` by replacing them with the corresponding `ACPI_<class>_EXCEPTION(Status)` macro.