### PR TITLE
Also handle "orphan" _REG methods for GPIO OpRegions

### DIFF
--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -164,8 +164,10 @@ extern UINT8        AcpiGbl_DefaultAddressSpaces[];
 /* Local prototypes */
 
 static void
-AcpiEvOrphanEcRegMethod (
-    ACPI_NAMESPACE_NODE     *EcDeviceNode);
+AcpiEvExecuteOrphanRegMethod (
+    ACPI_NAMESPACE_NODE     *DeviceNode,
+    ACPI_ADR_SPACE_TYPE     SpaceId);
+
 
 static ACPI_STATUS
 AcpiEvRegRun (
@@ -869,11 +871,13 @@ AcpiEvExecuteRegMethods (
     (void) AcpiNsWalkNamespace (ACPI_TYPE_ANY, Node, ACPI_UINT32_MAX,
         ACPI_NS_WALK_UNLOCK, AcpiEvRegRun, NULL, &Info, NULL);
 
-    /* Special case for EC: handle "orphan" _REG methods with no region */
-
-    if (SpaceId == ACPI_ADR_SPACE_EC)
+    /*
+     * Special case for EC and GPIO: handle "orphan" _REG methods with
+     * no region.
+     */
+    if (SpaceId == ACPI_ADR_SPACE_EC || SpaceId == ACPI_ADR_SPACE_GPIO)
     {
-        AcpiEvOrphanEcRegMethod (Node);
+        AcpiEvExecuteOrphanRegMethod (Node, SpaceId);
     }
 
     ACPI_DEBUG_PRINT_RAW ((ACPI_DB_NAMES,
@@ -954,32 +958,29 @@ AcpiEvRegRun (
 
 /*******************************************************************************
  *
- * FUNCTION:    AcpiEvOrphanEcRegMethod
+ * FUNCTION:    AcpiEvExecuteOrphanRegMethod
  *
- * PARAMETERS:  EcDeviceNode        - Namespace node for an EC device
+ * PARAMETERS:  DeviceNode          - Namespace node for an ACPI device
+ *              SpaceId             - The address space ID
  *
  * RETURN:      None
  *
- * DESCRIPTION: Execute an "orphan" _REG method that appears under the EC
+ * DESCRIPTION: Execute an "orphan" _REG method that appears under an ACPI
  *              device. This is a _REG method that has no corresponding region
- *              within the EC device scope. The orphan _REG method appears to
- *              have been enabled by the description of the ECDT in the ACPI
- *              specification: "The availability of the region space can be
- *              detected by providing a _REG method object underneath the
- *              Embedded Controller device."
- *
- *              To quickly access the EC device, we use the EcDeviceNode used
- *              during EC handler installation. Otherwise, we would need to
- *              perform a time consuming namespace walk, executing _HID
- *              methods to find the EC device.
+ *              within the device's scope. ACPI tables depending on these
+ *              "orphan" _REG methods have been seen for both EC and GPIO
+ *              Operation Regions. Presumably the Windows ACPI implementation
+ *              always calls the _REG method independent of the presence of
+ *              an actual Operation Region with the correct address space ID.
  *
  *  MUTEX:      Assumes the namespace is locked
  *
  ******************************************************************************/
 
 static void
-AcpiEvOrphanEcRegMethod (
-    ACPI_NAMESPACE_NODE     *EcDeviceNode)
+AcpiEvExecuteOrphanRegMethod (
+    ACPI_NAMESPACE_NODE     *DeviceNode,
+    ACPI_ADR_SPACE_TYPE     SpaceId)
 {
     ACPI_HANDLE             RegMethod;
     ACPI_NAMESPACE_NODE     *NextNode;
@@ -988,10 +989,10 @@ AcpiEvOrphanEcRegMethod (
     ACPI_OBJECT             Objects[2];
 
 
-    ACPI_FUNCTION_TRACE (EvOrphanEcRegMethod);
+    ACPI_FUNCTION_TRACE (EvExecuteOrphanRegMethod);
 
 
-    if (!EcDeviceNode)
+    if (!DeviceNode)
     {
         return_VOID;
     }
@@ -1002,7 +1003,7 @@ AcpiEvOrphanEcRegMethod (
 
     /* Get a handle to a _REG method immediately under the EC device */
 
-    Status = AcpiGetHandle (EcDeviceNode, METHOD_NAME__REG, &RegMethod);
+    Status = AcpiGetHandle (DeviceNode, METHOD_NAME__REG, &RegMethod);
     if (ACPI_FAILURE (Status))
     {
         goto Exit; /* There is no _REG method present */
@@ -1015,25 +1016,25 @@ AcpiEvOrphanEcRegMethod (
      * with other space IDs to be present; but the code below will then
      * execute the _REG method with the EmbeddedControl SpaceID argument.
      */
-    NextNode = AcpiNsGetNextNode (EcDeviceNode, NULL);
+    NextNode = AcpiNsGetNextNode (DeviceNode, NULL);
     while (NextNode)
     {
         if ((NextNode->Type == ACPI_TYPE_REGION) &&
             (NextNode->Object) &&
-            (NextNode->Object->Region.SpaceId == ACPI_ADR_SPACE_EC))
+            (NextNode->Object->Region.SpaceId == SpaceId))
         {
             goto Exit; /* Do not execute the _REG */
         }
 
-        NextNode = AcpiNsGetNextNode (EcDeviceNode, NextNode);
+        NextNode = AcpiNsGetNextNode (DeviceNode, NextNode);
     }
 
-    /* Evaluate the _REG(EmbeddedControl,Connect) method */
+    /* Evaluate the _REG(SpaceId,Connect) method */
 
     Args.Count = 2;
     Args.Pointer = Objects;
     Objects[0].Type = ACPI_TYPE_INTEGER;
-    Objects[0].Integer.Value = ACPI_ADR_SPACE_EC;
+    Objects[0].Integer.Value = SpaceId;
     Objects[1].Type = ACPI_TYPE_INTEGER;
     Objects[1].Integer.Value = ACPI_REG_CONNECT;
 


### PR DESCRIPTION
Before this commit AcpiEvExecuteRegMethods() had special handling
to handle "orphan" (no matching OpRegion declared) _REG methods for EC
nodes.

On Intel Cherry Trail devices there are 2 possible ACPI OpRegions for
accessing GPIOs. The standard GeneralPurposeIo OpRegion and the Cherry
Trail specific UserDefined 0x9X OpRegions.

Having 2 different types of OpRegions leads to potential issues with
checks for OpRegion availability, or in other words checks if _REG has
been called for the OpRegion which the ACPI code wants to use.

Except for the "orphan" EC handling, ACPICA core does not call _REG on
an ACPI node which does not define an OpRegion matching the type being
registered; and the reference design DSDT, from which most Cherry Trail
DSDTs are derived, does not define GeneralPurposeIo, nor UserDefined(0x93)
OpRegions for the GPO2 (UID 3) device, because no pins were assigned ACPI
controlled functions in the reference design.

Together this leads to the perfect storm, at least on the Cherry Trail
based Medion Akayo E1239T. This design does use a GPO2 pin from its ACPI
code and has added the Cherry Trail specific UserDefined(0x93) opregion
to its GPO2 ACPI node to access this pin.

But it uses a has _REG been called availability check for the standard
GeneralPurposeIo OpRegion. This clearly is a bug in the DSDT, but this
does work under Windows. This issue leads to the intel_vbtn driver
reporting the device always being in tablet-mode at boot, even if it
is in laptop mode. Which in turn causes userspace to ignore touchpad
events. So iow this issues causes the touchpad to not work at boot.

This commit fixes this by extending the "orphan" _REG method handling
to also apply to GPIO address-space handlers.

Note it seems that Windows always calls "orphan" _REG methods so me
may want to consider dropping the space-id check and always do
"orphan" _REG method handling.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>