### PR TITLE
Provide support for big-endian systems

### DIFF
--- a/generate/unix/acpibin/Makefile
+++ b/generate/unix/acpibin/Makefile
@@ -37,6 +37,7 @@ OBJECTS = \
 	$(OBJDIR)/utcache.o\
 	$(OBJDIR)/utdebug.o\
 	$(OBJDIR)/utdecode.o\
+	$(OBJDIR)/utendian.o\
 	$(OBJDIR)/utexcep.o\
 	$(OBJDIR)/utglobal.o\
 	$(OBJDIR)/utlock.o\

--- a/generate/unix/acpidump/Makefile
+++ b/generate/unix/acpidump/Makefile
@@ -36,6 +36,7 @@ OBJECTS = \
 	$(OBJDIR)/osunixdir.o\
 	$(OBJDIR)/osunixmap.o\
 	$(OBJDIR)/osunixxf.o\
+	$(OBJDIR)/utendian.o\
 	$(OBJDIR)/tbprint.o\
 	$(OBJDIR)/tbxfroot.o\
 	$(OBJDIR)/utascii.o\

--- a/generate/unix/acpiexamples/Makefile
+++ b/generate/unix/acpiexamples/Makefile
@@ -139,6 +139,7 @@ OBJECTS = \
 	$(OBJDIR)/utdebug.o\
 	$(OBJDIR)/utdecode.o\
 	$(OBJDIR)/utdelete.o\
+	$(OBJDIR)/utendian.o\
 	$(OBJDIR)/uterror.o\
 	$(OBJDIR)/uteval.o\
 	$(OBJDIR)/utexcep.o\

--- a/generate/unix/acpiexec/Makefile
+++ b/generate/unix/acpiexec/Makefile
@@ -214,6 +214,7 @@ OBJECTS = \
 	$(OBJDIR)/utdebug.o\
 	$(OBJDIR)/utdecode.o\
 	$(OBJDIR)/utdelete.o\
+	$(OBJDIR)/utendian.o\
 	$(OBJDIR)/uterror.o\
 	$(OBJDIR)/uteval.o\
 	$(OBJDIR)/utexcep.o\

--- a/generate/unix/acpihelp/Makefile
+++ b/generate/unix/acpihelp/Makefile
@@ -45,6 +45,7 @@ OBJECTS = \
 	$(OBJDIR)/getopt.o\
 	$(OBJDIR)/osunixxf.o\
 	$(OBJDIR)/utdebug.o\
+	$(OBJDIR)/utendian.o\
 	$(OBJDIR)/utexcep.o\
 	$(OBJDIR)/utglobal.o\
 	$(OBJDIR)/uthex.o\

--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -225,6 +225,7 @@ OBJECTS = \
 	$(OBJDIR)/utdebug.o\
 	$(OBJDIR)/utdecode.o\
 	$(OBJDIR)/utdelete.o\
+	$(OBJDIR)/utendian.o\
 	$(OBJDIR)/uterror.o\
 	$(OBJDIR)/utexcep.o\
 	$(OBJDIR)/utglobal.o\

--- a/source/common/adwalk.c
+++ b/source/common/adwalk.c
@@ -787,7 +787,8 @@ AcpiDmLoadDescendingOp (
 
         if (!Path && Op->Common.AmlOpcode == AML_INT_NAMEDFIELD_OP)
         {
-            *ACPI_CAST_PTR (UINT32, &FieldPath[0]) = Op->Named.Name;
+            AcpiUtWriteUint (FieldPath, ACPI_NAMESEG_SIZE,
+		             &Op->Named.Name, ACPI_NAMESEG_SIZE);
             FieldPath[4] = 0;
             Path = FieldPath;
         }

--- a/source/common/dmrestag.c
+++ b/source/common/dmrestag.c
@@ -1156,7 +1156,7 @@ AcpiDmAddResourcesToNamespace (
      * NextOp contains the Aml pointer and the Aml length
      */
     AcpiUtWalkAmlResources (NULL, (UINT8 *) NextOp->Named.Data,
-        (ACPI_SIZE) NextOp->Common.Value.Integer,
+        (ACPI_SIZE) NextOp->Common.Value.Size,
         AcpiDmAddResourceToNamespace, (void **) BufferNode);
 }
 

--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -1589,13 +1589,13 @@ AcpiDmDumpTable (
 
             /* DMAR subtable types */
 
-            Temp16 = ACPI_GET16 (Target);
+            Temp16 = AcpiUtReadUint16 (Target);
             if (Temp16 > ACPI_DMAR_TYPE_RESERVED)
             {
                 Temp16 = ACPI_DMAR_TYPE_RESERVED;
             }
 
-            AcpiOsPrintf (UINT16_FORMAT, ACPI_GET16 (Target),
+            AcpiOsPrintf (UINT16_FORMAT, Temp16,
                 AcpiDmDmarSubnames[Temp16]);
             break;
 

--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -749,7 +749,7 @@ AcpiDmDumpDataTable (
         {
             /* Dump the raw table data */
 
-            Length = Table->Length;
+            Length = AcpiUtReadUint32 (&Table->Length);
 
             AcpiOsPrintf ("\n/*\n%s: Length %d (0x%X)\n\n",
                 ACPI_RAW_TABLE_DATA_HEADER, Length, Length);
@@ -766,7 +766,7 @@ AcpiDmDumpDataTable (
      */
     if (ACPI_COMPARE_NAMESEG (Table->Signature, ACPI_SIG_FACS))
     {
-        Length = Table->Length;
+        Length = AcpiUtReadUint32 (&Table->Length);
         Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoFacs);
         if (ACPI_FAILURE (Status))
         {
@@ -786,7 +786,7 @@ AcpiDmDumpDataTable (
         /*
          * All other tables must use the common ACPI table header, dump it now
          */
-        Length = Table->Length;
+        Length = AcpiUtReadUint32(&Table->Length);
         Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoHeader);
         if (ACPI_FAILURE (Status))
         {
@@ -1426,7 +1426,7 @@ AcpiDmDumpTable (
 
             AcpiOsPrintf ("%2.2X", *Target);
             Temp8 = AcpiDmGenerateChecksum (Table,
-                ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Length,
+                AcpiUtReadUint32 (&(ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Length)),
                 ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Checksum);
 
             if (Temp8 != ACPI_CAST_PTR (ACPI_TABLE_HEADER, Table)->Checksum)

--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -1774,13 +1774,13 @@ AcpiDmDumpTable (
 
             /* NFIT subtable types */
 
-            Temp16 = ACPI_GET16 (Target);
+            Temp16 = AcpiUtReadUint16 (Target);
             if (Temp16 > ACPI_NFIT_TYPE_RESERVED)
             {
                 Temp16 = ACPI_NFIT_TYPE_RESERVED;
             }
 
-            AcpiOsPrintf (UINT16_FORMAT, ACPI_GET16 (Target),
+            AcpiOsPrintf (UINT16_FORMAT, Temp16,
                 AcpiDmNfitSubnames[Temp16]);
             break;
 

--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -250,6 +250,10 @@ AdCreateTableHeader (
     ACPI_TABLE_HEADER       *Table)
 {
     UINT8                   Checksum;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
+    UINT32                  OemRevision = AcpiUtReadUint32 (&Table->OemRevision);
+    UINT32                  CompilerRevision =
+                                AcpiUtReadUint32 (&Table->AslCompilerRevision);
 
 
     /* Reset globals for External statements */
@@ -264,7 +268,7 @@ AdCreateTableHeader (
 
     AcpiOsPrintf (" * Original Table Header:\n");
     AcpiOsPrintf (" *     Signature        \"%4.4s\"\n",    Table->Signature);
-    AcpiOsPrintf (" *     Length           0x%8.8X (%u)\n", Table->Length, Table->Length);
+    AcpiOsPrintf (" *     Length           0x%8.8X (%u)\n", TableLength, TableLength);
 
     /* Print and validate the revision */
 
@@ -296,7 +300,7 @@ AdCreateTableHeader (
 
     AcpiOsPrintf ("\n *     Checksum         0x%2.2X",        Table->Checksum);
 
-    Checksum = AcpiTbChecksum (ACPI_CAST_PTR (UINT8, Table), Table->Length);
+    Checksum = AcpiTbChecksum (ACPI_CAST_PTR (UINT8, Table), TableLength);
     if (Checksum)
     {
         AcpiOsPrintf (" **** Incorrect checksum, should be 0x%2.2X",
@@ -306,9 +310,9 @@ AdCreateTableHeader (
     AcpiOsPrintf ("\n");
     AcpiOsPrintf (" *     OEM ID           \"%.6s\"\n",     Table->OemId);
     AcpiOsPrintf (" *     OEM Table ID     \"%.8s\"\n",     Table->OemTableId);
-    AcpiOsPrintf (" *     OEM Revision     0x%8.8X (%u)\n", Table->OemRevision, Table->OemRevision);
+    AcpiOsPrintf (" *     OEM Revision     0x%8.8X (%u)\n", OemRevision, OemRevision);
     AcpiOsPrintf (" *     Compiler ID      \"%.4s\"\n",     Table->AslCompilerId);
-    AcpiOsPrintf (" *     Compiler Version 0x%8.8X (%u)\n", Table->AslCompilerRevision, Table->AslCompilerRevision);
+    AcpiOsPrintf (" *     Compiler Version 0x%8.8X (%u)\n", CompilerRevision, CompilerRevision);
     AcpiOsPrintf (" */\n");
 
     /*
@@ -329,7 +333,7 @@ AdCreateTableHeader (
     AcpiOsPrintf (
         "DefinitionBlock (\"\", \"%4.4s\", %u, \"%.6s\", \"%.8s\", 0x%8.8X)\n",
         Table->Signature, Table->Revision,
-        Table->OemId, Table->OemTableId, Table->OemRevision);
+        Table->OemId, Table->OemTableId, OemRevision);
 }
 
 
@@ -504,7 +508,8 @@ AdParseTable (
 
     fprintf (stderr, "Pass 1 parse of [%4.4s]\n", (char *) Table->Signature);
 
-    AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
+    AmlLength = AcpiUtReadUint32 (&Table->Length);
+    AmlLength -= sizeof (ACPI_TABLE_HEADER);
     AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
 
     AcpiUtSetIntegerWidth (Table->Revision);

--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -431,6 +431,7 @@ AcpiDmDumpXsdt (
     UINT32                  Entries;
     UINT32                  Offset;
     UINT32                  i;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Point to start of table pointer array */
@@ -440,12 +441,13 @@ AcpiDmDumpXsdt (
 
     /* XSDT uses 64-bit pointers */
 
-    Entries = (Table->Length - sizeof (ACPI_TABLE_HEADER)) / sizeof (UINT64);
+    Entries = (TableLength - sizeof (ACPI_TABLE_HEADER)) / sizeof (UINT64);
 
     for (i = 0; i < Entries; i++)
     {
         AcpiDmLineHeader2 (Offset, sizeof (UINT64), "ACPI Table Address", i);
-        AcpiOsPrintf ("%8.8X%8.8X\n", ACPI_FORMAT_UINT64 (Array[i]));
+        AcpiOsPrintf ("%8.8X%8.8X\n",
+                ACPI_FORMAT_UINT64 (AcpiUtReadUint64 (&Array[i])));
         Offset += sizeof (UINT64);
     }
 }

--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -390,6 +390,7 @@ AcpiDmDumpRsdt (
     UINT32                  Entries;
     UINT32                  Offset;
     UINT32                  i;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Point to start of table pointer array */
@@ -399,12 +400,12 @@ AcpiDmDumpRsdt (
 
     /* RSDT uses 32-bit pointers */
 
-    Entries = (Table->Length - sizeof (ACPI_TABLE_HEADER)) / sizeof (UINT32);
+    Entries = (TableLength - sizeof (ACPI_TABLE_HEADER)) / sizeof (UINT32);
 
     for (i = 0; i < Entries; i++)
     {
         AcpiDmLineHeader2 (Offset, sizeof (UINT32), "ACPI Table Address", i);
-        AcpiOsPrintf ("%8.8X\n", Array[i]);
+        AcpiOsPrintf ("%8.8X\n", AcpiUtReadUint32 (&Array[i]));
         Offset += sizeof (UINT32);
     }
 }

--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -471,11 +471,12 @@ AcpiDmDumpFadt (
     ACPI_TABLE_HEADER       *Table)
 {
     ACPI_STATUS             Status;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Always dump the minimum FADT revision 1 fields (ACPI 1.0) */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0,
         AcpiDmTableInfoFadt1);
     if (ACPI_FAILURE (Status))
     {
@@ -484,10 +485,10 @@ AcpiDmDumpFadt (
 
     /* Check for FADT revision 2 fields (ACPI 1.0B MS extensions) */
 
-    if ((Table->Length > ACPI_FADT_V1_SIZE) &&
-        (Table->Length <= ACPI_FADT_V2_SIZE))
+    if ((TableLength > ACPI_FADT_V1_SIZE) &&
+        (TableLength <= ACPI_FADT_V2_SIZE))
     {
-        Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+        Status = AcpiDmDumpTable (TableLength, 0, Table, 0,
             AcpiDmTableInfoFadt2);
         if (ACPI_FAILURE (Status))
         {
@@ -497,9 +498,9 @@ AcpiDmDumpFadt (
 
     /* Check for FADT revision 3/4 fields and up (ACPI 2.0+ extended data) */
 
-    else if (Table->Length > ACPI_FADT_V2_SIZE)
+    else if (TableLength > ACPI_FADT_V2_SIZE)
     {
-        Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+        Status = AcpiDmDumpTable (TableLength, 0, Table, 0,
             AcpiDmTableInfoFadt3);
         if (ACPI_FAILURE (Status))
         {
@@ -508,9 +509,9 @@ AcpiDmDumpFadt (
 
         /* Check for FADT revision 5 fields and up (ACPI 5.0+) */
 
-        if (Table->Length > ACPI_FADT_V3_SIZE)
+        if (TableLength > ACPI_FADT_V3_SIZE)
         {
-            Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+            Status = AcpiDmDumpTable (TableLength, 0, Table, 0,
                 AcpiDmTableInfoFadt5);
             if (ACPI_FAILURE (Status))
             {
@@ -520,9 +521,9 @@ AcpiDmDumpFadt (
 
         /* Check for FADT revision 6 fields and up (ACPI 6.0+) */
 
-        if (Table->Length > ACPI_FADT_V3_SIZE)
+        if (TableLength > ACPI_FADT_V3_SIZE)
         {
-            Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+            Status = AcpiDmDumpTable (TableLength, 0, Table, 0,
                 AcpiDmTableInfoFadt6);
             if (ACPI_FAILURE (Status))
             {
@@ -533,11 +534,11 @@ AcpiDmDumpFadt (
 
     /* Validate various fields in the FADT, including length */
 
-    AcpiTbCreateLocalFadt (Table, Table->Length);
+    AcpiTbCreateLocalFadt (Table, TableLength);
 
     /* Validate FADT length against the revision */
 
-    AcpiDmValidateFadtLength (Table->Revision, Table->Length);
+    AcpiDmValidateFadtLength (Table->Revision, TableLength);
 }
 
 

--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -446,8 +446,7 @@ AcpiDmDumpXsdt (
     for (i = 0; i < Entries; i++)
     {
         AcpiDmLineHeader2 (Offset, sizeof (UINT64), "ACPI Table Address", i);
-        AcpiOsPrintf ("%8.8X%8.8X\n",
-                ACPI_FORMAT_UINT64 (AcpiUtReadUint64 (&Array[i])));
+        AcpiOsPrintf ("%16.16lX\n", AcpiUtReadUint64 (&Array[i]));
         Offset += sizeof (UINT64);
     }
 }

--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -254,6 +254,8 @@ AcpiDmDumpUnicode (
     UINT8                   *Buffer;
     UINT32                  Length;
     UINT32                  i;
+    UINT16		    Tmp16;
+    UINT32                  start;
 
 
     Buffer = ((UINT8 *) Table) + BufferOffset;
@@ -263,7 +265,8 @@ AcpiDmDumpUnicode (
 
     for (i = 0; i < Length; i += 2)
     {
-        if (!isprint (Buffer[i]))
+        Tmp16 = AcpiUtReadUint16 (&Buffer[i]);
+        if (!isprint (Tmp16))
         {
             goto DumpRawBuffer;
         }
@@ -271,7 +274,8 @@ AcpiDmDumpUnicode (
 
     /* Ensure all high bytes are zero */
 
-    for (i = 1; i < Length; i += 2)
+    start = UtIsBigEndianMachine() ? 0 : 1;
+    for (i = start; i < Length; i += 2)
     {
         if (Buffer[i])
         {
@@ -284,7 +288,8 @@ AcpiDmDumpUnicode (
     AcpiOsPrintf ("\"");
     for (i = 0; i < Length; i += 2)
     {
-        AcpiOsPrintf ("%c", Buffer[i]);
+        Tmp16 = AcpiUtReadUint16 (&Buffer[i]);
+        AcpiOsPrintf ("%c", Tmp16);
     }
 
     AcpiOsPrintf ("\"\n");

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -406,16 +406,18 @@ AcpiDmDumpAsf (
     UINT32                  DataOffset = 0;
     UINT32                  i;
     UINT8                   Type;
+    UINT32                  TableLength;
 
 
     /* No main table, only subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_ASF_INFO, Table, Offset);
-    while (Offset < Table->Length)
+    TableLength = AcpiUtReadUint32 (&Table->Length);
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Header.Length, AcpiDmTableInfoAsfHdr);
         if (ACPI_FAILURE (Status))
         {
@@ -473,7 +475,7 @@ AcpiDmDumpAsf (
             return;
         }
 
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Header.Length, InfoTable);
         if (ACPI_FAILURE (Status))
         {
@@ -490,7 +492,7 @@ AcpiDmDumpAsf (
             for (i = 0; i < DataCount; i++)
             {
                 AcpiOsPrintf ("\n");
-                Status = AcpiDmDumpTable (Table->Length, DataOffset,
+                Status = AcpiDmDumpTable (TableLength, DataOffset,
                     DataTable, DataLength, DataInfoTable);
                 if (ACPI_FAILURE (Status))
                 {

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -646,7 +646,7 @@ AcpiDmDumpCpep (
 {
     ACPI_STATUS             Status;
     ACPI_CPEP_POLLING       *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_CPEP);
 
 
@@ -661,7 +661,7 @@ AcpiDmDumpCpep (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_CPEP_POLLING, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         AcpiOsPrintf ("\n");
         Status = AcpiDmDumpTable (Length, Offset, Subtable,

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1402,7 +1402,7 @@ AcpiDmDumpGtdt (
 {
     ACPI_STATUS             Status;
     ACPI_GTDT_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_GTDT);
     ACPI_DMTABLE_INFO       *InfoTable;
     UINT32                  SubtableLength;
@@ -1438,7 +1438,7 @@ AcpiDmDumpGtdt (
 
     /* Subtables */
 
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         /* Common subtable header */
 
@@ -1456,8 +1456,13 @@ AcpiDmDumpGtdt (
         case ACPI_GTDT_TYPE_TIMER_BLOCK:
 
             SubtableLength = sizeof (ACPI_GTDT_TIMER_BLOCK);
-            GtCount = (ACPI_CAST_PTR (ACPI_GTDT_TIMER_BLOCK,
-                Subtable))->TimerCount;
+            {
+                UINT32 Tmp32;
+
+                Tmp32 = (ACPI_CAST_PTR (ACPI_GTDT_TIMER_BLOCK,
+                    Subtable))->TimerCount;
+                GtCount = AcpiUtReadUint32 (&Tmp32);
+            }
 
             InfoTable = AcpiDmTableInfoGtdt0;
             break;

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1315,9 +1315,10 @@ AcpiDmDumpFpdt (
 {
     ACPI_STATUS             Status;
     ACPI_FPDT_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_FPDT);
     ACPI_DMTABLE_INFO       *InfoTable;
+    UINT16                  SubtableType;
 
 
     /* There is no main table (other than the standard ACPI header) */
@@ -1325,19 +1326,20 @@ AcpiDmDumpFpdt (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Length, AcpiDmTableInfoFpdtHdr);
         if (ACPI_FAILURE (Status))
         {
             return;
         }
 
-        switch (Subtable->Type)
+        SubtableType = AcpiUtReadUint16 (&Subtable->Type);
+        switch (SubtableType)
         {
         case ACPI_FPDT_TYPE_BOOT:
 
@@ -1364,7 +1366,7 @@ AcpiDmDumpFpdt (
             goto NextSubtable;
         }
 
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Length, InfoTable);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1543,12 +1543,13 @@ AcpiDmDumpHest (
 {
     ACPI_STATUS             Status;
     ACPI_HEST_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_HEST);
     ACPI_DMTABLE_INFO       *InfoTable;
     UINT32                  SubtableLength;
     UINT32                  BankCount;
     ACPI_HEST_IA_ERROR_BANK *BankTable;
+    UINT16                  SubtableType;
 
 
     /* Main table */
@@ -1562,10 +1563,11 @@ AcpiDmDumpHest (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_HEST_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         BankCount = 0;
-        switch (Subtable->Type)
+        SubtableType = Subtable->Type;
+        switch (SubtableType)
         {
         case ACPI_HEST_TYPE_IA32_CHECK:
 
@@ -1632,7 +1634,7 @@ AcpiDmDumpHest (
             /* Cannot continue on unknown type - no length */
 
             AcpiOsPrintf ("\n**** Unknown HEST subtable type 0x%X\n",
-                Subtable->Type);
+                SubtableType);
             return;
         }
 

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1097,11 +1097,14 @@ AcpiDmDumpDrtm (
     ACPI_DRTM_RESOURCE_LIST *DrtmRl;
     ACPI_DRTM_DPS_ID        *DrtmDps;
     UINT32                  Count;
+    UINT32                  ResourceCount;
+    UINT32                  ValidatedTableCount;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0,
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0,
         AcpiDmTableInfoDrtm);
     if (ACPI_FAILURE (Status))
     {
@@ -1116,7 +1119,7 @@ AcpiDmDumpDrtm (
 
     DrtmVtl = ACPI_ADD_PTR (ACPI_DRTM_VTABLE_LIST, Table, Offset);
     AcpiOsPrintf ("\n");
-    Status = AcpiDmDumpTable (Table->Length, Offset,
+    Status = AcpiDmDumpTable (TableLength, Offset,
         DrtmVtl, ACPI_OFFSET (ACPI_DRTM_VTABLE_LIST, ValidatedTables),
         AcpiDmTableInfoDrtm0);
     if (ACPI_FAILURE (Status))
@@ -1129,10 +1132,11 @@ AcpiDmDumpDrtm (
     /* Dump Validated table addresses */
 
     Count = 0;
-    while ((Offset < Table->Length) &&
-            (DrtmVtl->ValidatedTableCount > Count))
+    ValidatedTableCount = AcpiUtReadUint32 (&DrtmVtl->ValidatedTableCount);
+    while ((Offset < TableLength) &&
+            (ValidatedTableCount > Count))
     {
-        Status = AcpiDmDumpTable (Table->Length, Offset,
+        Status = AcpiDmDumpTable (TableLength, Offset,
             ACPI_ADD_PTR (void, Table, Offset), sizeof (UINT64),
             AcpiDmTableInfoDrtm0a);
         if (ACPI_FAILURE (Status))
@@ -1148,7 +1152,7 @@ AcpiDmDumpDrtm (
 
     DrtmRl = ACPI_ADD_PTR (ACPI_DRTM_RESOURCE_LIST, Table, Offset);
     AcpiOsPrintf ("\n");
-    Status = AcpiDmDumpTable (Table->Length, Offset,
+    Status = AcpiDmDumpTable (TableLength, Offset,
         DrtmRl, ACPI_OFFSET (ACPI_DRTM_RESOURCE_LIST, Resources),
         AcpiDmTableInfoDrtm1);
     if (ACPI_FAILURE (Status))
@@ -1161,10 +1165,11 @@ AcpiDmDumpDrtm (
     /* Dump the Resource List */
 
     Count = 0;
-    while ((Offset < Table->Length) &&
-           (DrtmRl->ResourceCount > Count))
+    ResourceCount = AcpiUtReadUint32 (&DrtmRl->ResourceCount);
+    while ((Offset < TableLength) &&
+           (ResourceCount > Count))
     {
-        Status = AcpiDmDumpTable (Table->Length, Offset,
+        Status = AcpiDmDumpTable (TableLength, Offset,
             ACPI_ADD_PTR (void, Table, Offset),
             sizeof (ACPI_DRTM_RESOURCE), AcpiDmTableInfoDrtm1a);
         if (ACPI_FAILURE (Status))
@@ -1180,7 +1185,7 @@ AcpiDmDumpDrtm (
 
     DrtmDps = ACPI_ADD_PTR (ACPI_DRTM_DPS_ID, Table, Offset);
     AcpiOsPrintf ("\n");
-    (void) AcpiDmDumpTable (Table->Length, Offset,
+    (void) AcpiDmDumpTable (TableLength, Offset,
         DrtmDps, sizeof (ACPI_DRTM_DPS_ID), AcpiDmTableInfoDrtm2);
 }
 

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1209,7 +1209,7 @@ AcpiDmDumpEinj (
 {
     ACPI_STATUS             Status;
     ACPI_WHEA_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_EINJ);
 
 
@@ -1224,7 +1224,7 @@ AcpiDmDumpEinj (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_WHEA_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         AcpiOsPrintf ("\n");
         Status = AcpiDmDumpTable (Length, Offset, Subtable,

--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1262,7 +1262,7 @@ AcpiDmDumpErst (
 {
     ACPI_STATUS             Status;
     ACPI_WHEA_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_ERST);
 
 
@@ -1277,7 +1277,7 @@ AcpiDmDumpErst (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_WHEA_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         AcpiOsPrintf ("\n");
         Status = AcpiDmDumpTable (Length, Offset, Subtable,

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1103,11 +1103,13 @@ AcpiDmDumpMpst (
     UINT16                  SubtableCount;
     UINT32                  PowerStateCount;
     UINT32                  ComponentCount;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
+    UINT16                  Tmp16;
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMpst);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoMpst);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -1115,13 +1117,14 @@ AcpiDmDumpMpst (
 
     /* Subtable: Memory Power Node(s) */
 
-    SubtableCount = (ACPI_CAST_PTR (ACPI_TABLE_MPST, Table))->PowerNodeCount;
+    Tmp16 = (ACPI_CAST_PTR (ACPI_TABLE_MPST, Table))->PowerNodeCount;
+    SubtableCount = AcpiUtReadUint16 (&Tmp16);
     Subtable0 = ACPI_ADD_PTR (ACPI_MPST_POWER_NODE, Table, Offset);
 
-    while ((Offset < Table->Length) && SubtableCount)
+    while ((Offset < TableLength) && SubtableCount)
     {
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable0,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable0,
             sizeof (ACPI_MPST_POWER_NODE), AcpiDmTableInfoMpst0);
         if (ACPI_FAILURE (Status))
         {
@@ -1130,8 +1133,8 @@ AcpiDmDumpMpst (
 
         /* Extract the sub-subtable counts */
 
-        PowerStateCount = Subtable0->NumPowerStates;
-        ComponentCount = Subtable0->NumPhysicalComponents;
+        PowerStateCount = AcpiUtReadUint16 (&Subtable0->NumPowerStates);
+        ComponentCount = AcpiUtReadUint16 (&Subtable0->NumPhysicalComponents);
         Offset += sizeof (ACPI_MPST_POWER_NODE);
 
         /* Sub-subtables - Memory Power State Structure(s) */
@@ -1142,7 +1145,7 @@ AcpiDmDumpMpst (
         while (PowerStateCount)
         {
             AcpiOsPrintf ("\n");
-            Status = AcpiDmDumpTable (Table->Length, Offset, Subtable0A,
+            Status = AcpiDmDumpTable (TableLength, Offset, Subtable0A,
                 sizeof (ACPI_MPST_POWER_STATE), AcpiDmTableInfoMpst0A);
             if (ACPI_FAILURE (Status))
             {
@@ -1165,7 +1168,7 @@ AcpiDmDumpMpst (
 
         while (ComponentCount)
         {
-            Status = AcpiDmDumpTable (Table->Length, Offset, Subtable0B,
+            Status = AcpiDmDumpTable (TableLength, Offset, Subtable0B,
                 sizeof (ACPI_MPST_COMPONENT), AcpiDmTableInfoMpst0B);
             if (ACPI_FAILURE (Status))
             {
@@ -1182,22 +1185,24 @@ AcpiDmDumpMpst (
         SubtableCount--;
         Subtable0 = ACPI_ADD_PTR (ACPI_MPST_POWER_NODE, Subtable0,
             sizeof (ACPI_MPST_POWER_NODE) +
-            (sizeof (ACPI_MPST_POWER_STATE) * Subtable0->NumPowerStates) +
-            (sizeof (ACPI_MPST_COMPONENT) * Subtable0->NumPhysicalComponents));
+            (sizeof (ACPI_MPST_POWER_STATE) *
+                AcpiUtReadUint16 (&Subtable0->NumPowerStates)) +
+            (sizeof (ACPI_MPST_COMPONENT) *
+                AcpiUtReadUint16 (&Subtable0->NumPhysicalComponents)));
     }
 
     /* Subtable: Count of Memory Power State Characteristic structures */
 
     AcpiOsPrintf ("\n");
     Subtable1 = ACPI_CAST_PTR (ACPI_MPST_DATA_HDR, Subtable0);
-    Status = AcpiDmDumpTable (Table->Length, Offset, Subtable1,
+    Status = AcpiDmDumpTable (TableLength, Offset, Subtable1,
         sizeof (ACPI_MPST_DATA_HDR), AcpiDmTableInfoMpst1);
     if (ACPI_FAILURE (Status))
     {
         return;
     }
 
-    SubtableCount = Subtable1->CharacteristicsCount;
+    SubtableCount = AcpiUtReadUint16 (&Subtable1->CharacteristicsCount);
     Offset += sizeof (ACPI_MPST_DATA_HDR);
 
     /* Subtable: Memory Power State Characteristics structure(s) */
@@ -1205,10 +1210,10 @@ AcpiDmDumpMpst (
     Subtable2 = ACPI_ADD_PTR (ACPI_MPST_POWER_DATA, Subtable1,
         sizeof (ACPI_MPST_DATA_HDR));
 
-    while ((Offset < Table->Length) && SubtableCount)
+    while ((Offset < TableLength) && SubtableCount)
     {
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable2,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable2,
             sizeof (ACPI_MPST_POWER_DATA), AcpiDmTableInfoMpst2);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1502,13 +1502,13 @@ AcpiDmDumpPcct (
     ACPI_STATUS             Status;
     ACPI_PCCT_SUBSPACE      *Subtable;
     ACPI_DMTABLE_INFO       *InfoTable;
-    UINT32                  Length = Table->Length;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_PCCT);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoPcct);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoPcct);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -1517,12 +1517,12 @@ AcpiDmDumpPcct (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_PCCT_SUBSPACE, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Header.Length, AcpiDmTableInfoPcctHdr);
         if (ACPI_FAILURE (Status))
         {
@@ -1570,7 +1570,7 @@ AcpiDmDumpPcct (
         }
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Header.Length, InfoTable);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -2147,6 +2147,8 @@ AcpiDmDumpS3pt (
     ACPI_FPDT_HEADER        *Subtable;
     ACPI_DMTABLE_INFO       *InfoTable;
     ACPI_TABLE_S3PT         *S3ptTable = ACPI_CAST_PTR (ACPI_TABLE_S3PT, Tables);
+    UINT32                  S3ptTableLength = AcpiUtReadUint32 (&S3ptTable->Length);
+    UINT16                  SubtableType;
 
 
     /* Main table */
@@ -2158,19 +2160,20 @@ AcpiDmDumpS3pt (
     }
 
     Subtable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, S3ptTable, Offset);
-    while (Offset < S3ptTable->Length)
+    while (Offset < S3ptTableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (S3ptTable->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (S3ptTableLength, Offset, Subtable,
             Subtable->Length, AcpiDmTableInfoS3ptHdr);
         if (ACPI_FAILURE (Status))
         {
             return 0;
         }
 
-        switch (Subtable->Type)
+        SubtableType = AcpiUtReadUint16 (&Subtable->Type);
+        switch (SubtableType)
         {
         case ACPI_S3PT_TYPE_RESUME:
 
@@ -2185,7 +2188,7 @@ AcpiDmDumpS3pt (
         default:
 
             AcpiOsPrintf ("\n**** Unknown S3PT subtable type 0x%X\n",
-                Subtable->Type);
+                SubtableType);
 
             /* Attempt to continue */
 
@@ -2198,7 +2201,7 @@ AcpiDmDumpS3pt (
         }
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (S3ptTable->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (S3ptTableLength, Offset, Subtable,
             Subtable->Length, InfoTable);
         if (ACPI_FAILURE (Status))
         {
@@ -2212,7 +2215,7 @@ NextSubtable:
         Subtable = ACPI_ADD_PTR (ACPI_FPDT_HEADER, Subtable, Subtable->Length);
     }
 
-    return (S3ptTable->Length);
+    return (S3ptTableLength);
 }
 
 

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -2233,7 +2233,7 @@ AcpiDmDumpSdev (
     ACPI_SDEV_NAMESPACE         *Namesp;
     ACPI_DMTABLE_INFO           *InfoTable;
     ACPI_DMTABLE_INFO           *SecureComponentInfoTable;
-    UINT32                      Length = Table->Length;
+    UINT32                      TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT32                      Offset = sizeof (ACPI_TABLE_SDEV);
     UINT16                      PathOffset;
     UINT16                      PathLength;
@@ -2241,11 +2241,12 @@ AcpiDmDumpSdev (
     UINT16                      VendorDataLength;
     ACPI_SDEV_SECURE_COMPONENT  *SecureComponent = NULL;
     UINT32                      CurrentOffset = 0;
+    UINT16                      SubtableLength;
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoSdev);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoSdev);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -2254,13 +2255,14 @@ AcpiDmDumpSdev (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_SDEV_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
-            Subtable->Length, AcpiDmTableInfoSdevHdr);
+	SubtableLength = AcpiUtReadUint16 (&Subtable->Length);
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
+            SubtableLength, AcpiDmTableInfoSdevHdr);
         if (ACPI_FAILURE (Status))
         {
             return;
@@ -2283,8 +2285,8 @@ AcpiDmDumpSdev (
         }
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, 0, Subtable,
-            Subtable->Length, InfoTable);
+        Status = AcpiDmDumpTable (TableLength, 0, Subtable,
+            SubtableLength, InfoTable);
         if (ACPI_FAILURE (Status))
         {
             return;
@@ -2343,12 +2345,12 @@ AcpiDmDumpSdev (
             /* Dump the PCIe device ID(s) */
 
             Namesp = ACPI_CAST_PTR (ACPI_SDEV_NAMESPACE, Subtable);
-            PathOffset = Namesp->DeviceIdOffset;
-            PathLength = Namesp->DeviceIdLength;
+            PathOffset = AcpiUtReadUint16 (&Namesp->DeviceIdOffset);
+            PathLength = AcpiUtReadUint16 (&Namesp->DeviceIdLength);
 
             if (PathLength)
             {
-                Status = AcpiDmDumpTable (Table->Length, CurrentOffset,
+                Status = AcpiDmDumpTable (TableLength, CurrentOffset,
                     ACPI_ADD_PTR (UINT8, Namesp, PathOffset),
                     PathLength, AcpiDmTableInfoSdev0a);
                 if (ACPI_FAILURE (Status))
@@ -2360,14 +2362,14 @@ AcpiDmDumpSdev (
 
             /* Dump the vendor-specific data */
 
-            VendorDataLength =
-                Namesp->VendorDataLength;
+            VendorDataLength = AcpiUtReadUint16 (&Namesp->VendorDataLength);
             VendorDataOffset =
-                Namesp->DeviceIdOffset + Namesp->DeviceIdLength;
+                AcpiUtReadUint16 (&Namesp->DeviceIdOffset) +
+		AcpiUtReadUint16 (&Namesp->DeviceIdLength);
 
             if (VendorDataLength)
             {
-                Status = AcpiDmDumpTable (Table->Length, 0,
+                Status = AcpiDmDumpTable (TableLength, 0,
                     ACPI_ADD_PTR (UINT8, Namesp, VendorDataOffset),
                     VendorDataLength, AcpiDmTableInfoSdev1b);
                 if (ACPI_FAILURE (Status))
@@ -2382,12 +2384,12 @@ AcpiDmDumpSdev (
             /* PCI path substructures */
 
             Pcie = ACPI_CAST_PTR (ACPI_SDEV_PCIE, Subtable);
-            PathOffset = Pcie->PathOffset;
-            PathLength = Pcie->PathLength;
+            PathOffset = AcpiUtReadUint16 (&Pcie->PathOffset);
+            PathLength = AcpiUtReadUint16 (&Pcie->PathLength);
 
             while (PathLength)
             {
-                Status = AcpiDmDumpTable (Table->Length,
+                Status = AcpiDmDumpTable (TableLength,
                     PathOffset + Offset,
                     ACPI_ADD_PTR (UINT8, Pcie, PathOffset),
                     sizeof (ACPI_SDEV_PCIE_PATH), AcpiDmTableInfoSdev1a);
@@ -2402,12 +2404,14 @@ AcpiDmDumpSdev (
 
             /* VendorData */
 
-            VendorDataLength = Pcie->VendorDataLength;
-            VendorDataOffset = Pcie->PathOffset + Pcie->PathLength;
+            VendorDataLength = AcpiUtReadUint16 (&Pcie->VendorDataLength);
+            VendorDataOffset = 
+	            AcpiUtReadUint16 (&Pcie->PathOffset) +
+	            AcpiUtReadUint16 (&Pcie->PathLength);
 
             if (VendorDataLength)
             {
-                Status = AcpiDmDumpTable (Table->Length, 0,
+                Status = AcpiDmDumpTable (TableLength, 0,
                     ACPI_ADD_PTR (UINT8, Pcie, VendorDataOffset),
                     VendorDataLength, AcpiDmTableInfoSdev1b);
                 if (ACPI_FAILURE (Status))
@@ -2424,8 +2428,8 @@ AcpiDmDumpSdev (
 NextSubtable:
         /* Point to next subtable */
 
-        Offset += Subtable->Length;
+        Offset += SubtableLength;
         Subtable = ACPI_ADD_PTR (ACPI_SDEV_HEADER, Subtable,
-            Subtable->Length);
+            SubtableLength);
     }
 }

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1241,11 +1241,12 @@ AcpiDmDumpMsct (
     ACPI_STATUS             Status;
     UINT32                  Offset = sizeof (ACPI_TABLE_MSCT);
     ACPI_MSCT_PROXIMITY     *Subtable;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMsct);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoMsct);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -1254,12 +1255,12 @@ AcpiDmDumpMsct (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_MSCT_PROXIMITY, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             sizeof (ACPI_MSCT_PROXIMITY), AcpiDmTableInfoMsct0);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1606,13 +1606,13 @@ AcpiDmDumpPdtt (
 {
     ACPI_STATUS             Status;
     ACPI_PDTT_CHANNEL       *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_PDTT);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoPdtt);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoPdtt);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -1621,10 +1621,10 @@ AcpiDmDumpPdtt (
     /* Subtables. Currently there is only one type, but can be multiples */
 
     Subtable = ACPI_ADD_PTR (ACPI_PDTT_CHANNEL, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             sizeof (ACPI_PDTT_CHANNEL), AcpiDmTableInfoPdtt0);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -527,11 +527,14 @@ AcpiDmDumpIvrs (
     ACPI_IVRS_DE_HEADER     *DeviceEntry;
     ACPI_IVRS_HEADER        *Subtable;
     ACPI_DMTABLE_INFO       *InfoTable;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
+    UINT16                  SubtableLength;
+
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoIvrs);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoIvrs);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -541,8 +544,9 @@ AcpiDmDumpIvrs (
 
     Subtable = ACPI_ADD_PTR (ACPI_IVRS_HEADER, Table, Offset);
 
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
+        SubtableLength = AcpiUtReadUint16 (&Subtable->Length);
         switch (Subtable->Type)
         {
         /* Type 10h, IVHD (I/O Virtualization Hardware Definition) */
@@ -579,7 +583,7 @@ AcpiDmDumpIvrs (
 
             /* Attempt to continue */
 
-            if (!Subtable->Length)
+            if (!SubtableLength)
             {
                 AcpiOsPrintf ("Invalid zero length subtable\n");
                 return;
@@ -589,8 +593,8 @@ AcpiDmDumpIvrs (
 
         /* Dump the subtable */
 
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
-            Subtable->Length, InfoTable);
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
+            SubtableLength, InfoTable);
         if (ACPI_FAILURE (Status))
         {
             return;
@@ -619,7 +623,7 @@ AcpiDmDumpIvrs (
 
             /* Process all of the Device Entries */
 
-            while (EntryOffset < (Offset + Subtable->Length))
+            while (EntryOffset < (Offset + SubtableLength))
             {
                 AcpiOsPrintf ("\n");
 
@@ -689,7 +693,7 @@ AcpiDmDumpIvrs (
 
                 /* Dump the Device Entry */
 
-                Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                Status = AcpiDmDumpTable (TableLength, EntryOffset,
                     DeviceEntry, EntryLength, InfoTable);
                 if (ACPI_FAILURE (Status))
                 {
@@ -713,12 +717,12 @@ AcpiDmDumpIvrs (
                      */
                     if (UtIsIdInteger ((UINT8 *) &HidSubtable->AcpiHid))
                     {
-                        Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                        Status = AcpiDmDumpTable (TableLength, EntryOffset,
                             &HidSubtable->AcpiHid, 8, AcpiDmTableInfoIvrsHidInteger);
                     }
                     else
                     {
-                        Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                        Status = AcpiDmDumpTable (TableLength, EntryOffset,
                             &HidSubtable->AcpiHid, 8, AcpiDmTableInfoIvrsHidString);
                     }
                     if (ACPI_FAILURE (Status))
@@ -736,12 +740,12 @@ AcpiDmDumpIvrs (
                      */
                     if (UtIsIdInteger ((UINT8 *) &HidSubtable->AcpiCid))
                     {
-                        Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                        Status = AcpiDmDumpTable (TableLength, EntryOffset,
                             &HidSubtable->AcpiCid, 8, AcpiDmTableInfoIvrsCidInteger);
                     }
                     else
                     {
-                        Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                        Status = AcpiDmDumpTable (TableLength, EntryOffset,
                             &HidSubtable->AcpiCid, 8, AcpiDmTableInfoIvrsCidString);
                     }
                     if (ACPI_FAILURE (Status))
@@ -758,7 +762,7 @@ AcpiDmDumpIvrs (
 
                         if (HidSubtable->UidType == ACPI_IVRS_UID_IS_STRING)
                         {
-                            Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                            Status = AcpiDmDumpTable (TableLength, EntryOffset,
                                 &HidSubtable->UidType, EntryLength, AcpiDmTableInfoIvrsUidString);
                             if (ACPI_FAILURE (Status))
                             {
@@ -767,7 +771,7 @@ AcpiDmDumpIvrs (
                         }
                         else /* ACPI_IVRS_UID_IS_INTEGER */
                         {
-                            Status = AcpiDmDumpTable (Table->Length, EntryOffset,
+                            Status = AcpiDmDumpTable (TableLength, EntryOffset,
                                 &HidSubtable->UidType, EntryLength, AcpiDmTableInfoIvrsUidInteger);
                             if (ACPI_FAILURE (Status))
                             {
@@ -786,8 +790,8 @@ AcpiDmDumpIvrs (
 NextSubtable:
         /* Point to next subtable */
 
-        Offset += Subtable->Length;
-        Subtable = ACPI_ADD_PTR (ACPI_IVRS_HEADER, Subtable, Subtable->Length);
+        Offset += SubtableLength;
+        Subtable = ACPI_ADD_PTR (ACPI_IVRS_HEADER, Subtable, SubtableLength);
     }
 }
 

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1893,6 +1893,8 @@ AcpiDmDumpPptt (
     UINT32                  Offset = sizeof (ACPI_TABLE_FPDT);
     ACPI_DMTABLE_INFO       *InfoTable;
     UINT32                  i;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
+    UINT32                  NumPrivRes;
 
 
     /* There is no main table (other than the standard ACPI header) */
@@ -1900,7 +1902,7 @@ AcpiDmDumpPptt (
     /* Subtables */
 
     Offset = sizeof (ACPI_TABLE_HEADER);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         AcpiOsPrintf ("\n");
 
@@ -1912,7 +1914,7 @@ AcpiDmDumpPptt (
             AcpiOsPrintf ("Invalid subtable length\n");
             return;
         }
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Length, AcpiDmTableInfoPpttHdr);
         if (ACPI_FAILURE (Status))
         {
@@ -1954,7 +1956,7 @@ AcpiDmDumpPptt (
             AcpiOsPrintf ("Invalid subtable length\n");
             return;
         }
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Length, InfoTable);
         if (ACPI_FAILURE (Status))
         {
@@ -1970,15 +1972,16 @@ AcpiDmDumpPptt (
 
             /* Dump SMBIOS handles */
 
-            if ((UINT8)(Subtable->Length - SubtableOffset) <
-                (UINT8)(PpttProcessor->NumberOfPrivResources * 4))
+            NumPrivRes = AcpiUtReadUint32 (&PpttProcessor->NumberOfPrivResources);
+            if ((UINT8) (Subtable->Length - SubtableOffset) <
+                (UINT8) (NumPrivRes * 4))
             {
                 AcpiOsPrintf ("Invalid private resource number\n");
                 return;
             }
-            for (i = 0; i < PpttProcessor->NumberOfPrivResources; i++)
+            for (i = 0; i < NumPrivRes; i++)
             {
-                Status = AcpiDmDumpTable (Table->Length, Offset + SubtableOffset,
+                Status = AcpiDmDumpTable (TableLength, Offset + SubtableOffset,
                     ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, Subtable, SubtableOffset),
                     4, AcpiDmTableInfoPptt0a);
                 if (ACPI_FAILURE (Status))

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -798,7 +798,7 @@ AcpiDmDumpLpit (
 {
     ACPI_STATUS             Status;
     ACPI_LPIT_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_LPIT);
     ACPI_DMTABLE_INFO       *InfoTable;
     UINT32                  SubtableLength;
@@ -807,11 +807,11 @@ AcpiDmDumpLpit (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_LPIT_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             sizeof (ACPI_LPIT_HEADER), AcpiDmTableInfoLpitHdr);
         if (ACPI_FAILURE (Status))
         {
@@ -835,7 +835,7 @@ AcpiDmDumpLpit (
             return;
         }
 
-        Status = AcpiDmDumpTable (Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             SubtableLength, InfoTable);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1038,11 +1038,12 @@ AcpiDmDumpMcfg (
     ACPI_STATUS             Status;
     UINT32                  Offset = sizeof (ACPI_TABLE_MCFG);
     ACPI_MCFG_ALLOCATION    *Subtable;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoMcfg);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoMcfg);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -1051,17 +1052,17 @@ AcpiDmDumpMcfg (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_MCFG_ALLOCATION, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
-        if (Offset + sizeof (ACPI_MCFG_ALLOCATION) > Table->Length)
+        if (Offset + sizeof (ACPI_MCFG_ALLOCATION) > TableLength)
         {
             AcpiOsPrintf ("Warning: there are %u invalid trailing bytes\n",
-                (UINT32) sizeof (ACPI_MCFG_ALLOCATION) - (Offset - Table->Length));
+                (UINT32) sizeof (ACPI_MCFG_ALLOCATION) - (Offset - TableLength));
             return;
         }
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             sizeof (ACPI_MCFG_ALLOCATION), AcpiDmTableInfoMcfg0);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -871,7 +871,7 @@ AcpiDmDumpMadt (
 {
     ACPI_STATUS             Status;
     ACPI_SUBTABLE_HEADER    *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_MADT);
     ACPI_DMTABLE_INFO       *InfoTable;
 
@@ -887,7 +887,7 @@ AcpiDmDumpMadt (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         /* Common subtable header */
 

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1794,8 +1794,9 @@ AcpiDmDumpPmtt (
 {
     ACPI_STATUS             Status;
     ACPI_PMTT_HEADER        *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  Length = AcpiUtReadUint32 (&Table->Length);
     UINT32                  Offset = sizeof (ACPI_TABLE_PMTT);
+    UINT16                  SubtableLength;
 
 
     /* Main table */
@@ -1809,17 +1810,18 @@ AcpiDmDumpPmtt (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_PMTT_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < Length)
     {
         /* Each of the types below contain the common subtable header */
 
         AcpiOsPrintf ("\n");
+	SubtableLength = AcpiUtReadUint16 (&Subtable->Length);
         switch (Subtable->Type)
         {
         case ACPI_PMTT_TYPE_SOCKET:
 
             Status = AcpiDmDumpTable (Length, Offset, Subtable,
-                Subtable->Length, AcpiDmTableInfoPmtt0);
+                SubtableLength, AcpiDmTableInfoPmtt0);
             if (ACPI_FAILURE (Status))
             {
                 return;
@@ -1828,7 +1830,7 @@ AcpiDmDumpPmtt (
 
         case ACPI_PMTT_TYPE_CONTROLLER:
             Status = AcpiDmDumpTable (Length, Offset, Subtable,
-                Subtable->Length, AcpiDmTableInfoPmtt1);
+                SubtableLength, AcpiDmTableInfoPmtt1);
             if (ACPI_FAILURE (Status))
             {
                 return;
@@ -1837,7 +1839,7 @@ AcpiDmDumpPmtt (
 
        case ACPI_PMTT_TYPE_DIMM:
             Status = AcpiDmDumpTable (Length, Offset, Subtable,
-                Subtable->Length, AcpiDmTableInfoPmtt2);
+                SubtableLength, AcpiDmTableInfoPmtt2);
             if (ACPI_FAILURE (Status))
             {
                 return;
@@ -1846,7 +1848,7 @@ AcpiDmDumpPmtt (
 
         case ACPI_PMTT_TYPE_VENDOR:
             Status = AcpiDmDumpTable (Length, Offset, Subtable,
-                Subtable->Length, AcpiDmTableInfoPmttVendor);
+                SubtableLength, AcpiDmTableInfoPmttVendor);
             if (ACPI_FAILURE (Status))
             {
                 return;
@@ -1862,9 +1864,9 @@ AcpiDmDumpPmtt (
 
         /* Point to next subtable */
 
-        Offset += Subtable->Length;
+        Offset += SubtableLength;
         Subtable = ACPI_ADD_PTR (ACPI_PMTT_HEADER,
-            Subtable, Subtable->Length);
+            Subtable, SubtableLength);
     }
 }
 

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -509,11 +509,13 @@ AcpiDmDumpTcpa (
     ACPI_TABLE_TCPA_HDR     *Subtable = ACPI_ADD_PTR (
                                 ACPI_TABLE_TCPA_HDR, Table, Offset);
     ACPI_STATUS             Status;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
+    UINT16                  PlatformClass;
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table,
+    Status = AcpiDmDumpTable (TableLength, 0, Table,
         0, AcpiDmTableInfoTcpaHdr);
     if (ACPI_FAILURE (Status))
     {
@@ -524,18 +526,19 @@ AcpiDmDumpTcpa (
      * Examine the PlatformClass field to determine the table type.
      * Either a client or server table. Only one.
      */
-    switch (CommonHeader->PlatformClass)
+    PlatformClass = AcpiUtReadUint16 (&CommonHeader->PlatformClass);
+    switch (PlatformClass)
     {
     case ACPI_TCPA_CLIENT_TABLE:
 
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Table->Length - Offset, AcpiDmTableInfoTcpaClient);
         break;
 
     case ACPI_TCPA_SERVER_TABLE:
 
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
-            Table->Length - Offset, AcpiDmTableInfoTcpaServer);
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
+            TableLength - Offset, AcpiDmTableInfoTcpaServer);
         break;
 
     default:

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -578,11 +578,12 @@ AcpiDmDumpTpm2Rev3 (
     ACPI_TABLE_TPM23        *CommonHeader = ACPI_CAST_PTR (ACPI_TABLE_TPM23, Table);
     ACPI_TPM23_TRAILER      *Subtable = ACPI_ADD_PTR (ACPI_TPM23_TRAILER, Table, Offset);
     ACPI_STATUS             Status;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoTpm23);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoTpm23);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -594,8 +595,8 @@ AcpiDmDumpTpm2Rev3 (
     {
     case ACPI_TPM23_ACPI_START_METHOD:
 
-        (void) AcpiDmDumpTable (Table->Length, Offset, Subtable,
-            Table->Length - Offset, AcpiDmTableInfoTpm23a);
+        (void) AcpiDmDumpTable (TableLength, Offset, Subtable,
+            TableLength - Offset, AcpiDmTableInfoTpm23a);
         break;
 
     default:
@@ -625,6 +626,7 @@ AcpiDmDumpTpm2 (
     ACPI_TPM2_TRAILER       *Subtable = ACPI_ADD_PTR (ACPI_TPM2_TRAILER, Table, Offset);
     ACPI_TPM2_ARM_SMC       *ArmSubtable;
     ACPI_STATUS             Status;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     if (Table->Revision == 3)
@@ -635,7 +637,7 @@ AcpiDmDumpTpm2 (
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoTpm2);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoTpm2);
 
     if (ACPI_FAILURE (Status))
     {
@@ -643,8 +645,8 @@ AcpiDmDumpTpm2 (
     }
 
     AcpiOsPrintf ("\n");
-    Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
-        Table->Length - Offset, AcpiDmTableInfoTpm2a);
+    Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
+        TableLength - Offset, AcpiDmTableInfoTpm2a);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -659,8 +661,8 @@ AcpiDmDumpTpm2 (
         Offset += sizeof (ACPI_TPM2_TRAILER);
 
         AcpiOsPrintf ("\n");
-        (void) AcpiDmDumpTable (Table->Length, Offset, ArmSubtable,
-            Table->Length - Offset, AcpiDmTableInfoTpm211);
+        (void) AcpiDmDumpTable (TableLength, Offset, ArmSubtable,
+            TableLength - Offset, AcpiDmTableInfoTpm211);
         break;
 
     default:

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -281,11 +281,12 @@ AcpiDmDumpSrat (
     UINT32                  Offset = sizeof (ACPI_TABLE_SRAT);
     ACPI_SUBTABLE_HEADER    *Subtable;
     ACPI_DMTABLE_INFO       *InfoTable;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoSrat);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoSrat);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -294,12 +295,12 @@ AcpiDmDumpSrat (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Length, AcpiDmTableInfoSratHdr);
         if (ACPI_FAILURE (Status))
         {
@@ -353,7 +354,7 @@ AcpiDmDumpSrat (
         }
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             Subtable->Length, InfoTable);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -783,11 +783,12 @@ AcpiDmDumpWdat (
     ACPI_STATUS             Status;
     UINT32                  Offset = sizeof (ACPI_TABLE_WDAT);
     ACPI_WDAT_ENTRY         *Subtable;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoWdat);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoWdat);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -796,12 +797,12 @@ AcpiDmDumpWdat (
     /* Subtables */
 
     Subtable = ACPI_ADD_PTR (ACPI_WDAT_ENTRY, Table, Offset);
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         /* Common subtable header */
 
         AcpiOsPrintf ("\n");
-        Status = AcpiDmDumpTable (Table->Length, Offset, Subtable,
+        Status = AcpiDmDumpTable (TableLength, Offset, Subtable,
             sizeof (ACPI_WDAT_ENTRY), AcpiDmTableInfoWdat0);
         if (ACPI_FAILURE (Status))
         {

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -844,13 +844,13 @@ AcpiDmDumpWpbt (
 {
     ACPI_STATUS             Status;
     ACPI_TABLE_WPBT         *Subtable;
-    UINT32                  Length = Table->Length;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT16                  ArgumentsLength;
 
 
     /* Dump the main table */
 
-    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoWpbt);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoWpbt);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -859,10 +859,10 @@ AcpiDmDumpWpbt (
     /* Extract the arguments buffer length from the main table */
 
     Subtable = ACPI_CAST_PTR (ACPI_TABLE_WPBT, Table);
-    ArgumentsLength = Subtable->ArgumentsLength;
+    ArgumentsLength = AcpiUtReadUint16 (&Subtable->ArgumentsLength);
 
     /* Dump the arguments buffer */
 
-    (void) AcpiDmDumpTable (Table->Length, 0, Table, ArgumentsLength,
+    (void) AcpiDmDumpTable (TableLength, 0, Table, ArgumentsLength,
         AcpiDmTableInfoWpbt0);
 }

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -393,14 +393,14 @@ AcpiDmDumpStao (
 {
     ACPI_STATUS             Status;
     char                    *Namepath;
-    UINT32                  Length = Table->Length;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
     UINT32                  StringLength;
     UINT32                  Offset = sizeof (ACPI_TABLE_STAO);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Length, 0, Table, 0, AcpiDmTableInfoStao);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoStao);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -408,7 +408,7 @@ AcpiDmDumpStao (
 
     /* The rest of the table consists of Namepath strings */
 
-    while (Offset < Table->Length)
+    while (Offset < TableLength)
     {
         Namepath = ACPI_ADD_PTR (char, Table, Offset);
         StringLength = strlen (Namepath) + 1;

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -204,11 +204,12 @@ AcpiDmDumpSlit (
     UINT32                  Localities;
     UINT32                  i;
     UINT32                  j;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     /* Main table */
 
-    Status = AcpiDmDumpTable (Table->Length, 0, Table, 0, AcpiDmTableInfoSlit);
+    Status = AcpiDmDumpTable (TableLength, 0, Table, 0, AcpiDmTableInfoSlit);
     if (ACPI_FAILURE (Status))
     {
         return;
@@ -216,7 +217,8 @@ AcpiDmDumpSlit (
 
     /* Display the Locality NxN Matrix */
 
-    Localities = (UINT32) ACPI_CAST_PTR (ACPI_TABLE_SLIT, Table)->LocalityCount;
+    Localities = (UINT32)
+        AcpiUtReadUint64 (&ACPI_CAST_PTR (ACPI_TABLE_SLIT, Table)->LocalityCount);
     Offset = ACPI_OFFSET (ACPI_TABLE_SLIT, Entry[0]);
     Row = (UINT8 *) ACPI_CAST_PTR (ACPI_TABLE_SLIT, Table)->Entry;
 
@@ -229,7 +231,7 @@ AcpiDmDumpSlit (
         {
             /* Check for beyond EOT */
 
-            if (Offset >= Table->Length)
+            if (Offset >= TableLength)
             {
                 AcpiOsPrintf (
                     "\n**** Not enough room in table for all localities\n");

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -176,9 +176,11 @@ void
 AcpiDmDumpSlic (
     ACPI_TABLE_HEADER       *Table)
 {
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
-    (void) AcpiDmDumpTable (Table->Length, sizeof (ACPI_TABLE_HEADER), Table,
-        Table->Length - sizeof (*Table), AcpiDmTableInfoSlic);
+    (void) AcpiDmDumpTable (TableLength, sizeof (ACPI_TABLE_HEADER),
+        (void *) (Table + sizeof (*Table)),
+        TableLength - sizeof (*Table), AcpiDmTableInfoSlic);
 }
 
 

--- a/source/compiler/aslanalyze.c
+++ b/source/compiler/aslanalyze.c
@@ -577,7 +577,7 @@ ApCheckForGpeNameConflict (
 
     /* Need a null-terminated string version of NameSeg */
 
-    ACPI_MOVE_32_TO_32 (Name, Op->Asl.NameSeg);
+    ACPI_COPY_NAMESEG (Name, Op->Asl.NameSeg);
     Name[ACPI_NAMESEG_SIZE] = 0;
 
     /*
@@ -604,7 +604,7 @@ ApCheckForGpeNameConflict (
      * We are now sure we have an _Lxx or _Exx.
      * Create the target name that would cause collision (Flip E/L)
      */
-    ACPI_MOVE_32_TO_32 (Target, Name);
+    ACPI_COPY_NAMESEG (Target, Name);
 
     /* Inject opposite letter ("L" versus "E") */
 

--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1228,10 +1228,6 @@ BOOLEAN
 UtIsIdInteger (
     UINT8                   *Target);
 
-UINT8
-UtIsBigEndianMachine (
-    void);
-
 BOOLEAN
 UtQueryForOverwrite (
     char                    *Pathname);

--- a/source/compiler/aslmain.c
+++ b/source/compiler/aslmain.c
@@ -209,18 +209,6 @@ main (
 
     signal (SIGINT, AslSignalHandler);
 
-    /*
-     * Big-endian machines are not currently supported. ACPI tables must
-     * be little-endian, and support for big-endian machines needs to
-     * be implemented.
-     */
-    if (UtIsBigEndianMachine ())
-    {
-        fprintf (stderr,
-            "iASL is not currently supported on big-endian machines.\n");
-        return (-1);
-    }
-
     AcpiOsInitialize ();
     ACPI_DEBUG_INITIALIZE (); /* For debug version only */
 

--- a/source/compiler/aslopcodes.c
+++ b/source/compiler/aslopcodes.c
@@ -619,7 +619,8 @@ OpcDoUnicode (
 
     for (i = 0; i < Count; i++)
     {
-        UnicodeString[i] = (UINT16) AsciiString[i];
+        AcpiUtWriteUint (&UnicodeString[i], sizeof (UINT16),
+                &AsciiString[i], sizeof (UINT8));
     }
 
     /*

--- a/source/compiler/aslrestype1.c
+++ b/source/compiler/aslrestype1.c
@@ -251,6 +251,7 @@ RsDoMemory24Descriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -259,7 +260,8 @@ RsDoMemory24Descriptor (
 
     Descriptor = Rnode->Buffer;
     Descriptor->Memory24.DescriptorType = ACPI_RESOURCE_NAME_MEMORY24;
-    Descriptor->Memory24.ResourceLength = 9;
+    Tmp16 = 9;
+    Descriptor->Memory24.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     /* Process all child initialization nodes */
 
@@ -276,7 +278,8 @@ RsDoMemory24Descriptor (
 
         case 1: /* Min Address */
 
-            Descriptor->Memory24.Minimum = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory24.Minimum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory24.Minimum));
             MinOp = InitializerOp;
@@ -284,7 +287,8 @@ RsDoMemory24Descriptor (
 
         case 2: /* Max Address */
 
-            Descriptor->Memory24.Maximum = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory24.Maximum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory24.Maximum));
             MaxOp = InitializerOp;
@@ -292,14 +296,16 @@ RsDoMemory24Descriptor (
 
         case 3: /* Alignment */
 
-            Descriptor->Memory24.Alignment = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory24.Alignment = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_ALIGNMENT,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory24.Alignment));
             break;
 
         case 4: /* Length */
 
-            Descriptor->Memory24.AddressLength = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory24.AddressLength = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory24.AddressLength));
             LengthOp = InitializerOp;
@@ -322,10 +328,10 @@ RsDoMemory24Descriptor (
     /* Validate the Min/Max/Len/Align values (Alignment==0 means 64K) */
 
     RsSmallAddressCheck (ACPI_RESOURCE_NAME_MEMORY24,
-        Descriptor->Memory24.Minimum,
-        Descriptor->Memory24.Maximum,
-        Descriptor->Memory24.AddressLength,
-        Descriptor->Memory24.Alignment,
+        (UINT32) AcpiUtReadUint16 (&Descriptor->Memory24.Minimum),
+        (UINT32) AcpiUtReadUint16 (&Descriptor->Memory24.Maximum),
+        (UINT32) AcpiUtReadUint16 (&Descriptor->Memory24.AddressLength),
+        (UINT32) AcpiUtReadUint16 (&Descriptor->Memory24.Alignment),
         MinOp, MaxOp, LengthOp, NULL, Info->DescriptorTypeOp);
 
     return (Rnode);
@@ -357,6 +363,8 @@ RsDoMemory32Descriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -365,7 +373,8 @@ RsDoMemory32Descriptor (
 
     Descriptor = Rnode->Buffer;
     Descriptor->Memory32.DescriptorType = ACPI_RESOURCE_NAME_MEMORY32;
-    Descriptor->Memory32.ResourceLength = 17;
+    Tmp16 = 17;
+    Descriptor->Memory32.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     /* Process all child initialization nodes */
 
@@ -382,7 +391,8 @@ RsDoMemory32Descriptor (
 
         case 1:  /* Min Address */
 
-            Descriptor->Memory32.Minimum = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory32.Minimum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory32.Minimum));
             MinOp = InitializerOp;
@@ -390,7 +400,8 @@ RsDoMemory32Descriptor (
 
         case 2: /* Max Address */
 
-            Descriptor->Memory32.Maximum = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory32.Maximum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory32.Maximum));
             MaxOp = InitializerOp;
@@ -398,7 +409,8 @@ RsDoMemory32Descriptor (
 
         case 3: /* Alignment */
 
-            Descriptor->Memory32.Alignment = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory32.Alignment = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_ALIGNMENT,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory32.Alignment));
             AlignOp = InitializerOp;
@@ -406,7 +418,8 @@ RsDoMemory32Descriptor (
 
         case 4: /* Length */
 
-            Descriptor->Memory32.AddressLength = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Memory32.AddressLength = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Memory32.AddressLength));
             LengthOp = InitializerOp;
@@ -429,10 +442,10 @@ RsDoMemory32Descriptor (
     /* Validate the Min/Max/Len/Align values */
 
     RsSmallAddressCheck (ACPI_RESOURCE_NAME_MEMORY32,
-        Descriptor->Memory32.Minimum,
-        Descriptor->Memory32.Maximum,
-        Descriptor->Memory32.AddressLength,
-        Descriptor->Memory32.Alignment,
+        AcpiUtReadUint32 (&Descriptor->Memory32.Minimum),
+        AcpiUtReadUint32 (&Descriptor->Memory32.Maximum),
+        AcpiUtReadUint32 (&Descriptor->Memory32.AddressLength),
+        AcpiUtReadUint32 (&Descriptor->Memory32.Alignment),
         MinOp, MaxOp, LengthOp, AlignOp, Info->DescriptorTypeOp);
 
     return (Rnode);
@@ -460,6 +473,8 @@ RsDoMemory32FixedDescriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -468,7 +483,8 @@ RsDoMemory32FixedDescriptor (
 
     Descriptor = Rnode->Buffer;
     Descriptor->FixedMemory32.DescriptorType = ACPI_RESOURCE_NAME_FIXED_MEMORY32;
-    Descriptor->FixedMemory32.ResourceLength = 9;
+    Tmp16 = 9;
+    Descriptor->FixedMemory32.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     /* Process all child initialization nodes */
 
@@ -485,14 +501,16 @@ RsDoMemory32FixedDescriptor (
 
         case 1: /* Address */
 
-            Descriptor->FixedMemory32.Address = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->FixedMemory32.Address = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_BASEADDRESS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (FixedMemory32.Address));
             break;
 
         case 2: /* Length */
 
-            Descriptor->FixedMemory32.AddressLength = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->FixedMemory32.AddressLength = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (FixedMemory32.AddressLength));
             break;

--- a/source/compiler/aslrestype1i.c
+++ b/source/compiler/aslrestype1i.c
@@ -307,6 +307,7 @@ RsDoFixedDmaDescriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -325,14 +326,16 @@ RsDoFixedDmaDescriptor (
         {
         case 0: /* DMA Request Lines [WORD] (_DMA) */
 
-            Descriptor->FixedDma.RequestLines = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->FixedDma.RequestLines = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_DMA,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (FixedDma.RequestLines));
             break;
 
         case 1: /* DMA Channel [WORD] (_TYP) */
 
-            Descriptor->FixedDma.Channels = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->FixedDma.Channels = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_DMATYPE,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (FixedDma.Channels));
             break;
@@ -383,6 +386,7 @@ RsDoFixedIoDescriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -401,8 +405,8 @@ RsDoFixedIoDescriptor (
         {
         case 0: /* Base Address */
 
-            Descriptor->FixedIo.Address =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->FixedIo.Address = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_BASEADDRESS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (FixedIo.Address));
             AddressOp = InitializerOp;
@@ -432,7 +436,7 @@ RsDoFixedIoDescriptor (
 
     /* Error checks */
 
-    if (Descriptor->FixedIo.Address > 0x03FF)
+    if (AcpiUtReadUint16 (&Descriptor->FixedIo.Address) > 0x03FF)
     {
         AslError (ASL_WARNING, ASL_MSG_ISA_ADDRESS, AddressOp, NULL);
     }
@@ -466,6 +470,7 @@ RsDoIoDescriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -491,8 +496,8 @@ RsDoIoDescriptor (
 
         case 1:  /* Min Address */
 
-            Descriptor->Io.Minimum =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Io.Minimum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Io.Minimum));
             MinOp = InitializerOp;
@@ -500,8 +505,8 @@ RsDoIoDescriptor (
 
         case 2: /* Max Address */
 
-            Descriptor->Io.Maximum =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Io.Maximum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Io.Maximum));
             MaxOp = InitializerOp;
@@ -542,10 +547,10 @@ RsDoIoDescriptor (
     /* Validate the Min/Max/Len/Align values */
 
     RsSmallAddressCheck (ACPI_RESOURCE_NAME_IO,
-        Descriptor->Io.Minimum,
-        Descriptor->Io.Maximum,
-        Descriptor->Io.AddressLength,
-        Descriptor->Io.Alignment,
+        (UINT32) (AcpiUtReadUint16 (&Descriptor->Io.Minimum)),
+        (UINT32) (AcpiUtReadUint16 (&Descriptor->Io.Maximum)),
+        (UINT32) Descriptor->Io.AddressLength,
+        (UINT32) Descriptor->Io.Alignment,
         MinOp, MaxOp, LengthOp, AlignOp, Info->DescriptorTypeOp);
 
     return (Rnode);
@@ -669,7 +674,7 @@ RsDoIrqDescriptor (
 
     /* Now we can set the channel mask */
 
-    Descriptor->Irq.IrqMask = IrqMask;
+    Descriptor->Irq.IrqMask = AcpiUtReadUint16 (&IrqMask);
     return (Rnode);
 }
 
@@ -768,6 +773,6 @@ RsDoIrqNoFlagsDescriptor (
 
     /* Now we can set the interrupt mask */
 
-    Descriptor->Irq.IrqMask = IrqMask;
+    Descriptor->Irq.IrqMask = AcpiUtReadUint16(&IrqMask);
     return (Rnode);
 }

--- a/source/compiler/aslrestype2.c
+++ b/source/compiler/aslrestype2.c
@@ -185,6 +185,8 @@ RsDoGeneralRegisterDescriptor (
     ASL_RESOURCE_NODE       *Rnode;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT64                  Tmp64;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -193,7 +195,8 @@ RsDoGeneralRegisterDescriptor (
 
     Descriptor = Rnode->Buffer;
     Descriptor->GenericReg.DescriptorType = ACPI_RESOURCE_NAME_GENERIC_REGISTER;
-    Descriptor->GenericReg.ResourceLength = 12;
+    Tmp16 = 12;
+    Descriptor->GenericReg.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     /* Process all child initialization nodes */
 
@@ -224,7 +227,8 @@ RsDoGeneralRegisterDescriptor (
 
         case 3: /* Register Address */
 
-            Descriptor->GenericReg.Address = InitializerOp->Asl.Value.Integer;
+            Tmp64 = InitializerOp->Asl.Value.Integer;
+            Descriptor->GenericReg.Address = AcpiUtReadUint64 (&Tmp64);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_ADDRESS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (GenericReg.Address));
             break;
@@ -292,6 +296,8 @@ RsDoInterruptDescriptor (
     BOOLEAN                 HasResSourceIndex = FALSE;
     UINT8                   ResSourceIndex = 0;
     UINT8                   *ResSourceString = NULL;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -333,7 +339,7 @@ RsDoInterruptDescriptor (
      * Initial descriptor length -- may be enlarged if there are
      * optional fields present
      */
-    Descriptor->ExtendedIrq.ResourceLength  = 2;  /* Flags and table length byte */
+    Descriptor->ExtendedIrq.ResourceLength  = 2; /* Flags and table length byte */
     Descriptor->ExtendedIrq.InterruptCount  = 0;
 
     Rover = ACPI_CAST_PTR (AML_RESOURCE,
@@ -441,7 +447,8 @@ RsDoInterruptDescriptor (
 
             /* Save the integer and move pointer to the next one */
 
-            Rover->DwordItem = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Rover->DwordItem = AcpiUtReadUint32 (&Tmp32);
             Rover = ACPI_ADD_PTR (AML_RESOURCE, &(Rover->DwordItem), 4);
             Descriptor->ExtendedIrq.InterruptCount++;
             Descriptor->ExtendedIrq.ResourceLength += 4;
@@ -492,6 +499,8 @@ RsDoInterruptDescriptor (
         Descriptor->ExtendedIrq.ResourceLength = (UINT16)
             (Descriptor->ExtendedIrq.ResourceLength + StringLength);
     }
+    Tmp16 = Descriptor->ExtendedIrq.ResourceLength;
+    Descriptor->ExtendedIrq.ResourceLength  = AcpiUtReadUint16 (&Tmp16);
 
     Rnode->BufferLength =
         (ASL_RESDESC_OFFSET (ExtendedIrq.Interrupts[0]) -
@@ -544,7 +553,8 @@ RsDoVendorLargeDescriptor (
 
     Descriptor = Rnode->Buffer;
     Descriptor->VendorLarge.DescriptorType = ACPI_RESOURCE_NAME_VENDOR_LARGE;
-    Descriptor->VendorLarge.ResourceLength = (UINT16) i;
+    AcpiUtWriteUint (&Descriptor->VendorLarge.ResourceLength, sizeof (UINT16),
+            &i, sizeof (UINT32));
 
     /* Point to end-of-descriptor for vendor data */
 

--- a/source/compiler/aslrestype2d.c
+++ b/source/compiler/aslrestype2d.c
@@ -192,6 +192,8 @@ RsDoDwordIoDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -255,8 +257,8 @@ RsDoDwordIoDescriptor (
 
         case 5: /* Address Granularity */
 
-            Descriptor->Address32.Granularity =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Granularity = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Granularity));
             GranOp = InitializerOp;
@@ -264,8 +266,8 @@ RsDoDwordIoDescriptor (
 
         case 6: /* Address Min */
 
-            Descriptor->Address32.Minimum =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Minimum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Minimum));
             MinOp = InitializerOp;
@@ -273,8 +275,8 @@ RsDoDwordIoDescriptor (
 
         case 7: /* Address Max */
 
-            Descriptor->Address32.Maximum =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Maximum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Maximum));
             MaxOp = InitializerOp;
@@ -282,16 +284,16 @@ RsDoDwordIoDescriptor (
 
         case 8: /* Translation Offset */
 
-            Descriptor->Address32.TranslationOffset =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.TranslationOffset = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.TranslationOffset));
             break;
 
         case 9: /* Address Length */
 
-            Descriptor->Address32.AddressLength =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.AddressLength = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.AddressLength));
             LengthOp = InitializerOp;
@@ -379,11 +381,14 @@ RsDoDwordIoDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->Address32.ResourceLength;
+    Descriptor->Address32.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        (UINT64) Descriptor->Address32.Minimum,
-        (UINT64) Descriptor->Address32.Maximum,
-        (UINT64) Descriptor->Address32.AddressLength,
-        (UINT64) Descriptor->Address32.Granularity,
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Minimum),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Maximum),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.AddressLength),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Granularity),
         Descriptor->Address32.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 
@@ -422,6 +427,8 @@ RsDoDwordMemoryDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -493,8 +500,8 @@ RsDoDwordMemoryDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->Address32.Granularity =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Granularity = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Granularity));
             GranOp = InitializerOp;
@@ -502,8 +509,8 @@ RsDoDwordMemoryDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->Address32.Minimum =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Minimum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Minimum));
             MinOp = InitializerOp;
@@ -511,8 +518,8 @@ RsDoDwordMemoryDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->Address32.Maximum =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Maximum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Maximum));
             MaxOp = InitializerOp;
@@ -520,16 +527,16 @@ RsDoDwordMemoryDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->Address32.TranslationOffset =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.TranslationOffset = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->Address32.AddressLength =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.AddressLength = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.AddressLength));
             LengthOp = InitializerOp;
@@ -614,11 +621,14 @@ RsDoDwordMemoryDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->Address32.ResourceLength;
+    Descriptor->Address32.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        (UINT64) Descriptor->Address32.Minimum,
-        (UINT64) Descriptor->Address32.Maximum,
-        (UINT64) Descriptor->Address32.AddressLength,
-        (UINT64) Descriptor->Address32.Granularity,
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Minimum),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Maximum),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.AddressLength),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Granularity),
         Descriptor->Address32.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 
@@ -657,6 +667,8 @@ RsDoDwordSpaceDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -724,8 +736,8 @@ RsDoDwordSpaceDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->Address32.Granularity =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Granularity = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Granularity));
             GranOp = InitializerOp;
@@ -733,8 +745,8 @@ RsDoDwordSpaceDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->Address32.Minimum =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Minimum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Minimum));
             MinOp = InitializerOp;
@@ -742,8 +754,8 @@ RsDoDwordSpaceDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->Address32.Maximum =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Maximum = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.Maximum));
             MaxOp = InitializerOp;
@@ -751,16 +763,16 @@ RsDoDwordSpaceDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->Address32.TranslationOffset =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.TranslationOffset = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->Address32.AddressLength =
-                (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.AddressLength = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address32.AddressLength));
             LengthOp = InitializerOp;
@@ -831,11 +843,14 @@ RsDoDwordSpaceDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->Address32.ResourceLength;
+    Descriptor->Address32.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        (UINT64) Descriptor->Address32.Minimum,
-        (UINT64) Descriptor->Address32.Maximum,
-        (UINT64) Descriptor->Address32.AddressLength,
-        (UINT64) Descriptor->Address32.Granularity,
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Minimum),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Maximum),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.AddressLength),
+        (UINT64) AcpiUtReadUint32 (&Descriptor->Address32.Granularity),
         Descriptor->Address32.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 

--- a/source/compiler/aslrestype2e.c
+++ b/source/compiler/aslrestype2e.c
@@ -188,6 +188,7 @@ RsDoExtendedIoDescriptor (
     UINT16                  StringLength = 0;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -247,7 +248,8 @@ RsDoExtendedIoDescriptor (
 
         case 5: /* Address Granularity */
 
-            Descriptor->ExtAddress64.Granularity = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Granularity =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Granularity));
             GranOp = InitializerOp;
@@ -255,7 +257,8 @@ RsDoExtendedIoDescriptor (
 
         case 6: /* Address Min */
 
-            Descriptor->ExtAddress64.Minimum = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Minimum =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Minimum));
             MinOp = InitializerOp;
@@ -263,7 +266,8 @@ RsDoExtendedIoDescriptor (
 
         case 7: /* Address Max */
 
-            Descriptor->ExtAddress64.Maximum = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Maximum =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Maximum));
             MaxOp = InitializerOp;
@@ -271,14 +275,16 @@ RsDoExtendedIoDescriptor (
 
         case 8: /* Translation Offset */
 
-            Descriptor->ExtAddress64.TranslationOffset = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.TranslationOffset =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.TranslationOffset));
             break;
 
         case 9: /* Address Length */
 
-            Descriptor->ExtAddress64.AddressLength = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.AddressLength =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.AddressLength));
             LengthOp = InitializerOp;
@@ -286,7 +292,8 @@ RsDoExtendedIoDescriptor (
 
         case 10: /* Type-Specific Attributes */
 
-            Descriptor->ExtAddress64.TypeSpecific = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.TypeSpecific =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TYPESPECIFICATTRIBUTES,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.TypeSpecific));
             break;
@@ -321,11 +328,14 @@ RsDoExtendedIoDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->ExtAddress64.ResourceLength;
+    Descriptor->ExtAddress64.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        Descriptor->ExtAddress64.Minimum,
-        Descriptor->ExtAddress64.Maximum,
-        Descriptor->ExtAddress64.AddressLength,
-        Descriptor->ExtAddress64.Granularity,
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Minimum),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Maximum),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.AddressLength),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Granularity),
         Descriptor->ExtAddress64.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 
@@ -361,6 +371,7 @@ RsDoExtendedMemoryDescriptor (
     UINT16                  StringLength = 0;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -427,7 +438,8 @@ RsDoExtendedMemoryDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->ExtAddress64.Granularity = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Granularity =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Granularity));
             GranOp = InitializerOp;
@@ -435,7 +447,8 @@ RsDoExtendedMemoryDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->ExtAddress64.Minimum = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Minimum =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Minimum));
             MinOp = InitializerOp;
@@ -443,7 +456,8 @@ RsDoExtendedMemoryDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->ExtAddress64.Maximum = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Maximum =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Maximum));
             MaxOp = InitializerOp;
@@ -451,14 +465,16 @@ RsDoExtendedMemoryDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->ExtAddress64.TranslationOffset = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.TranslationOffset =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->ExtAddress64.AddressLength = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.AddressLength =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.AddressLength));
             LengthOp = InitializerOp;
@@ -466,7 +482,8 @@ RsDoExtendedMemoryDescriptor (
 
         case 11: /* Type-Specific Attributes */
 
-            Descriptor->ExtAddress64.TypeSpecific = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.TypeSpecific =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TYPESPECIFICATTRIBUTES,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.TypeSpecific));
             break;
@@ -502,11 +519,14 @@ RsDoExtendedMemoryDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->ExtAddress64.ResourceLength;
+    Descriptor->ExtAddress64.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        Descriptor->ExtAddress64.Minimum,
-        Descriptor->ExtAddress64.Maximum,
-        Descriptor->ExtAddress64.AddressLength,
-        Descriptor->ExtAddress64.Granularity,
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Minimum),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Maximum),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.AddressLength),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Granularity),
         Descriptor->ExtAddress64.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 
@@ -542,6 +562,7 @@ RsDoExtendedSpaceDescriptor (
     UINT16                  StringLength = 0;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -605,7 +626,8 @@ RsDoExtendedSpaceDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->ExtAddress64.Granularity = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Granularity =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Granularity));
             GranOp = InitializerOp;
@@ -613,7 +635,8 @@ RsDoExtendedSpaceDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->ExtAddress64.Minimum = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Minimum =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Minimum));
             MinOp = InitializerOp;
@@ -621,7 +644,8 @@ RsDoExtendedSpaceDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->ExtAddress64.Maximum = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.Maximum =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.Maximum));
             MaxOp = InitializerOp;
@@ -629,14 +653,16 @@ RsDoExtendedSpaceDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->ExtAddress64.TranslationOffset = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.TranslationOffset =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->ExtAddress64.AddressLength = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.AddressLength =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.AddressLength));
             LengthOp = InitializerOp;
@@ -644,7 +670,8 @@ RsDoExtendedSpaceDescriptor (
 
         case 11: /* Type-Specific Attributes */
 
-            Descriptor->ExtAddress64.TypeSpecific = InitializerOp->Asl.Value.Integer;
+            Descriptor->ExtAddress64.TypeSpecific =
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TYPESPECIFICATTRIBUTES,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (ExtAddress64.TypeSpecific));
             break;
@@ -665,11 +692,14 @@ RsDoExtendedSpaceDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->ExtAddress64.ResourceLength;
+    Descriptor->ExtAddress64.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        Descriptor->ExtAddress64.Minimum,
-        Descriptor->ExtAddress64.Maximum,
-        Descriptor->ExtAddress64.AddressLength,
-        Descriptor->ExtAddress64.Granularity,
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Minimum),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Maximum),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.AddressLength),
+        AcpiUtReadUint64 (&Descriptor->ExtAddress64.Granularity),
         Descriptor->ExtAddress64.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 

--- a/source/compiler/aslrestype2q.c
+++ b/source/compiler/aslrestype2q.c
@@ -192,6 +192,7 @@ RsDoQwordIoDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -255,7 +256,8 @@ RsDoQwordIoDescriptor (
 
         case 5: /* Address Granularity */
 
-            Descriptor->Address64.Granularity = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Granularity = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Granularity));
             GranOp = InitializerOp;
@@ -263,7 +265,8 @@ RsDoQwordIoDescriptor (
 
         case 6: /* Address Min */
 
-            Descriptor->Address64.Minimum = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Minimum = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Minimum));
             MinOp = InitializerOp;
@@ -271,7 +274,8 @@ RsDoQwordIoDescriptor (
 
         case 7: /* Address Max */
 
-            Descriptor->Address64.Maximum = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Maximum = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Maximum));
             MaxOp = InitializerOp;
@@ -279,14 +283,16 @@ RsDoQwordIoDescriptor (
 
         case 8: /* Translation Offset */
 
-            Descriptor->Address64.TranslationOffset = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.TranslationOffset = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateByteField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.TranslationOffset));
             break;
 
         case 9: /* Address Length */
 
-            Descriptor->Address64.AddressLength = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.AddressLength = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.AddressLength));
             LengthOp = InitializerOp;
@@ -370,11 +376,14 @@ RsDoQwordIoDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->Address64.ResourceLength;
+    Descriptor->Address64.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        Descriptor->Address64.Minimum,
-        Descriptor->Address64.Maximum,
-        Descriptor->Address64.AddressLength,
-        Descriptor->Address64.Granularity,
+        AcpiUtReadUint64 (&Descriptor->Address64.Minimum),
+        AcpiUtReadUint64 (&Descriptor->Address64.Maximum),
+        AcpiUtReadUint64 (&Descriptor->Address64.AddressLength),
+        AcpiUtReadUint64 (&Descriptor->Address64.Granularity),
         Descriptor->Address64.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 
@@ -413,6 +422,7 @@ RsDoQwordMemoryDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -483,7 +493,8 @@ RsDoQwordMemoryDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->Address64.Granularity = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Granularity = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Granularity));
             GranOp = InitializerOp;
@@ -491,7 +502,8 @@ RsDoQwordMemoryDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->Address64.Minimum = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Minimum = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Minimum));
             MinOp = InitializerOp;
@@ -499,7 +511,8 @@ RsDoQwordMemoryDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->Address64.Maximum = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Maximum = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Maximum));
             MaxOp = InitializerOp;
@@ -507,14 +520,16 @@ RsDoQwordMemoryDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->Address64.TranslationOffset = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.TranslationOffset = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->Address64.AddressLength = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.AddressLength = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.AddressLength));
             LengthOp = InitializerOp;
@@ -599,11 +614,14 @@ RsDoQwordMemoryDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->Address64.ResourceLength;
+    Descriptor->Address64.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        Descriptor->Address64.Minimum,
-        Descriptor->Address64.Maximum,
-        Descriptor->Address64.AddressLength,
-        Descriptor->Address64.Granularity,
+        AcpiUtReadUint64 (&Descriptor->Address64.Minimum),
+        AcpiUtReadUint64 (&Descriptor->Address64.Maximum),
+        AcpiUtReadUint64 (&Descriptor->Address64.AddressLength),
+        AcpiUtReadUint64 (&Descriptor->Address64.Granularity),
         Descriptor->Address64.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 
@@ -642,6 +660,7 @@ RsDoQwordSpaceDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -709,7 +728,8 @@ RsDoQwordSpaceDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->Address64.Granularity = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Granularity = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Granularity));
             GranOp = InitializerOp;
@@ -717,7 +737,8 @@ RsDoQwordSpaceDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->Address64.Minimum = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Minimum = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Minimum));
             MinOp = InitializerOp;
@@ -725,7 +746,8 @@ RsDoQwordSpaceDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->Address64.Maximum = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.Maximum = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.Maximum));
             MaxOp = InitializerOp;
@@ -733,14 +755,16 @@ RsDoQwordSpaceDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->Address64.TranslationOffset = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.TranslationOffset = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->Address64.AddressLength = InitializerOp->Asl.Value.Integer;
+            Descriptor->Address64.AddressLength = 
+                AcpiUtReadUint64 (&InitializerOp->Asl.Value.Integer);
             RsCreateQwordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address64.AddressLength));
             LengthOp = InitializerOp;
@@ -810,11 +834,14 @@ RsDoQwordSpaceDescriptor (
 
     /* Validate the Min/Max/Len/Gran values */
 
+    Tmp16 = Descriptor->Address64.ResourceLength;
+    Descriptor->Address64.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+
     RsLargeAddressCheck (
-        Descriptor->Address64.Minimum,
-        Descriptor->Address64.Maximum,
-        Descriptor->Address64.AddressLength,
-        Descriptor->Address64.Granularity,
+        AcpiUtReadUint64 (&Descriptor->Address64.Minimum),
+        AcpiUtReadUint64 (&Descriptor->Address64.Maximum),
+        AcpiUtReadUint64 (&Descriptor->Address64.AddressLength),
+        AcpiUtReadUint64 (&Descriptor->Address64.Granularity),
         Descriptor->Address64.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
 

--- a/source/compiler/aslrestype2s.c
+++ b/source/compiler/aslrestype2s.c
@@ -451,6 +451,7 @@ RsDoGpioIntDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  PinCount = 0;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -593,7 +594,8 @@ RsDoGpioIntDescriptor (
              *  (implies resource source must immediately follow the pin list.)
              *  Name: _PIN
              */
-            *InterruptList = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            *InterruptList = AcpiUtReadUint16 (&Tmp16);
             InterruptList++;
             PinCount++;
 
@@ -626,6 +628,27 @@ RsDoGpioIntDescriptor (
 
     MpSaveGpioInfo (Info->MappingOp, Descriptor,
         PinCount, PinList, ResourceSource);
+
+    /* correct endian-ness issues */
+    Tmp16 = Descriptor->Gpio.ResourceLength;
+    Descriptor->Gpio.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.Flags;
+    Descriptor->Gpio.Flags = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.IntFlags;
+    Descriptor->Gpio.IntFlags = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.DriveStrength;
+    Descriptor->Gpio.DriveStrength = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.DebounceTimeout;
+    Descriptor->Gpio.DebounceTimeout = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.PinTableOffset;
+    Descriptor->Gpio.PinTableOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.ResSourceOffset;
+    Descriptor->Gpio.ResSourceOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.VendorOffset;
+    Descriptor->Gpio.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.VendorLength;
+    Descriptor->Gpio.VendorLength = AcpiUtReadUint16 (&Tmp16);
+
     return (Rnode);
 }
 
@@ -660,6 +683,7 @@ RsDoGpioIoDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  PinCount = 0;
     UINT32                  i;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -799,7 +823,8 @@ RsDoGpioIoDescriptor (
              *  (implies resource source must immediately follow the pin list.)
              *  Name: _PIN
              */
-            *InterruptList = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            *InterruptList = AcpiUtReadUint16 (&Tmp16);
             InterruptList++;
             PinCount++;
 
@@ -832,6 +857,27 @@ RsDoGpioIoDescriptor (
 
     MpSaveGpioInfo (Info->MappingOp, Descriptor,
         PinCount, PinList, ResourceSource);
+
+    /* correct endian-ness issues */
+    Tmp16 = Descriptor->Gpio.ResourceLength;
+    Descriptor->Gpio.ResourceLength = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.Flags;
+    Descriptor->Gpio.Flags = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.IntFlags;
+    Descriptor->Gpio.IntFlags = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.DriveStrength;
+    Descriptor->Gpio.DriveStrength = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.DebounceTimeout;
+    Descriptor->Gpio.DebounceTimeout = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.PinTableOffset;
+    Descriptor->Gpio.PinTableOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.ResSourceOffset;
+    Descriptor->Gpio.ResSourceOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.VendorOffset;
+    Descriptor->Gpio.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->Gpio.VendorLength;
+    Descriptor->Gpio.VendorLength = AcpiUtReadUint16 (&Tmp16);
+
     return (Rnode);
 }
 
@@ -862,6 +908,8 @@ RsDoI2cSerialBusDescriptor (
     UINT16                  DescriptorSize;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -889,7 +937,8 @@ RsDoI2cSerialBusDescriptor (
     Descriptor->I2cSerialBus.RevisionId = AML_RESOURCE_I2C_REVISION;
     Descriptor->I2cSerialBus.TypeRevisionId = AML_RESOURCE_I2C_TYPE_REVISION;
     Descriptor->I2cSerialBus.Type = AML_RESOURCE_I2C_SERIALBUSTYPE;
-    Descriptor->I2cSerialBus.TypeDataLength = AML_RESOURCE_I2C_MIN_DATA_LEN + VendorLength;
+    Tmp16 = AML_RESOURCE_I2C_MIN_DATA_LEN + VendorLength;
+    Descriptor->I2cSerialBus.TypeDataLength = AcpiUtReadUint16 (&Tmp16);
 
     if (Info->DescriptorTypeOp->Asl.ParseOpcode == PARSEOP_I2C_SERIALBUS_V2)
     {
@@ -903,13 +952,15 @@ RsDoI2cSerialBusDescriptor (
 
     /* Process all child initialization nodes */
 
+    Descriptor->I2cSerialBus.TypeSpecificFlags = 0;
     for (i = 0; InitializerOp; i++)
     {
         switch (i)
         {
         case 0: /* Slave Address [WORD] (_ADR) */
 
-            Descriptor->I2cSerialBus.SlaveAddress = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->I2cSerialBus.SlaveAddress = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_ADDRESS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (I2cSerialBus.SlaveAddress));
             break;
@@ -923,16 +974,19 @@ RsDoI2cSerialBusDescriptor (
 
         case 2: /* Connection Speed [DWORD] (_SPE) */
 
-            Descriptor->I2cSerialBus.ConnectionSpeed = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->I2cSerialBus.ConnectionSpeed = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_SPEED,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (I2cSerialBus.ConnectionSpeed));
             break;
 
         case 3: /* Addressing Mode [Flag] (_MOD) */
 
-            RsSetFlagBits16 (&Descriptor->I2cSerialBus.TypeSpecificFlags, InitializerOp, 0, 0);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->I2cSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 0, 0);
             RsCreateBitField (InitializerOp, ACPI_RESTAG_MODE,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (I2cSerialBus.TypeSpecificFlags), 0);
+            Descriptor->I2cSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);
             break;
 
         case 4: /* ResSource [Optional Field - STRING] */
@@ -990,6 +1044,8 @@ RsDoI2cSerialBusDescriptor (
         InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
     }
 
+    Tmp16 = Descriptor->I2cSerialBus.ResourceLength;
+    Descriptor->I2cSerialBus.ResourceLength = AcpiUtReadUint16 (&Tmp16);
     MpSaveSerialInfo (Info->MappingOp, Descriptor, ResourceSource);
     return (Rnode);
 }
@@ -1021,6 +1077,8 @@ RsDoSpiSerialBusDescriptor (
     UINT16                  DescriptorSize;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -1043,12 +1101,13 @@ RsDoSpiSerialBusDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->SpiSerialBus.ResourceLength = DescriptorSize;
+    Descriptor->SpiSerialBus.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->SpiSerialBus.DescriptorType = ACPI_RESOURCE_NAME_SERIAL_BUS;
     Descriptor->SpiSerialBus.RevisionId = AML_RESOURCE_SPI_REVISION;
     Descriptor->SpiSerialBus.TypeRevisionId = AML_RESOURCE_SPI_TYPE_REVISION;
     Descriptor->SpiSerialBus.Type = AML_RESOURCE_SPI_SERIALBUSTYPE;
-    Descriptor->SpiSerialBus.TypeDataLength = AML_RESOURCE_SPI_MIN_DATA_LEN + VendorLength;
+    Tmp16 = AML_RESOURCE_SPI_MIN_DATA_LEN + VendorLength;
+    Descriptor->SpiSerialBus.TypeDataLength = AcpiUtReadUint16 (&Tmp16);
 
     if (Info->DescriptorTypeOp->Asl.ParseOpcode == PARSEOP_SPI_SERIALBUS_V2)
     {
@@ -1063,29 +1122,35 @@ RsDoSpiSerialBusDescriptor (
 
     /* Process all child initialization nodes */
 
+    Descriptor->SpiSerialBus.TypeSpecificFlags = 0;
     for (i = 0; InitializerOp; i++)
     {
         switch (i)
         {
         case 0: /* Device Selection [WORD] (_ADR) */
 
-            Descriptor->SpiSerialBus.DeviceSelection = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->SpiSerialBus.DeviceSelection = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_ADDRESS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (SpiSerialBus.DeviceSelection));
             break;
 
         case 1: /* Device Polarity [Flag] (_DPL) */
 
-            RsSetFlagBits16 (&Descriptor->SpiSerialBus.TypeSpecificFlags, InitializerOp, 1, 0);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->SpiSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 1, 0);
             RsCreateBitField (InitializerOp, ACPI_RESTAG_DEVICEPOLARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (SpiSerialBus.TypeSpecificFlags), 1);
+            Descriptor->SpiSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);
             break;
 
         case 2: /* Wire Mode [Flag] (_MOD) */
 
-            RsSetFlagBits16 (&Descriptor->SpiSerialBus.TypeSpecificFlags, InitializerOp, 0, 0);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->SpiSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 0, 0);
             RsCreateBitField (InitializerOp, ACPI_RESTAG_MODE,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (SpiSerialBus.TypeSpecificFlags), 0);
+            Descriptor->SpiSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);
             break;
 
         case 3: /* Device Bit Length [BYTE] (_LEN) */
@@ -1104,7 +1169,8 @@ RsDoSpiSerialBusDescriptor (
 
         case 5: /* Connection Speed [DWORD] (_SPE) */
 
-            Descriptor->SpiSerialBus.ConnectionSpeed = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->SpiSerialBus.ConnectionSpeed = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_SPEED,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (SpiSerialBus.ConnectionSpeed));
             break;
@@ -1209,6 +1275,8 @@ RsDoUartSerialBusDescriptor (
     UINT16                  DescriptorSize;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -1231,12 +1299,13 @@ RsDoUartSerialBusDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->UartSerialBus.ResourceLength = DescriptorSize;
+    Descriptor->UartSerialBus.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->UartSerialBus.DescriptorType = ACPI_RESOURCE_NAME_SERIAL_BUS;
     Descriptor->UartSerialBus.RevisionId = AML_RESOURCE_UART_REVISION;
     Descriptor->UartSerialBus.TypeRevisionId = AML_RESOURCE_UART_TYPE_REVISION;
     Descriptor->UartSerialBus.Type = AML_RESOURCE_UART_SERIALBUSTYPE;
-    Descriptor->UartSerialBus.TypeDataLength = AML_RESOURCE_UART_MIN_DATA_LEN + VendorLength;
+    Tmp16 = AML_RESOURCE_UART_MIN_DATA_LEN + VendorLength;
+    Descriptor->UartSerialBus.TypeDataLength = AcpiUtReadUint16 (&Tmp16);
 
     if (Info->DescriptorTypeOp->Asl.ParseOpcode == PARSEOP_UART_SERIALBUS_V2)
     {
@@ -1250,29 +1319,35 @@ RsDoUartSerialBusDescriptor (
 
     /* Process all child initialization nodes */
 
+    Descriptor->UartSerialBus.TypeSpecificFlags = 0;
     for (i = 0; InitializerOp; i++)
     {
         switch (i)
         {
         case 0: /* Connection Speed (Baud Rate) [DWORD] (_SPE) */
 
-            Descriptor->UartSerialBus.DefaultBaudRate = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->UartSerialBus.DefaultBaudRate = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_SPEED,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.DefaultBaudRate));
             break;
 
         case 1: /* Bits Per Byte [Flags] (_LEN) */
 
-            RsSetFlagBits16 (&Descriptor->UartSerialBus.TypeSpecificFlags, InitializerOp, 4, 3);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->UartSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 4, 3);
             RsCreateMultiBitField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.TypeSpecificFlags), 4, 3);
+            Descriptor->UartSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);;
             break;
 
         case 2: /* Stop Bits [Flags] (_STB) */
 
-            RsSetFlagBits16 (&Descriptor->UartSerialBus.TypeSpecificFlags, InitializerOp, 2, 1);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->UartSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 2, 1);
             RsCreateMultiBitField (InitializerOp, ACPI_RESTAG_STOPBITS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.TypeSpecificFlags), 2, 2);
+            Descriptor->UartSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);;
             break;
 
         case 3: /* Lines In Use [BYTE] (_LIN) */
@@ -1284,9 +1359,11 @@ RsDoUartSerialBusDescriptor (
 
         case 4: /* Endianness [Flag] (_END) */
 
-            RsSetFlagBits16 (&Descriptor->UartSerialBus.TypeSpecificFlags, InitializerOp, 7, 0);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->UartSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 7, 0);
             RsCreateBitField (InitializerOp, ACPI_RESTAG_ENDIANNESS,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.TypeSpecificFlags), 7);
+            Descriptor->UartSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);;
             break;
 
         case 5: /* Parity [BYTE] (_PAR) */
@@ -1298,21 +1375,25 @@ RsDoUartSerialBusDescriptor (
 
         case 6: /* Flow Control [Flags] (_FLC) */
 
-            RsSetFlagBits16 (&Descriptor->UartSerialBus.TypeSpecificFlags, InitializerOp, 0, 0);
+            Tmp16 = AcpiUtReadUint16 (&Descriptor->UartSerialBus.TypeSpecificFlags);
+            RsSetFlagBits16 (&Tmp16, InitializerOp, 0, 0);
             RsCreateMultiBitField (InitializerOp, ACPI_RESTAG_FLOWCONTROL,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.TypeSpecificFlags), 0, 2);
+            Descriptor->UartSerialBus.TypeSpecificFlags = AcpiUtReadUint16 (&Tmp16);;
             break;
 
         case 7: /* Rx Buffer Size [WORD] (_RXL) */
 
-            Descriptor->UartSerialBus.RxFifoSize = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->UartSerialBus.RxFifoSize = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_LENGTH_RX,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.RxFifoSize));
             break;
 
         case 8: /* Tx Buffer Size [WORD] (_TXL) */
 
-            Descriptor->UartSerialBus.TxFifoSize = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->UartSerialBus.TxFifoSize = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_LENGTH_TX,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (UartSerialBus.TxFifoSize));
             break;
@@ -1552,6 +1633,7 @@ RsDoPinFunctionDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  PinCount = 0;
     UINT32                  i;
+    UINT16                  Tmp16;
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
     CurrentByteOffset = Info->CurrentByteOffset;
@@ -1575,7 +1657,7 @@ RsDoPinFunctionDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->PinFunction.ResourceLength = DescriptorSize;
+    Descriptor->PinFunction.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->PinFunction.DescriptorType = ACPI_RESOURCE_NAME_PIN_FUNCTION;
     Descriptor->PinFunction.RevisionId = AML_RESOURCE_PIN_FUNCTION_REVISION;
 
@@ -1615,7 +1697,8 @@ RsDoPinFunctionDescriptor (
 
         case 2: /* Function Number [WORD] (_FUN) */
 
-            Descriptor->PinFunction.FunctionNumber = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->PinFunction.FunctionNumber = AcpiUtReadUint16 (&Tmp16);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_FUNCTION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (PinFunction.FunctionNumber));
             break;
@@ -1663,6 +1746,12 @@ RsDoPinFunctionDescriptor (
             {
                 Descriptor->PinFunction.VendorLength = VendorLength;
             }
+            Tmp16 = (UINT16) ACPI_PTR_DIFF (VendorData, Descriptor);
+            Descriptor->PinFunction.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+            
+            Tmp16 = Descriptor->PinFunction.VendorLength;
+            Descriptor->PinFunction.VendorLength = AcpiUtReadUint16 (&Tmp16);
+
             break;
 
         default:
@@ -1674,7 +1763,8 @@ RsDoPinFunctionDescriptor (
              *  (implies resource source must immediately follow the pin list.)
              *  Name: _PIN
              */
-            *PinList = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            *PinList = AcpiUtReadUint16 (&Tmp16);
             PinList++;
             PinCount++;
 
@@ -1704,6 +1794,13 @@ RsDoPinFunctionDescriptor (
 
         InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
     }
+
+    /* correct the endian-ness of the values */
+    Tmp16 = Descriptor->PinFunction.PinTableOffset;
+    Descriptor->PinFunction.PinTableOffset = AcpiUtReadUint16 (&Tmp16);
+
+    Tmp16 = Descriptor->PinFunction.ResSourceOffset;
+    Descriptor->PinFunction.ResSourceOffset = AcpiUtReadUint16 (&Tmp16);
 
     return (Rnode);
 }
@@ -1738,6 +1835,8 @@ RsDoPinConfigDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  PinCount = 0;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
     CurrentByteOffset = Info->CurrentByteOffset;
@@ -1761,7 +1860,7 @@ RsDoPinConfigDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->PinConfig.ResourceLength = DescriptorSize;
+    Descriptor->PinConfig.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->PinConfig.DescriptorType = ACPI_RESOURCE_NAME_PIN_CONFIG;
     Descriptor->PinConfig.RevisionId = AML_RESOURCE_PIN_CONFIG_REVISION;
 
@@ -1815,7 +1914,8 @@ RsDoPinConfigDescriptor (
 
         case 2: /* Pin Config Value [DWORD] (_VAL) */
 
-            Descriptor->PinConfig.PinConfigValue = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->PinConfig.PinConfigValue = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_PINCONFIG_VALUE,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (PinConfig.PinConfigValue));
             break;
@@ -1874,7 +1974,8 @@ RsDoPinConfigDescriptor (
              *  (implies resource source must immediately follow the pin list.)
              *  Name: _PIN
              */
-            *PinList = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            *PinList = AcpiUtReadUint16 (&Tmp16);
             PinList++;
             PinCount++;
 
@@ -1904,6 +2005,16 @@ RsDoPinConfigDescriptor (
 
         InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
     }
+
+    /* correct the endianness if needed */
+    Tmp16 = Descriptor->PinConfig.PinTableOffset;
+    Descriptor->PinConfig.PinTableOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinConfig.ResSourceOffset;
+    Descriptor->PinConfig.ResSourceOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinConfig.VendorOffset;
+    Descriptor->PinConfig.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinConfig.VendorLength;
+    Descriptor->PinConfig.VendorLength = AcpiUtReadUint16 (&Tmp16);
 
     return (Rnode);
 }
@@ -1938,6 +2049,7 @@ RsDoPinGroupDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  PinCount = 0;
     UINT32                  i;
+    UINT16                  Tmp16;
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
     CurrentByteOffset = Info->CurrentByteOffset;
@@ -1961,7 +2073,7 @@ RsDoPinGroupDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->PinGroup.ResourceLength = DescriptorSize;
+    Descriptor->PinGroup.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->PinGroup.DescriptorType = ACPI_RESOURCE_NAME_PIN_GROUP;
     Descriptor->PinGroup.RevisionId = AML_RESOURCE_PIN_GROUP_REVISION;
 
@@ -2028,7 +2140,8 @@ RsDoPinGroupDescriptor (
              *  (implies resource source must immediately follow the pin list.)
              *  Name: _PIN
              */
-            *PinList = (UINT16) InitializerOp->Asl.Value.Integer;
+        Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            *PinList = AcpiUtReadUint16 (&Tmp16);
             PinList++;
             PinCount++;
 
@@ -2058,6 +2171,16 @@ RsDoPinGroupDescriptor (
 
         InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
     }
+
+    /* correct enddianness as needed */
+    Tmp16 = Descriptor->PinGroup.PinTableOffset;
+    Descriptor->PinGroup.PinTableOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroup.LabelOffset;
+    Descriptor->PinGroup.LabelOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroup.VendorOffset;
+    Descriptor->PinGroup.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroup.VendorLength;
+    Descriptor->PinGroup.VendorLength = AcpiUtReadUint16 (&Tmp16);
 
     return (Rnode);
 }
@@ -2091,6 +2214,7 @@ RsDoPinGroupFunctionDescriptor (
     UINT16                  DescriptorSize;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
     CurrentByteOffset = Info->CurrentByteOffset;
@@ -2114,7 +2238,7 @@ RsDoPinGroupFunctionDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->PinGroupFunction.ResourceLength = DescriptorSize;
+    Descriptor->PinGroupFunction.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->PinGroupFunction.DescriptorType = ACPI_RESOURCE_NAME_PIN_GROUP_FUNCTION;
     Descriptor->PinGroupFunction.RevisionId = AML_RESOURCE_PIN_GROUP_FUNCTION_REVISION;
 
@@ -2146,7 +2270,8 @@ RsDoPinGroupFunctionDescriptor (
 
         case 1: /* Function Number [WORD] */
 
-            Descriptor->PinGroupFunction.FunctionNumber = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->PinGroupFunction.FunctionNumber = AcpiUtReadUint16 (&Tmp16);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_FUNCTION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (PinGroupFunction.FunctionNumber));
             break;
@@ -2205,6 +2330,16 @@ RsDoPinGroupFunctionDescriptor (
         InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
     }
 
+    /* correct enddianness as needed */
+    Tmp16 = Descriptor->PinGroupFunction.ResSourceOffset;
+    Descriptor->PinGroupFunction.ResSourceOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroupFunction.ResSourceLabelOffset;
+    Descriptor->PinGroupFunction.ResSourceLabelOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroupFunction.VendorOffset;
+    Descriptor->PinGroupFunction.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroupFunction.VendorLength;
+    Descriptor->PinGroupFunction.VendorLength = AcpiUtReadUint16 (&Tmp16);
+
     return (Rnode);
 }
 
@@ -2237,6 +2372,8 @@ RsDoPinGroupConfigDescriptor (
     UINT16                  DescriptorSize;
     UINT32                  CurrentByteOffset;
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
     CurrentByteOffset = Info->CurrentByteOffset;
@@ -2260,7 +2397,7 @@ RsDoPinGroupConfigDescriptor (
         sizeof (AML_RESOURCE_LARGE_HEADER));
 
     Descriptor = Rnode->Buffer;
-    Descriptor->PinGroupConfig.ResourceLength = DescriptorSize;
+    Descriptor->PinGroupConfig.ResourceLength = AcpiUtReadUint16 (&DescriptorSize);
     Descriptor->PinGroupConfig.DescriptorType = ACPI_RESOURCE_NAME_PIN_GROUP_CONFIG;
     Descriptor->PinGroupConfig.RevisionId = AML_RESOURCE_PIN_GROUP_CONFIG_REVISION;
 
@@ -2313,7 +2450,8 @@ RsDoPinGroupConfigDescriptor (
 
         case 2: /* Pin Config Value [DWORD] (_VAL) */
 
-            Descriptor->PinGroupConfig.PinConfigValue = (UINT32) InitializerOp->Asl.Value.Integer;
+            Tmp32 = (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->PinGroupConfig.PinConfigValue = AcpiUtReadUint32 (&Tmp32);
             RsCreateDwordField (InitializerOp, ACPI_RESTAG_PINCONFIG_VALUE,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (PinGroupConfig.PinConfigValue));
             break;
@@ -2373,6 +2511,16 @@ RsDoPinGroupConfigDescriptor (
 
         InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
     }
+
+    /* correct enddianness as needed */
+    Tmp16 = Descriptor->PinGroupConfig.ResSourceOffset;
+    Descriptor->PinGroupConfig.ResSourceOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroupConfig.ResSourceLabelOffset;
+    Descriptor->PinGroupConfig.ResSourceLabelOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroupConfig.VendorOffset;
+    Descriptor->PinGroupConfig.VendorOffset = AcpiUtReadUint16 (&Tmp16);
+    Tmp16 = Descriptor->PinGroupConfig.VendorLength;
+    Descriptor->PinGroupConfig.VendorLength = AcpiUtReadUint16 (&Tmp16);
 
     return (Rnode);
 }

--- a/source/compiler/aslrestype2w.c
+++ b/source/compiler/aslrestype2w.c
@@ -192,6 +192,7 @@ RsDoWordIoDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -255,7 +256,8 @@ RsDoWordIoDescriptor (
 
         case 5: /* Address Granularity */
 
-            Descriptor->Address16.Granularity = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Granularity = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Granularity));
             GranOp = InitializerOp;
@@ -263,7 +265,8 @@ RsDoWordIoDescriptor (
 
         case 6: /* Address Min */
 
-            Descriptor->Address16.Minimum = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Minimum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Minimum));
             MinOp = InitializerOp;
@@ -271,7 +274,8 @@ RsDoWordIoDescriptor (
 
         case 7: /* Address Max */
 
-            Descriptor->Address16.Maximum = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Maximum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Maximum));
             MaxOp = InitializerOp;
@@ -279,14 +283,16 @@ RsDoWordIoDescriptor (
 
         case 8: /* Translation Offset */
 
-            Descriptor->Address16.TranslationOffset = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.TranslationOffset = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.TranslationOffset));
             break;
 
         case 9: /* Address Length */
 
-            Descriptor->Address16.AddressLength = (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.AddressLength = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_LENGTH,
                  CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.AddressLength));
             LengthOp = InitializerOp;
@@ -371,12 +377,16 @@ RsDoWordIoDescriptor (
     /* Validate the Min/Max/Len/Gran values */
 
     RsLargeAddressCheck (
-        (UINT64) Descriptor->Address16.Minimum,
-        (UINT64) Descriptor->Address16.Maximum,
-        (UINT64) Descriptor->Address16.AddressLength,
-        (UINT64) Descriptor->Address16.Granularity,
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Minimum),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Maximum),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.AddressLength),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Granularity),
         Descriptor->Address16.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
+
+    /* correct enddianness */
+    Tmp16 = Descriptor->Address16.ResourceLength;
+    Descriptor->Address16.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     Rnode->BufferLength = sizeof (AML_RESOURCE_ADDRESS16) +
         OptionIndex + StringLength;
@@ -413,6 +423,7 @@ RsDoWordBusNumberDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -469,8 +480,8 @@ RsDoWordBusNumberDescriptor (
 
         case 4: /* Address Granularity */
 
-            Descriptor->Address16.Granularity =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Granularity = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Granularity));
             GranOp = InitializerOp;
@@ -478,8 +489,8 @@ RsDoWordBusNumberDescriptor (
 
         case 5: /* Min Address */
 
-            Descriptor->Address16.Minimum =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Minimum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Minimum));
             MinOp = InitializerOp;
@@ -487,8 +498,8 @@ RsDoWordBusNumberDescriptor (
 
         case 6: /* Max Address */
 
-            Descriptor->Address16.Maximum =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Maximum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Maximum));
             MaxOp = InitializerOp;
@@ -496,16 +507,16 @@ RsDoWordBusNumberDescriptor (
 
         case 7: /* Translation Offset */
 
-            Descriptor->Address16.TranslationOffset =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.TranslationOffset = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.TranslationOffset));
             break;
 
         case 8: /* Address Length */
 
-            Descriptor->Address16.AddressLength =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.AddressLength = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_LENGTH,
                  CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.AddressLength));
             LengthOp = InitializerOp;
@@ -576,12 +587,16 @@ RsDoWordBusNumberDescriptor (
     /* Validate the Min/Max/Len/Gran values */
 
     RsLargeAddressCheck (
-        (UINT64) Descriptor->Address16.Minimum,
-        (UINT64) Descriptor->Address16.Maximum,
-        (UINT64) Descriptor->Address16.AddressLength,
-        (UINT64) Descriptor->Address16.Granularity,
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Minimum),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Maximum),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.AddressLength),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Granularity),
         Descriptor->Address16.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
+
+    /* correct enddianness */
+    Tmp16 = Descriptor->Address16.ResourceLength;
+    Descriptor->Address16.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     Rnode->BufferLength = sizeof (AML_RESOURCE_ADDRESS16) +
         OptionIndex + StringLength;
@@ -618,6 +633,7 @@ RsDoWordSpaceDescriptor (
     UINT32                  CurrentByteOffset;
     UINT32                  i;
     BOOLEAN                 ResSourceIndex = FALSE;
+    UINT16                  Tmp16;
 
 
     InitializerOp = Info->DescriptorTypeOp->Asl.Child;
@@ -685,8 +701,8 @@ RsDoWordSpaceDescriptor (
 
         case 6: /* Address Granularity */
 
-            Descriptor->Address16.Granularity =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Granularity = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_GRANULARITY,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Granularity));
             GranOp = InitializerOp;
@@ -694,8 +710,8 @@ RsDoWordSpaceDescriptor (
 
         case 7: /* Min Address */
 
-            Descriptor->Address16.Minimum =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Minimum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MINADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Minimum));
             MinOp = InitializerOp;
@@ -703,8 +719,8 @@ RsDoWordSpaceDescriptor (
 
         case 8: /* Max Address */
 
-            Descriptor->Address16.Maximum =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.Maximum = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_MAXADDR,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.Maximum));
             MaxOp = InitializerOp;
@@ -712,16 +728,16 @@ RsDoWordSpaceDescriptor (
 
         case 9: /* Translation Offset */
 
-            Descriptor->Address16.TranslationOffset =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.TranslationOffset = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_TRANSLATION,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.TranslationOffset));
             break;
 
         case 10: /* Address Length */
 
-            Descriptor->Address16.AddressLength =
-                (UINT16) InitializerOp->Asl.Value.Integer;
+            Tmp16 = (UINT16) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address16.AddressLength = AcpiUtReadUint16 (&Tmp16);
             RsCreateWordField (InitializerOp, ACPI_RESTAG_LENGTH,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Address16.AddressLength));
             LengthOp = InitializerOp;
@@ -792,12 +808,16 @@ RsDoWordSpaceDescriptor (
     /* Validate the Min/Max/Len/Gran values */
 
     RsLargeAddressCheck (
-        (UINT64) Descriptor->Address16.Minimum,
-        (UINT64) Descriptor->Address16.Maximum,
-        (UINT64) Descriptor->Address16.AddressLength,
-        (UINT64) Descriptor->Address16.Granularity,
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Minimum),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Maximum),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.AddressLength),
+        (UINT64) AcpiUtReadUint16 (&Descriptor->Address16.Granularity),
         Descriptor->Address16.Flags,
         MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
+
+    /* correct enddianness */
+    Tmp16 = Descriptor->Address16.ResourceLength;
+    Descriptor->Address16.ResourceLength = AcpiUtReadUint16 (&Tmp16);
 
     Rnode->BufferLength = sizeof (AML_RESOURCE_ADDRESS16) +
         OptionIndex + StringLength;

--- a/source/compiler/aslutils.c
+++ b/source/compiler/aslutils.c
@@ -181,33 +181,6 @@ UtDisplayErrorSummary (
 
 /*******************************************************************************
  *
- * FUNCTION:    UtIsBigEndianMachine
- *
- * PARAMETERS:  None
- *
- * RETURN:      TRUE if machine is big endian
- *              FALSE if machine is little endian
- *
- * DESCRIPTION: Detect whether machine is little endian or big endian.
- *
- ******************************************************************************/
-
-UINT8
-UtIsBigEndianMachine (
-    void)
-{
-    union {
-        UINT32              Integer;
-        UINT8               Bytes[4];
-    } Overlay =                 {0xFF000000};
-
-
-    return (Overlay.Bytes[0]); /* Returns 0xFF (TRUE) for big endian */
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    UtIsIdInteger
  *
  * PARAMETERS:  Pointer to an ACPI ID (HID, CID) string

--- a/source/compiler/cvparser.c
+++ b/source/compiler/cvparser.c
@@ -252,6 +252,7 @@ CvInitFileTree (
     char                    *ChildFilename = NULL;
     UINT8                   *AmlStart;
     UINT32                  AmlLength;
+    UINT32                  TableLength = AcpiUtReadUint32 (&Table->Length);
 
 
     if (!AcpiGbl_CaptureComments)
@@ -260,7 +261,7 @@ CvInitFileTree (
     }
 
 
-    AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
+    AmlLength = TableLength - sizeof (ACPI_TABLE_HEADER);
     AmlStart = ((UINT8 *) Table + sizeof (ACPI_TABLE_HEADER));
 
     CvDbgPrint ("AmlLength: %x\n", AmlLength);
@@ -270,7 +271,7 @@ CvInitFileTree (
     AcpiGbl_FileTreeRoot = AcpiOsAcquireObject (AcpiGbl_FileCache);
 
     AcpiGbl_FileTreeRoot->FileStart = (char *)(AmlStart);
-    AcpiGbl_FileTreeRoot->FileEnd = (char *)(AmlStart + Table->Length);
+    AcpiGbl_FileTreeRoot->FileEnd = (char *)(AmlStart + TableLength);
     AcpiGbl_FileTreeRoot->Next = NULL;
     AcpiGbl_FileTreeRoot->Parent = NULL;
     AcpiGbl_FileTreeRoot->Filename = (char *)(AmlStart+2);

--- a/source/compiler/dtfield.c
+++ b/source/compiler/dtfield.c
@@ -469,7 +469,7 @@ DtCompileInteger (
         DtError (ASL_ERROR, ASL_MSG_INTEGER_SIZE, Field, AslGbl_MsgBuffer);
     }
 
-    memcpy (Buffer, &Value, ByteLength);
+    AcpiUtWriteUint (Buffer, ByteLength, &Value, sizeof (UINT64));
     return;
 }
 

--- a/source/compiler/dtsubtable.c
+++ b/source/compiler/dtsubtable.c
@@ -486,6 +486,6 @@ DtSetSubtableLength (
         return;
     }
 
-    memcpy (Subtable->LengthField, &Subtable->TotalLength,
-        Subtable->SizeOfLengthField);
+    AcpiUtWriteUint (Subtable->LengthField, Subtable->SizeOfLengthField,
+                     &Subtable->TotalLength, sizeof (Subtable->TotalLength));
 }

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -1694,6 +1694,8 @@ DtCompileHmat (
     UINT32                  TgtPDNumber;
     UINT64                  EntryNumber;
     UINT16                  SMBIOSHandleNumber;
+    UINT16                  HmatStructType;
+    UINT32                  Length;
 
 
     ParentTable = DtPeekSubtable ();
@@ -1724,7 +1726,8 @@ DtCompileHmat (
 
         /* Compile HMAT structure body */
 
-        switch (HmatStruct->Type)
+        HmatStructType = AcpiUtReadUint16 (&HmatStruct->Type);
+        switch (HmatStructType)
         {
         case ACPI_HMAT_TYPE_ADDRESS_RANGE:
 
@@ -1757,7 +1760,7 @@ DtCompileHmat (
 
         /* Compile HMAT structure additionals */
 
-        switch (HmatStruct->Type)
+        switch (HmatStructType)
         {
         case ACPI_HMAT_TYPE_LOCALITY:
 
@@ -1783,7 +1786,7 @@ DtCompileHmat (
                 HmatStruct->Length += Subtable->Length;
                 IntPDNumber++;
             }
-            HmatLocality->NumberOfInitiatorPDs = IntPDNumber;
+            HmatLocality->NumberOfInitiatorPDs = AcpiUtReadUint32 (&IntPDNumber);
 
             /* Compile target proximity domain list */
 
@@ -1804,7 +1807,7 @@ DtCompileHmat (
                 HmatStruct->Length += Subtable->Length;
                 TgtPDNumber++;
             }
-            HmatLocality->NumberOfTargetPDs = TgtPDNumber;
+            HmatLocality->NumberOfTargetPDs = AcpiUtReadUint32 (&TgtPDNumber);
 
             /* Save start of the entries for reporting errors */
 
@@ -1829,6 +1832,9 @@ DtCompileHmat (
                 HmatStruct->Length += Subtable->Length;
                 EntryNumber++;
             }
+
+            Length = AcpiUtReadUint32 (&HmatStruct->Length);
+            HmatStruct->Length = Length;
 
             /* Validate number of entries */
 
@@ -1863,10 +1869,18 @@ DtCompileHmat (
                 HmatStruct->Length += Subtable->Length;
                 SMBIOSHandleNumber++;
             }
-            HmatCache->NumberOfSMBIOSHandles = SMBIOSHandleNumber;
+            HmatCache->NumberOfSMBIOSHandles =
+                    AcpiUtReadUint16 (&SMBIOSHandleNumber);
+
+            Length = AcpiUtReadUint32 (&HmatStruct->Length);
+            HmatStruct->Length = Length;
+
             break;
 
         default:
+
+        Length = AcpiUtReadUint32(&HmatStruct->Length);
+        HmatStruct->Length = Length;
 
             break;
         }

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -1532,6 +1532,7 @@ DtCompileHest (
     DT_FIELD                *SubtableStart;
     ACPI_DMTABLE_INFO       *InfoTable;
     UINT16                  Type;
+    UINT16                  Tmp16;
     UINT32                  BankCount;
 
 
@@ -1550,7 +1551,8 @@ DtCompileHest (
         /* Get subtable type */
 
         SubtableStart = *PFieldList;
-        DtCompileInteger ((UINT8 *) &Type, *PFieldList, 2, 0);
+        DtCompileInteger ((UINT8 *) &Tmp16, *PFieldList, 2, 0);
+        Type = AcpiUtReadUint32 (&Tmp16);
 
         switch (Type)
         {

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -680,6 +680,7 @@ DtCompileCsrt (
     DT_FIELD                **PFieldList = (DT_FIELD **) List;
     UINT32                  DescriptorCount;
     UINT32                  GroupLength;
+    UINT32                  Tmp;
 
 
     /* Subtables (Resource Groups) */
@@ -698,12 +699,13 @@ DtCompileCsrt (
 
         /* Compute the number of resource descriptors */
 
-        GroupLength =
-            (ACPI_CAST_PTR (ACPI_CSRT_GROUP,
-                Subtable->Buffer))->Length -
-            (ACPI_CAST_PTR (ACPI_CSRT_GROUP,
-                Subtable->Buffer))->SharedInfoLength -
-            sizeof (ACPI_CSRT_GROUP);
+        Tmp = AcpiUtReadUint32 (&(ACPI_CAST_PTR (ACPI_CSRT_GROUP,
+                                Subtable->Buffer))->Length);
+        GroupLength = Tmp;
+        Tmp = AcpiUtReadUint32 (&(ACPI_CAST_PTR (ACPI_CSRT_GROUP,
+                                Subtable->Buffer))->SharedInfoLength);
+        GroupLength -= Tmp;
+        GroupLength -= sizeof (ACPI_CSRT_GROUP);
 
         DescriptorCount = (GroupLength  /
             sizeof (ACPI_CSRT_DESCRIPTOR));
@@ -791,6 +793,7 @@ DtCompileDbg2 (
     ACPI_DBG2_DEVICE        *DeviceInfo;
     UINT16                  CurrentOffset;
     UINT32                  i;
+    UINT32                  Tmp;
 
 
     /* Main table */
@@ -807,10 +810,12 @@ DtCompileDbg2 (
     /* Main table fields */
 
     Dbg2Header = ACPI_CAST_PTR (ACPI_DBG2_HEADER, Subtable->Buffer);
-    Dbg2Header->InfoOffset = sizeof (ACPI_TABLE_HEADER) + ACPI_PTR_DIFF (
-        ACPI_ADD_PTR (UINT8, Dbg2Header, sizeof (ACPI_DBG2_HEADER)), Dbg2Header);
+    Tmp = sizeof (ACPI_TABLE_HEADER) + ACPI_PTR_DIFF (
+       ACPI_ADD_PTR (UINT8, Dbg2Header, sizeof (ACPI_DBG2_HEADER)), Dbg2Header);
+    AcpiUtWriteUint (&Dbg2Header->InfoOffset, sizeof (UINT32),
+            &Tmp, sizeof (UINT32));
 
-    SubtableCount = Dbg2Header->InfoCount;
+    SubtableCount = Tmp;
     DtPushSubtable (Subtable);
 
     /* Process all Device Information subtables (Count = InfoCount) */
@@ -837,7 +842,8 @@ DtCompileDbg2 (
 
         /* BaseAddressRegister GAS array (Required, size is RegisterCount) */
 
-        DeviceInfo->BaseAddressOffset = CurrentOffset;
+        AcpiUtWriteUint (&DeviceInfo->BaseAddressOffset, sizeof (UINT16),
+                &CurrentOffset, sizeof (UINT16));
         for (i = 0; *PFieldList && (i < DeviceInfo->RegisterCount); i++)
         {
             Status = DtCompileTable (PFieldList, AcpiDmTableInfoDbg2Addr,
@@ -853,7 +859,8 @@ DtCompileDbg2 (
 
         /* AddressSize array (Required, size = RegisterCount) */
 
-        DeviceInfo->AddressSizeOffset = CurrentOffset;
+        AcpiUtWriteUint (&DeviceInfo->AddressSizeOffset, sizeof (UINT16),
+                &CurrentOffset, sizeof (UINT16));
         for (i = 0; *PFieldList && (i < DeviceInfo->RegisterCount); i++)
         {
             Status = DtCompileTable (PFieldList, AcpiDmTableInfoDbg2Size,
@@ -869,7 +876,8 @@ DtCompileDbg2 (
 
         /* NamespaceString device identifier (Required, size = NamePathLength) */
 
-        DeviceInfo->NamepathOffset = CurrentOffset;
+        AcpiUtWriteUint (&DeviceInfo->NamepathOffset, sizeof (UINT16),
+            &CurrentOffset, sizeof (UINT16));
         Status = DtCompileTable (PFieldList, AcpiDmTableInfoDbg2Name,
             &Subtable);
         if (ACPI_FAILURE (Status))
@@ -879,8 +887,9 @@ DtCompileDbg2 (
 
         /* Update the device info header */
 
-        DeviceInfo->NamepathLength = (UINT16) Subtable->Length;
-        CurrentOffset += (UINT16) DeviceInfo->NamepathLength;
+        AcpiUtWriteUint (&DeviceInfo->NamepathLength, sizeof (UINT16),
+            &Subtable->Length, sizeof (UINT32));
+        CurrentOffset += AcpiUtReadUint16 (&DeviceInfo->NamepathLength);
         DtInsertSubtable (ParentTable, Subtable);
 
         /* OemData - Variable-length data (Optional, size = OemDataLength) */
@@ -907,8 +916,10 @@ DtCompileDbg2 (
 
         if (Subtable && Subtable->Length)
         {
-            DeviceInfo->OemDataOffset = CurrentOffset;
-            DeviceInfo->OemDataLength = (UINT16) Subtable->Length;
+            AcpiUtWriteUint (&DeviceInfo->OemDataOffset, sizeof (UINT16),
+                &CurrentOffset, sizeof (UINT16));
+            AcpiUtWriteUint (&DeviceInfo->OemDataLength, sizeof (UINT16),
+                &Subtable->Length, sizeof (UINT32));
 
             DtInsertSubtable (ParentTable, Subtable);
         }

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -1396,8 +1396,13 @@ DtCompileGtdt (
             DtPushSubtable (Subtable);
             ParentTable = DtPeekSubtable ();
 
-            GtCount = (ACPI_CAST_PTR (ACPI_GTDT_TIMER_BLOCK,
-                Subtable->Buffer - sizeof(ACPI_GTDT_HEADER)))->TimerCount;
+            {
+                UINT32 Tmp32;
+
+                Tmp32 = (ACPI_CAST_PTR (ACPI_GTDT_TIMER_BLOCK,
+                    Subtable->Buffer - sizeof (ACPI_GTDT_HEADER)))->TimerCount;
+                GtCount = AcpiUtReadUint32 (&Tmp32);
+            }
 
             while (GtCount)
             {

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -959,6 +959,7 @@ DtCompileDmar (
     ACPI_DMAR_DEVICE_SCOPE  *DmarDeviceScope;
     UINT32                  DeviceScopeLength;
     UINT32                  PciPathLength;
+    UINT16                  DmarHeaderType;
 
 
     Status = DtCompileTable (PFieldList, AcpiDmTableInfoDmar, &Subtable);
@@ -989,7 +990,8 @@ DtCompileDmar (
 
         DmarHeader = ACPI_CAST_PTR (ACPI_DMAR_HEADER, Subtable->Buffer);
 
-        switch (DmarHeader->Type)
+        DmarHeaderType = AcpiUtReadUint16 (&DmarHeader->Type);
+        switch (DmarHeaderType)
         {
         case ACPI_DMAR_TYPE_HARDWARE_UNIT:
 
@@ -1036,8 +1038,8 @@ DtCompileDmar (
         /*
          * Optional Device Scope subtables
          */
-        if ((DmarHeader->Type == ACPI_DMAR_TYPE_HARDWARE_AFFINITY) ||
-            (DmarHeader->Type == ACPI_DMAR_TYPE_NAMESPACE))
+        if ((DmarHeaderType == ACPI_DMAR_TYPE_HARDWARE_AFFINITY) ||
+            (DmarHeaderType == ACPI_DMAR_TYPE_NAMESPACE))
         {
             /* These types do not support device scopes */
 
@@ -1046,8 +1048,8 @@ DtCompileDmar (
         }
 
         DtPushSubtable (Subtable);
-        DeviceScopeLength = DmarHeader->Length - Subtable->Length -
-            ParentTable->Length;
+        DeviceScopeLength = AcpiUtReadUint16 (&DmarHeader->Length) -
+                Subtable->Length - ParentTable->Length;
         while (DeviceScopeLength)
         {
             Status = DtCompileTable (PFieldList, AcpiDmTableInfoDmarScope,

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -1174,7 +1174,8 @@ DtCompileDrtm (
         Count++;
     }
 
-    DrtmVtl->ValidatedTableCount = Count;
+    AcpiUtWriteUint (&DrtmVtl->ValidatedTableCount, sizeof (UINT32),
+            &Count, sizeof (UINT32));
     DtPopSubtable ();
     ParentTable = DtPeekSubtable ();
 
@@ -1212,7 +1213,8 @@ DtCompileDrtm (
         Count++;
     }
 
-    DrtmRl->ResourceCount = Count;
+    AcpiUtWriteUint(&DrtmRl->ResourceCount, sizeof(UINT32),
+            &Count, sizeof(UINT32));
     DtPopSubtable ();
     ParentTable = DtPeekSubtable ();
 

--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -1450,6 +1450,7 @@ DtCompileFpdt (
     ACPI_DMTABLE_INFO       *InfoTable;
     DT_FIELD                **PFieldList = (DT_FIELD **) List;
     DT_FIELD                *SubtableStart;
+    UINT16                  SubtableType;
 
 
     while (*PFieldList)
@@ -1468,7 +1469,8 @@ DtCompileFpdt (
 
         FpdtHeader = ACPI_CAST_PTR (ACPI_FPDT_HEADER, Subtable->Buffer);
 
-        switch (FpdtHeader->Type)
+        SubtableType = AcpiUtReadUint16 (&FpdtHeader->Type);
+        switch (SubtableType)
         {
         case ACPI_FPDT_TYPE_BOOT:
 

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -2375,6 +2375,7 @@ DtCompileTpm2 (
     DT_SUBTABLE             *ParentTable;
     ACPI_STATUS             Status = AE_OK;
     ACPI_TABLE_HEADER       *Header;
+    UINT8                   StartMethod;
 
 
     ParentTable = DtPeekSubtable ();
@@ -2418,7 +2419,8 @@ DtCompileTpm2 (
 
     /* Subtable type depends on the StartMethod */
 
-    switch (Tpm2Header->StartMethod)
+    StartMethod = *(UINT8 *) &Tpm2Header->StartMethod;
+    switch (StartMethod)
     {
     case ACPI_TPM2_COMMAND_BUFFER_WITH_ARM_SMC:
 
@@ -2449,7 +2451,7 @@ DtCompileTpm2 (
     case ACPI_TPM2_RESERVED10:
 
         AcpiOsPrintf ("\n**** Reserved TPM2 Start Method type 0x%X\n",
-            Tpm2Header->StartMethod);
+            StartMethod);
         Status = AE_ERROR;
         break;
 
@@ -2457,7 +2459,7 @@ DtCompileTpm2 (
     default:
 
         AcpiOsPrintf ("\n**** Unknown TPM2 Start Method type 0x%X\n",
-            Tpm2Header->StartMethod);
+            StartMethod);
         Status = AE_ERROR;
         break;
     }

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -978,6 +978,8 @@ DtCompilePhat (
     ACPI_DMTABLE_INFO       *Info;
     ACPI_PHAT_VERSION_DATA  *VersionData;
     UINT32                  RecordCount;
+    UINT16                  SubtableType;
+    UINT16                  Tmp16;
 
 
     /* The table consist of subtables */
@@ -995,8 +997,9 @@ DtCompilePhat (
         DtPushSubtable (Subtable);
 
         PhatHeader = ACPI_CAST_PTR (ACPI_PHAT_HEADER, Subtable->Buffer);
+	SubtableType = AcpiUtReadUint16 (&PhatHeader->Type);
 
-        switch (PhatHeader->Type)
+        switch (SubtableType)
         {
         case ACPI_PHAT_TYPE_FW_VERSION_DATA:
 
@@ -1027,13 +1030,13 @@ DtCompilePhat (
         ParentTable = DtPeekSubtable ();
         DtInsertSubtable (ParentTable, Subtable);
 
-        switch (PhatHeader->Type)
+        switch (SubtableType)
         {
         case ACPI_PHAT_TYPE_FW_VERSION_DATA:
 
             VersionData = ACPI_CAST_PTR (ACPI_PHAT_VERSION_DATA,
                 (Subtable->Buffer - sizeof (ACPI_PHAT_HEADER)));
-            RecordCount = VersionData->ElementCount;
+            RecordCount = AcpiUtReadUint32 (&VersionData->ElementCount);
 
             while (RecordCount)
             {
@@ -1084,6 +1087,9 @@ DtCompilePhat (
             DtFatal (ASL_MSG_UNKNOWN_SUBTABLE, *PFieldList, "PHAT");
             return (AE_ERROR);
         }
+
+	Tmp16 = AcpiUtReadUint16 (&PhatHeader->Length);
+	PhatHeader->Length = Tmp16;
     }
 
     return (Status);

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1945,7 +1945,7 @@ DtCompileSlit (
     ParentTable = DtPeekSubtable ();
     DtInsertSubtable (ParentTable, Subtable);
 
-    Localities = *ACPI_CAST_PTR (UINT32, Subtable->Buffer);
+    Localities = (UINT32) AcpiUtReadUint64 (Subtable->Buffer);
     LocalityBuffer = UtLocalCalloc (Localities);
     LocalityListLength = 0;
 

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1601,6 +1601,7 @@ DtCompileSdev (
     UINT32                      EntryCount;
     ACPI_SDEV_SECURE_COMPONENT  *SecureComponent = NULL;
     UINT16                      ComponentLength = 0;
+    UINT16                      Tmp16;
 
 
     /* Subtables */
@@ -1622,7 +1623,7 @@ DtCompileSdev (
         DtPushSubtable (Subtable);
 
         SdevHeader = ACPI_CAST_PTR (ACPI_SDEV_HEADER, Subtable->Buffer);
-        SdevHeader->Length = (UINT8)(sizeof (ACPI_SDEV_HEADER));
+        SdevHeader->Length = (UINT16) (sizeof (ACPI_SDEV_HEADER));
 
         switch (SdevHeader->Type)
         {
@@ -1795,6 +1796,18 @@ DtCompileSdev (
                 }
             }
 
+            /* Make sure everything is now little-endian */
+            Tmp16 = AcpiUtReadUint16 (&SdevHeader->Length);
+            SdevHeader->Length = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Namesp->DeviceIdOffset);
+            Namesp->DeviceIdOffset = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Namesp->DeviceIdLength);
+            Namesp->DeviceIdLength = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Namesp->VendorDataOffset);
+            Namesp->VendorDataOffset = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Namesp->VendorDataLength);
+            Namesp->VendorDataLength = Tmp16;
+
             break;
 
         case ACPI_SDEV_TYPE_PCIE_ENDPOINT_DEVICE:
@@ -1857,6 +1870,18 @@ DtCompileSdev (
             SdevHeader->Length =
                 sizeof (ACPI_SDEV_PCIE) +
                 Pcie->PathLength + Pcie->VendorDataLength;
+
+            Tmp16 = AcpiUtReadUint16 (&SdevHeader->Length);
+            SdevHeader->Length = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Pcie->PathOffset);
+            Pcie->PathOffset = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Pcie->PathLength);
+            Pcie->PathLength = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Pcie->VendorDataOffset);
+            Pcie->VendorDataOffset = Tmp16;
+            Tmp16 = AcpiUtReadUint16 (&Pcie->VendorDataLength);
+            Pcie->VendorDataLength = Tmp16;
+		
             break;
 
         default:

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -605,6 +605,7 @@ DtCompileNfit (
     UINT32                  Count;
     ACPI_NFIT_INTERLEAVE    *Interleave = NULL;
     ACPI_NFIT_FLUSH_ADDRESS *Hint = NULL;
+    UINT16                  NfitHeaderType;
 
 
     /* Main table */
@@ -638,7 +639,8 @@ DtCompileNfit (
 
         NfitHeader = ACPI_CAST_PTR (ACPI_NFIT_HEADER, Subtable->Buffer);
 
-        switch (NfitHeader->Type)
+        NfitHeaderType = AcpiUtReadUint16 (&NfitHeader->Type);
+        switch (NfitHeaderType)
         {
         case ACPI_NFIT_TYPE_SYSTEM_ADDRESS:
 
@@ -698,7 +700,7 @@ DtCompileNfit (
         DtInsertSubtable (ParentTable, Subtable);
         DtPopSubtable ();
 
-        switch (NfitHeader->Type)
+        switch (NfitHeaderType)
         {
         case ACPI_NFIT_TYPE_INTERLEAVE:
 
@@ -724,7 +726,8 @@ DtCompileNfit (
                 Count++;
             }
 
-            Interleave->LineCount = Count;
+            AcpiUtWriteUint (&Interleave->LineCount, sizeof (UINT32),
+                &Count, sizeof (UINT32));
             break;
 
         case ACPI_NFIT_TYPE_SMBIOS:
@@ -770,6 +773,8 @@ DtCompileNfit (
             }
 
             Hint->HintCount = (UINT16) Count;
+            AcpiUtWriteUint (&Hint->HintCount, sizeof (UINT16),
+                &Count, sizeof (UINT32));
             break;
 
         default:

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -2746,7 +2746,7 @@ DtCompileWpbt (
     AcpiUtWriteUint (&Length, sizeof (UINT16),
            &Subtable->TotalLength, sizeof (UINT32));
     Table = ACPI_CAST_PTR (ACPI_TABLE_WPBT, ParentTable->Buffer);
-    Table->ArgumentsLength = Length;
+    Table->ArgumentsLength = AcpiUtReadUint16 (&Length);
 
     ParentTable = DtPeekSubtable ();
     DtInsertSubtable (ParentTable, Subtable);

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -458,7 +458,7 @@ DtCompileMpst (
     DtPushSubtable (Subtable);
 
     MpstChannelInfo = ACPI_CAST_PTR (ACPI_MPST_CHANNEL, Subtable->Buffer);
-    SubtableCount = MpstChannelInfo->PowerNodeCount;
+    SubtableCount = AcpiUtReadUint16 (&MpstChannelInfo->PowerNodeCount);
 
     while (*PFieldList && SubtableCount)
     {
@@ -476,8 +476,8 @@ DtCompileMpst (
         DtPushSubtable (Subtable);
 
         MpstPowerNode = ACPI_CAST_PTR (ACPI_MPST_POWER_NODE, Subtable->Buffer);
-        PowerStateCount = MpstPowerNode->NumPowerStates;
-        ComponentCount = MpstPowerNode->NumPhysicalComponents;
+        PowerStateCount = AcpiUtReadUint16 (&MpstPowerNode->NumPowerStates);
+        ComponentCount = AcpiUtReadUint16 (&MpstPowerNode->NumPhysicalComponents);
 
         ParentTable = DtPeekSubtable ();
 
@@ -530,7 +530,7 @@ DtCompileMpst (
     DtPushSubtable (Subtable);
 
     MpstDataHeader = ACPI_CAST_PTR (ACPI_MPST_DATA_HDR, Subtable->Buffer);
-    SubtableCount = MpstDataHeader->CharacteristicsCount;
+    SubtableCount = AcpiUtReadUint16(&MpstDataHeader->CharacteristicsCount);
 
     ParentTable = DtPeekSubtable ();
 

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -2247,6 +2247,7 @@ DtCompileTcpa (
     ACPI_TABLE_TCPA_HDR     *TcpaHeader;
     DT_SUBTABLE             *ParentTable;
     ACPI_STATUS             Status;
+    UINT16                  PlatformClass;
 
 
     /* Compile the main table */
@@ -2267,7 +2268,8 @@ DtCompileTcpa (
      */
     TcpaHeader = ACPI_CAST_PTR (ACPI_TABLE_TCPA_HDR, ParentTable->Buffer);
 
-    switch (TcpaHeader->PlatformClass)
+    PlatformClass = AcpiUtReadUint16 (&TcpaHeader->PlatformClass);
+    switch (PlatformClass)
     {
     case ACPI_TCPA_CLIENT_TABLE:
 

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1231,6 +1231,7 @@ DtCompilePptt (
     DT_FIELD                **PFieldList = (DT_FIELD **) List;
     DT_FIELD                *SubtableStart;
     ACPI_TABLE_HEADER       *PpttAcpiHeader;
+    UINT32                  NumPrivRes;
 
 
     ParentTable = DtPeekSubtable ();
@@ -1295,7 +1296,7 @@ DtCompilePptt (
             {
                 /* Compile initiator proximity domain list */
 
-                PpttProcessor->NumberOfPrivResources = 0;
+                NumPrivRes = 0;
                 while (*PFieldList)
                 {
                     Status = DtCompileTable (PFieldList,
@@ -1311,8 +1312,10 @@ DtCompilePptt (
 
                     DtInsertSubtable (ParentTable, Subtable);
                     PpttHeader->Length += (UINT8)(Subtable->Length);
-                    PpttProcessor->NumberOfPrivResources++;
+                    NumPrivRes++;
                 }
+                PpttProcessor->NumberOfPrivResources =
+                        AcpiUtReadUint32 (&NumPrivRes);
             }
             break;
 

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1514,6 +1514,7 @@ DtCompileS3pt (
     DT_SUBTABLE             *ParentTable;
     ACPI_DMTABLE_INFO       *InfoTable;
     DT_FIELD                *SubtableStart;
+    UINT16                  S3ptHeaderType;
 
 
     Status = DtCompileTable (PFieldList, AcpiDmTableInfoS3pt,
@@ -1541,7 +1542,8 @@ DtCompileS3pt (
 
         S3ptHeader = ACPI_CAST_PTR (ACPI_FPDT_HEADER, Subtable->Buffer);
 
-        switch (S3ptHeader->Type)
+        S3ptHeaderType = AcpiUtReadUint16 (&S3ptHeader->Type);
+        switch (S3ptHeaderType)
         {
         case ACPI_S3PT_TYPE_RESUME:
 

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -2743,7 +2743,8 @@ DtCompileWpbt (
 
     /* Extract the length of the Arguments buffer, insert into main table */
 
-    Length = (UINT16) Subtable->TotalLength;
+    AcpiUtWriteUint (&Length, sizeof (UINT16),
+           &Subtable->TotalLength, sizeof (UINT32));
     Table = ACPI_CAST_PTR (ACPI_TABLE_WPBT, ParentTable->Buffer);
     Table->ArgumentsLength = Length;
 

--- a/source/components/disassembler/dmopcode.c
+++ b/source/components/disassembler/dmopcode.c
@@ -886,7 +886,9 @@ AcpiDmDisassembleOneOp (
         }
         else
         {
-            AcpiOsPrintf ("0x%4.4X", (UINT32) Op->Common.Value.Integer);
+            UINT16 Tmp16 = (UINT16) Op->Common.Value.Integer;
+
+            AcpiOsPrintf ("0x%4.4X", (UINT32) AcpiUtReadUint16 (&Tmp16));
         }
         break;
 
@@ -898,14 +900,19 @@ AcpiDmDisassembleOneOp (
         }
         else
         {
-            AcpiOsPrintf ("0x%8.8X", (UINT32) Op->Common.Value.Integer);
+            UINT32 Tmp32 = (UINT32) Op->Common.Value.Integer;
+
+            AcpiOsPrintf ("0x%8.8X", (UINT32) AcpiUtReadUint32 (&Tmp32));
         }
         break;
 
     case AML_QWORD_OP:
 
-        AcpiOsPrintf ("0x%8.8X%8.8X",
-            ACPI_FORMAT_UINT64 (Op->Common.Value.Integer));
+        {
+	    UINT64 Tmp64 = AcpiUtReadUint64 (&Op->Common.Value.Integer);
+
+            AcpiOsPrintf ("0x%8.8X%8.8X", ACPI_FORMAT_UINT64 (Tmp64));
+        }
         break;
 
     case AML_STRING_OP:
@@ -995,18 +1002,18 @@ AcpiDmDisassembleOneOp (
         AcpiOsPrintf (",");
         ASL_CV_PRINT_ONE_COMMENT (Op, AML_NAMECOMMENT, NULL, 0);
         AcpiOsPrintf ("%*.s  %u", (unsigned) (5 - Length), " ",
-            (UINT32) Op->Common.Value.Integer);
+            (UINT32) Op->Common.Value.Size);
 
         AcpiDmCommaIfFieldMember (Op);
 
-        Info->BitOffset += (UINT32) Op->Common.Value.Integer;
+        Info->BitOffset += (UINT32) Op->Common.Value.Size;
         break;
 
     case AML_INT_RESERVEDFIELD_OP:
 
         /* Offset() -- Must account for previous offsets */
 
-        Offset = (UINT32) Op->Common.Value.Integer;
+        Offset = (UINT32) Op->Common.Value.Size;
         Info->BitOffset += Offset;
 
         if (Info->BitOffset % 8 == 0)

--- a/source/components/disassembler/dmresrc.c
+++ b/source/components/disassembler/dmresrc.c
@@ -525,7 +525,7 @@ AcpiDmIsResourceTemplate (
         return (AE_TYPE);
     }
 
-    DeclaredBufferLength = NextOp->Common.Value.Size;
+    DeclaredBufferLength = NextOp->Common.Value.Integer;
 
     /* Get the length of the raw initialization byte list */
 

--- a/source/components/disassembler/dmresrcl.c
+++ b/source/components/disassembler/dmresrcl.c
@@ -249,6 +249,8 @@ AcpiDmMemoryFields (
     UINT32                  Level)
 {
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
 
 
     for (i = 0; i < 4; i++)
@@ -259,14 +261,16 @@ AcpiDmMemoryFields (
         {
         case 16:
 
-            AcpiDmDumpInteger16 (ACPI_CAST_PTR (UINT16, Source)[i],
-                AcpiDmMemoryNames[i]);
+            Tmp16 = ACPI_CAST_PTR (UINT16, Source)[i];
+            AcpiDmDumpInteger16 (AcpiUtReadUint16 (&Tmp16),
+                     AcpiDmMemoryNames[i]);
             break;
 
         case 32:
 
-            AcpiDmDumpInteger32 (ACPI_CAST_PTR (UINT32, Source)[i],
-                AcpiDmMemoryNames[i]);
+            Tmp32 = ACPI_CAST_PTR (UINT32, Source)[i];
+            AcpiDmDumpInteger32 (AcpiUtReadUint32 (&Tmp32),
+                     AcpiDmMemoryNames[i]);
             break;
 
         default:
@@ -298,6 +302,9 @@ AcpiDmAddressFields (
     UINT32                  Level)
 {
     UINT32                  i;
+    UINT16                  Tmp16;
+    UINT32                  Tmp32;
+    UINT64                  Tmp64;
 
 
     AcpiOsPrintf ("\n");
@@ -310,20 +317,23 @@ AcpiDmAddressFields (
         {
         case 16:
 
-            AcpiDmDumpInteger16 (ACPI_CAST_PTR (UINT16, Source)[i],
-                AcpiDmAddressNames[i]);
+            Tmp16 = ACPI_CAST_PTR (UINT16, Source)[i];
+            AcpiDmDumpInteger16 (AcpiUtReadUint16 (&Tmp16),
+                         AcpiDmAddressNames[i]);
             break;
 
         case 32:
 
-            AcpiDmDumpInteger32 (ACPI_CAST_PTR (UINT32, Source)[i],
-                AcpiDmAddressNames[i]);
+            Tmp32 = ACPI_CAST_PTR (UINT32, Source)[i];
+            AcpiDmDumpInteger32 (AcpiUtReadUint32 (&Tmp32),
+                         AcpiDmAddressNames[i]);
             break;
 
         case 64:
 
-            AcpiDmDumpInteger64 (ACPI_CAST_PTR (UINT64, Source)[i],
-                AcpiDmAddressNames[i]);
+            Tmp64 = ACPI_CAST_PTR (UINT64, Source)[i];
+            AcpiDmDumpInteger64 (AcpiUtReadUint64 (&Tmp64),
+                         AcpiDmAddressNames[i]);
             break;
 
         default:
@@ -857,7 +867,7 @@ AcpiDmExtendedDescriptor (
     /* Extra field for this descriptor only */
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger64 (Resource->ExtAddress64.TypeSpecific,
+    AcpiDmDumpInteger64 (AcpiUtReadUint64 (&Resource->ExtAddress64.TypeSpecific),
         "Type-Specific Attributes");
 
     /* Insert a descriptor name */
@@ -984,11 +994,11 @@ AcpiDmFixedMemory32Descriptor (
         AcpiGbl_RwDecode [ACPI_GET_1BIT_FLAG (Resource->FixedMemory32.Flags)]);
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger32 (Resource->FixedMemory32.Address,
+    AcpiDmDumpInteger32 (AcpiUtReadUint32 (&Resource->FixedMemory32.Address),
         "Address Base");
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger32 (Resource->FixedMemory32.AddressLength,
+    AcpiDmDumpInteger32 (AcpiUtReadUint32 (&Resource->FixedMemory32.AddressLength),
         "Address Length");
 
     /* Insert a descriptor name */
@@ -1034,7 +1044,8 @@ AcpiDmGenericRegisterDescriptor (
     AcpiDmDumpInteger8 (Resource->GenericReg.BitOffset, "Bit Offset");
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger64 (Resource->GenericReg.Address, "Address");
+    AcpiDmDumpInteger64 (AcpiUtReadUint64 (&Resource->GenericReg.Address),
+                 "Address");
 
     /* Optional field for ACPI 3.0 */
 
@@ -1097,7 +1108,7 @@ AcpiDmInterruptDescriptor (
     AcpiDmResourceSource (Resource,
         sizeof (AML_RESOURCE_EXTENDED_IRQ) +
             ((UINT32) Resource->ExtendedIrq.InterruptCount - 1) * sizeof (UINT32),
-        Resource->ExtendedIrq.ResourceLength);
+            AcpiUtReadUint16 (&Resource->ExtendedIrq.ResourceLength));
 
     /* Insert a descriptor name */
 
@@ -1112,7 +1123,7 @@ AcpiDmInterruptDescriptor (
     {
         AcpiDmIndent (Level + 1);
         AcpiOsPrintf ("0x%8.8X,\n",
-            (UINT32) Resource->ExtendedIrq.Interrupts[i]);
+            AcpiUtReadUint32 (&Resource->ExtendedIrq.Interrupts[i]));
     }
 
     AcpiDmIndent (Level);

--- a/source/components/disassembler/dmresrcs.c
+++ b/source/components/disassembler/dmresrcs.c
@@ -201,7 +201,7 @@ AcpiDmIrqDescriptor (
     AcpiOsPrintf (")\n");
 
     AcpiDmIndent (Level + 1);
-    AcpiDmBitList (Resource->Irq.IrqMask);
+    AcpiDmBitList (AcpiUtReadUint16 (&Resource->Irq.IrqMask));
 }
 
 
@@ -269,8 +269,8 @@ AcpiDmFixedDmaDescriptor (
 
     AcpiDmIndent (Level);
     AcpiOsPrintf ("FixedDMA (0x%4.4X, 0x%4.4X, ",
-        Resource->FixedDma.RequestLines,
-        Resource->FixedDma.Channels);
+        AcpiUtReadUint16 (&Resource->FixedDma.RequestLines),
+        AcpiUtReadUint16 (&Resource->FixedDma.Channels));
 
     if (Resource->FixedDma.Width <= 5)
     {
@@ -318,10 +318,12 @@ AcpiDmIoDescriptor (
         AcpiGbl_IoDecode [ACPI_GET_1BIT_FLAG (Resource->Io.Flags)]);
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger16 (Resource->Io.Minimum, "Range Minimum");
+    AcpiDmDumpInteger16 (AcpiUtReadUint16 (&Resource->Io.Minimum),
+                 "Range Minimum");
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger16 (Resource->Io.Maximum, "Range Maximum");
+    AcpiDmDumpInteger16 (AcpiUtReadUint16 (&Resource->Io.Maximum),
+                 "Range Maximum");
 
     AcpiDmIndent (Level + 1);
     AcpiDmDumpInteger8 (Resource->Io.Alignment, "Alignment");
@@ -364,10 +366,12 @@ AcpiDmFixedIoDescriptor (
     AcpiOsPrintf ("FixedIO (\n");
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger16 (Resource->FixedIo.Address, "Address");
+    AcpiDmDumpInteger16 (AcpiUtReadUint16 (&Resource->FixedIo.Address),
+                 "Address");
 
     AcpiDmIndent (Level + 1);
-    AcpiDmDumpInteger8 (Resource->FixedIo.AddressLength, "Length");
+    AcpiDmDumpInteger8 (AcpiUtReadUint16 (&Resource->FixedIo.AddressLength),
+            "Length");
 
     /* Insert a descriptor name */
 

--- a/source/components/disassembler/dmwalk.c
+++ b/source/components/disassembler/dmwalk.c
@@ -1263,7 +1263,7 @@ AcpiDmAscendingOp (
         {
             ParentOp->Common.DisasmFlags |= ACPI_PARSEOP_EMPTY_TERMLIST;
             ASL_CV_CLOSE_PAREN (Op, Level);
-            AcpiOsPrintf ("{");
+            AcpiOsPrintf (" {");
         }
     }
 

--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -661,6 +661,7 @@ AcpiDsCreateField (
         Status = AcpiNsLookup (WalkState->ScopeInfo, Arg->Common.Value.Name,
             ACPI_TYPE_REGION, ACPI_IMODE_EXECUTE,
             ACPI_NS_SEARCH_PARENT, WalkState, &RegionNode);
+
 #ifdef ACPI_ASL_COMPILER
         Status = AcpiDsCreateExternalRegion (Status, Arg,
             Arg->Common.Value.Name, WalkState, &RegionNode);

--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -752,7 +752,7 @@ AcpiNsLookup (
 
         /* Extract one ACPI name from the front of the pathname */
 
-        ACPI_MOVE_32_TO_32 (&SimpleName, Path);
+        ACPI_COPY_NAMESEG (&SimpleName, Path);
 
         /* Try to find the single (4 character) ACPI name */
 

--- a/source/components/namespace/nsnames.c
+++ b/source/components/namespace/nsnames.c
@@ -405,10 +405,10 @@ AcpiNsBuildNormalizedPath (
     {
         if (NextNode != Node)
         {
-            ACPI_PATH_PUT8(FullPath, PathSize, AML_DUAL_NAME_PREFIX, Length);
+            ACPI_PATH_PUT8 (FullPath, PathSize, AML_DUAL_NAME_PREFIX, Length);
         }
 
-        ACPI_MOVE_32_TO_32 (Name, &NextNode->Name);
+        ACPI_COPY_NAMESEG (Name, &NextNode->Name);
         DoNoTrailing = NoTrailing;
         for (i = 0; i < 4; i++)
         {

--- a/source/components/namespace/nsparse.c
+++ b/source/components/namespace/nsparse.c
@@ -311,6 +311,7 @@ AcpiNsOneCompleteParse (
     ACPI_WALK_STATE         *WalkState;
     ACPI_TABLE_HEADER       *Table;
     ACPI_OWNER_ID           OwnerId;
+    UINT32                  TableLength;
 
 
     ACPI_FUNCTION_TRACE (NsOneCompleteParse);
@@ -324,13 +325,14 @@ AcpiNsOneCompleteParse (
 
     /* Table must consist of at least a complete header */
 
-    if (Table->Length < sizeof (ACPI_TABLE_HEADER))
+    TableLength = AcpiUtReadUint32 (&Table->Length);
+    if (TableLength < sizeof (ACPI_TABLE_HEADER))
     {
         return_ACPI_STATUS (AE_BAD_HEADER);
     }
 
     AmlStart = (UINT8 *) Table + sizeof (ACPI_TABLE_HEADER);
-    AmlLength = Table->Length - sizeof (ACPI_TABLE_HEADER);
+    AmlLength = TableLength - sizeof (ACPI_TABLE_HEADER);
 
     Status = AcpiTbGetOwnerId (TableIndex, &OwnerId);
     if (ACPI_FAILURE (Status))

--- a/source/components/namespace/nsutils.c
+++ b/source/components/namespace/nsutils.c
@@ -380,6 +380,7 @@ AcpiNsBuildInternalName (
     const char              *ExternalName = Info->NextExternalChar;
     char                    *Result = NULL;
     UINT32                  i;
+    char                    TmpSeg[ACPI_NAMESEG_SIZE+1];
 
 
     ACPI_FUNCTION_TRACE (NsBuildInternalName);
@@ -443,6 +444,7 @@ AcpiNsBuildInternalName (
 
     for (; NumSegments; NumSegments--)
     {
+        memset (TmpSeg, 0, ACPI_NAMESEG_SIZE+1);
         for (i = 0; i < ACPI_NAMESEG_SIZE; i++)
         {
             if (ACPI_IS_PATH_SEPARATOR (*ExternalName) ||
@@ -450,16 +452,17 @@ AcpiNsBuildInternalName (
             {
                 /* Pad the segment with underscore(s) if segment is short */
 
-                Result[i] = '_';
+                TmpSeg[i] = '_';
             }
             else
             {
                 /* Convert the character to uppercase and save it */
 
-                Result[i] = (char) toupper ((int) *ExternalName);
+                TmpSeg[i] = (char) toupper ((int) *ExternalName);
                 ExternalName++;
             }
         }
+    AcpiUtWriteUint (Result, ACPI_NAMESEG_SIZE, TmpSeg, ACPI_NAMESEG_SIZE);
 
         /* Now we must have a path separator, or the pathname is bad */
 

--- a/source/components/namespace/nsutils.c
+++ b/source/components/namespace/nsutils.c
@@ -380,7 +380,6 @@ AcpiNsBuildInternalName (
     const char              *ExternalName = Info->NextExternalChar;
     char                    *Result = NULL;
     UINT32                  i;
-    char                    TmpSeg[ACPI_NAMESEG_SIZE+1];
 
 
     ACPI_FUNCTION_TRACE (NsBuildInternalName);
@@ -444,7 +443,6 @@ AcpiNsBuildInternalName (
 
     for (; NumSegments; NumSegments--)
     {
-        memset (TmpSeg, 0, ACPI_NAMESEG_SIZE+1);
         for (i = 0; i < ACPI_NAMESEG_SIZE; i++)
         {
             if (ACPI_IS_PATH_SEPARATOR (*ExternalName) ||
@@ -452,17 +450,16 @@ AcpiNsBuildInternalName (
             {
                 /* Pad the segment with underscore(s) if segment is short */
 
-                TmpSeg[i] = '_';
+                Result[i] = '_';
             }
             else
             {
                 /* Convert the character to uppercase and save it */
 
-                TmpSeg[i] = (char) toupper ((int) *ExternalName);
+                Result[i] = (char) toupper ((int) *ExternalName);
                 ExternalName++;
             }
         }
-    AcpiUtWriteUint (Result, ACPI_NAMESEG_SIZE, TmpSeg, ACPI_NAMESEG_SIZE);
 
         /* Now we must have a path separator, or the pathname is bad */
 

--- a/source/components/tables/tbprint.c
+++ b/source/components/tables/tbprint.c
@@ -152,6 +152,8 @@
 #include "acpi.h"
 #include "accommon.h"
 #include "actables.h"
+#include "platform/acenv.h"
+#include "acutils.h"
 
 #define _COMPONENT          ACPI_TABLES
         ACPI_MODULE_NAME    ("tbprint")
@@ -259,7 +261,7 @@ AcpiTbPrintTableHeader (
 
         ACPI_INFO (("%-4.4s 0x%8.8X%8.8X %06X",
             Header->Signature, ACPI_FORMAT_UINT64 (Address),
-            Header->Length));
+            AcpiUtReadUint32 (&Header->Length)));
     }
     else if (ACPI_VALIDATE_RSDP_SIG (Header->Signature))
     {
@@ -286,9 +288,12 @@ AcpiTbPrintTableHeader (
             "%-4.4s 0x%8.8X%8.8X"
             " %06X (v%.2d %-6.6s %-8.8s %08X %-4.4s %08X)",
             LocalHeader.Signature, ACPI_FORMAT_UINT64 (Address),
-            LocalHeader.Length, LocalHeader.Revision, LocalHeader.OemId,
-            LocalHeader.OemTableId, LocalHeader.OemRevision,
-            LocalHeader.AslCompilerId, LocalHeader.AslCompilerRevision));
+            AcpiUtReadUint32 (&LocalHeader.Length),
+            LocalHeader.Revision, LocalHeader.OemId,
+            LocalHeader.OemTableId,
+            AcpiUtReadUint32 (&LocalHeader.OemRevision),
+            LocalHeader.AslCompilerId,
+            AcpiUtReadUint32 (&LocalHeader.AslCompilerRevision)));
     }
 }
 

--- a/source/components/utilities/utendian.c
+++ b/source/components/utilities/utendian.c
@@ -1,0 +1,236 @@
+/******************************************************************************
+ *
+ * Module Name: utendian -- byte swapping support for other-endianness
+ *
+ *****************************************************************************/
+
+/*****************************************************************************
+ *
+ * Copyright (c) 2020, Al Stone <ahs3@redhat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions, and the following disclaimer,
+ *    without modification.
+ * 2. Redistributions in binary form must reproduce at minimum a disclaimer
+ *    substantially similar to the "NO WARRANTY" disclaimer below
+ *    ("Disclaimer") and any redistribution must be conditioned upon
+ *    including a substantially similar Disclaimer requirement for further
+ *    binary redistribution.
+ * 3. Neither the names of the above-listed copyright holders nor the names
+ *    of any contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * GNU General Public License ("GPL") version 2 as published by the Free
+ * Software Foundation.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+
+#define _COMPONENT          ACPI_COMPILER
+        ACPI_MODULE_NAME    ("utendian")
+
+/*
+ * Endianness support functions.
+ *
+ * Ultimately, everything in ACPI tables or AML must be in little-endian
+ * format.  However, we sometimes find it necessary to run on a big-endian
+ * machine and create or read those little-endian values.  This is a small
+ * libary of functions to make that easier, and more visible.
+ *
+ */
+
+/*******************************************************************************
+ *
+ * FUNCTION:    UtIsBigEndianMachine
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      TRUE if machine is big endian
+ *              FALSE if machine is little endian
+ *
+ * DESCRIPTION: Detect whether machine is little endian or big endian.
+ *
+ ******************************************************************************/
+
+UINT8
+UtIsBigEndianMachine (
+    void)
+{
+    union {
+        UINT32              Integer;
+        UINT8               Bytes[4];
+    } Overlay =                 {0xFF000000};
+
+
+    return (Overlay.Bytes[0]); /* Returns 0xFF (TRUE) for big endian */
+}
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiUtReadUint16
+ *
+ * PARAMETERS:  Src         - location containing the little-endian
+ *                                    value
+ *
+ * RETURN:      UINT16 value in host-native form
+ *
+ * DESCRIPTION: Read a UINT16 little-endian value from a given location
+ *              and return it in host-native form
+ *
+ ******************************************************************************/
+
+UINT16
+AcpiUtReadUint16 (
+    void                    *SrcPtr)
+{
+    UINT16                  Result = 0;
+    UINT8                   *Dst = (UINT8 *) &Result;
+    UINT8                   *Src = (UINT8 *) SrcPtr;
+
+    if (!UtIsBigEndianMachine())
+    {
+        return (*(UINT16 *) SrcPtr);
+    }
+
+    Dst[0] = Src[1];
+    Dst[1] = Src[0];
+
+    return (Result);
+}
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiUtReadUint32
+ *
+ * PARAMETERS:  Src         - location containing the little-endian
+ *                                    value
+ *
+ * RETURN:      UINT32 value in host-native form
+ *
+ * DESCRIPTION: Read a UINT32 little-endian value from a given location
+ *              and return it in host-native form
+ *
+ ******************************************************************************/
+
+UINT32
+AcpiUtReadUint32 (
+    void                    *SrcPtr)
+{
+    UINT32                  Result = 0;
+    UINT8                   *Dst = (UINT8 *) &Result;
+    UINT8                   *Src = (UINT8 *) SrcPtr;
+
+    if (!UtIsBigEndianMachine())
+    {
+        return (*(UINT32 *) SrcPtr);
+    }
+
+    Dst[0] = Src[3];
+    Dst[1] = Src[2];
+    Dst[2] = Src[1];
+    Dst[3] = Src[0];
+
+    return (Result);
+}
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiUtReadUint64
+ *
+ * PARAMETERS:  Src         - location containing the little-endian
+ *                                    value
+ *
+ * RETURN:      UINT64 value in host-native form
+ *
+ * DESCRIPTION: Read a UINT64 little-endian value from a given location
+ *              and return it in host-native form
+ *
+ ******************************************************************************/
+
+UINT64
+AcpiUtReadUint64 (
+    void                    *SrcPtr)
+{
+    UINT64                  Result = 0;
+    UINT8                   *Dst = (UINT8 *) &Result;
+    UINT8                   *Src = (UINT8 *) SrcPtr;
+
+    if (!UtIsBigEndianMachine())
+    {
+        return (*(UINT64 *) SrcPtr);
+    }
+
+    Dst[0] = Src[7];
+    Dst[1] = Src[6];
+    Dst[2] = Src[5];
+    Dst[3] = Src[4];
+    Dst[4] = Src[3];
+    Dst[5] = Src[2];
+    Dst[6] = Src[1];
+    Dst[7] = Src[0];
+
+    return (Result);
+}
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiUtWriteUint
+ *
+ * PARAMETERS:  DstPtr      - where to place the retrieved value
+ *              DstLength   - space in bytes for this int type
+ *              SrcPtr      - where the little-endian value lives
+ *              SrcLength   - space in bytes for this int type
+ *
+ * RETURN:      None.
+ *
+ * DESCRIPTION: Write a host-native integer value of the given size, and
+ *              store it in the location specified in little-endian form.
+ *              Given the amount of integer type casting done, this general
+ *              version seems the most useful (vs 32->32, 32->16, 16->32,
+ *              ad infinitum)
+ *
+ ******************************************************************************/
+
+void
+AcpiUtWriteUint (
+    void                    *DstPtr,
+    int                     DstLength,
+    const void              *SrcPtr,
+    const int               SrcLength)
+{
+    UINT8                   *Dst = (UINT8 *) DstPtr;
+    UINT8                   *Src = (UINT8 *) SrcPtr;
+    int                      Length;
+    int                      ii;
+
+    if (!UtIsBigEndianMachine())
+    {
+        Length = SrcLength > DstLength ? DstLength : SrcLength;
+        memcpy (Dst, Src, Length);
+	return;
+    }
+
+    Length = SrcLength >= DstLength ? DstLength : SrcLength;
+    for (ii = 0; ii < Length; ii++)
+        Dst[ii] = Src[SrcLength - ii - 1];
+
+}

--- a/source/components/utilities/utresrc.c
+++ b/source/components/utilities/utresrc.c
@@ -649,7 +649,7 @@ AcpiUtGetResourceLength (
     {
         /* Large Resource type -- bytes 1-2 contain the 16-bit length */
 
-        ACPI_MOVE_16_TO_16 (&ResourceLength, ACPI_ADD_PTR (UINT8, Aml, 1));
+        ResourceLength = AcpiUtReadUint16 (ACPI_ADD_PTR (UINT8, Aml, 1));
 
     }
     else

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -184,61 +184,6 @@
  * If the hardware supports the transfer of unaligned data, just do the store.
  * Otherwise, we have to move one byte at a time.
  */
-#ifdef ACPI_BIG_ENDIAN
-/*
- * Macros for big-endian machines
- */
-
-/* These macros reverse the bytes during the move, converting little-endian to big endian */
-
-                                                     /* Big Endian      <==        Little Endian */
-                                                     /*  Hi...Lo                     Lo...Hi     */
-/* 16-bit source, 16/32/64 destination */
-
-#define ACPI_MOVE_16_TO_16(d, s)        {((  UINT8 *)(void *)(d))[0] = ((UINT8 *)(void *)(s))[1];\
-                                         ((  UINT8 *)(void *)(d))[1] = ((UINT8 *)(void *)(s))[0];}
-
-#define ACPI_MOVE_16_TO_32(d, s)        {(*(UINT32 *)(void *)(d))=0;\
-                                           ((UINT8 *)(void *)(d))[2] = ((UINT8 *)(void *)(s))[1];\
-                                           ((UINT8 *)(void *)(d))[3] = ((UINT8 *)(void *)(s))[0];}
-
-#define ACPI_MOVE_16_TO_64(d, s)        {(*(UINT64 *)(void *)(d))=0;\
-                                           ((UINT8 *)(void *)(d))[6] = ((UINT8 *)(void *)(s))[1];\
-                                           ((UINT8 *)(void *)(d))[7] = ((UINT8 *)(void *)(s))[0];}
-
-/* 32-bit source, 16/32/64 destination */
-
-#define ACPI_MOVE_32_TO_16(d, s)        ACPI_MOVE_16_TO_16(d, s)    /* Truncate to 16 */
-
-#define ACPI_MOVE_32_TO_32(d, s)        {((  UINT8 *)(void *)(d))[0] = ((UINT8 *)(void *)(s))[3];\
-                                         ((  UINT8 *)(void *)(d))[1] = ((UINT8 *)(void *)(s))[2];\
-                                         ((  UINT8 *)(void *)(d))[2] = ((UINT8 *)(void *)(s))[1];\
-                                         ((  UINT8 *)(void *)(d))[3] = ((UINT8 *)(void *)(s))[0];}
-
-#define ACPI_MOVE_32_TO_64(d, s)        {(*(UINT64 *)(void *)(d))=0;\
-                                           ((UINT8 *)(void *)(d))[4] = ((UINT8 *)(void *)(s))[3];\
-                                           ((UINT8 *)(void *)(d))[5] = ((UINT8 *)(void *)(s))[2];\
-                                           ((UINT8 *)(void *)(d))[6] = ((UINT8 *)(void *)(s))[1];\
-                                           ((UINT8 *)(void *)(d))[7] = ((UINT8 *)(void *)(s))[0];}
-
-/* 64-bit source, 16/32/64 destination */
-
-#define ACPI_MOVE_64_TO_16(d, s)        ACPI_MOVE_16_TO_16(d, s)    /* Truncate to 16 */
-
-#define ACPI_MOVE_64_TO_32(d, s)        ACPI_MOVE_32_TO_32(d, s)    /* Truncate to 32 */
-
-#define ACPI_MOVE_64_TO_64(d, s)        {((  UINT8 *)(void *)(d))[0] = ((UINT8 *)(void *)(s))[7];\
-                                         ((  UINT8 *)(void *)(d))[1] = ((UINT8 *)(void *)(s))[6];\
-                                         ((  UINT8 *)(void *)(d))[2] = ((UINT8 *)(void *)(s))[5];\
-                                         ((  UINT8 *)(void *)(d))[3] = ((UINT8 *)(void *)(s))[4];\
-                                         ((  UINT8 *)(void *)(d))[4] = ((UINT8 *)(void *)(s))[3];\
-                                         ((  UINT8 *)(void *)(d))[5] = ((UINT8 *)(void *)(s))[2];\
-                                         ((  UINT8 *)(void *)(d))[6] = ((UINT8 *)(void *)(s))[1];\
-                                         ((  UINT8 *)(void *)(d))[7] = ((UINT8 *)(void *)(s))[0];}
-#else
-/*
- * Macros for little-endian machines
- */
 
 #ifndef ACPI_MISALIGNMENT_NOT_SUPPORTED
 
@@ -300,7 +245,6 @@
                                          ((  UINT8 *)(void *)(d))[5] = ((UINT8 *)(void *)(s))[5];\
                                          ((  UINT8 *)(void *)(d))[6] = ((UINT8 *)(void *)(s))[6];\
                                          ((  UINT8 *)(void *)(d))[7] = ((UINT8 *)(void *)(s))[7];}
-#endif
 #endif
 
 

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -1275,4 +1275,36 @@ AcpiUtConvertUuidToString (
     char                    *OutString);
 #endif
 
+
+/*
+ * utendian -- byte-swapping for big-endian support
+ */
+
+UINT8
+UtIsBigEndianMachine (
+    void);
+
+#if defined(ACPI_ASL_COMPILER) || defined(ACPI_EXEC_APP) || \
+    defined(ACPI_HELP_APP)     || defined(ACPI_DUMP_APP) || \
+    defined(ACPI_EXAMPLE_APP)  || defined(ACPI_BIN_APP)
+UINT32
+AcpiUtReadUint32 (
+    void                    *SrcPtr);
+
+UINT16
+AcpiUtReadUint16 (
+    void                    *SrcPtr);
+
+UINT64
+AcpiUtReadUint64 (
+    void                    *SrcPtr);
+
+void  
+AcpiUtWriteUint (
+    void                    *DstPtr,
+    int                     DstLength,
+    const void              *SrcPtr,
+    const int               SrcLength);
+#endif
+
 #endif /* _ACUTILS_H */

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -306,6 +306,7 @@
 
 #ifdef ACPI_USE_STANDARD_HEADERS
 #include <unistd.h>
+#include <endian.h>
 #endif
 
 /* Define/disable kernel-specific declarators */

--- a/source/tools/acpibin/abcompare.c
+++ b/source/tools/acpibin/abcompare.c
@@ -150,6 +150,7 @@
  *****************************************************************************/
 
 #include "acpibin.h"
+#include "acutils.h"
 
 
 ACPI_TABLE_HEADER           Header1;
@@ -287,14 +288,14 @@ AbPrintHeadersInfo (
     /* Display header information for both headers */
 
     printf ("Signature          %8.4s : %4.4s\n",    Header->Signature, Header2->Signature);
-    printf ("Length             %8.8X : %8.8X\n",    Header->Length, Header2->Length);
+    printf ("Length             %8.8X : %8.8X\n",    AcpiUtReadUint32 (&Header->Length), AcpiUtReadUint32 (&Header2->Length));
     printf ("Revision           %8.2X : %2.2X\n",    Header->Revision, Header2->Revision);
     printf ("Checksum           %8.2X : %2.2X\n",    Header->Checksum, Header2->Checksum);
     printf ("OEM ID             %8.6s : %.6s\n",     Header->OemId, Header2->OemId);
     printf ("OEM Table ID       %8.8s : %.8s\n",     Header->OemTableId, Header2->OemTableId);
-    printf ("OEM Revision       %8.8X : %8.8X\n",    Header->OemRevision, Header2->OemRevision);
+    printf ("OEM Revision       %8.8X : %8.8X\n",    AcpiUtReadUint32 (&Header->OemRevision), AcpiUtReadUint32 (&Header2->OemRevision));
     printf ("ASL Compiler ID    %8.4s : %.4s\n",     Header->AslCompilerId, Header2->AslCompilerId);
-    printf ("Compiler Revision  %8.8X : %8.8X\n",    Header->AslCompilerRevision, Header2->AslCompilerRevision);
+    printf ("Compiler Revision  %8.8X : %8.8X\n",    AcpiUtReadUint32 (&Header->AslCompilerRevision), AcpiUtReadUint32 (&Header2->AslCompilerRevision));
     printf ("\n");
 }
 


### PR DESCRIPTION
Let's try this a different way.  In prior attempts at providing support for big-endian systems, replacing macros was sort of working but it was getting very fragile as upstream code improved.  What this attempt does is reduce the functions needed to a a small handful constrained to a single file (source/components/utilities/utendian.c), and then make as few changes as possible elsewhere.  In general, we only had to change code when we actually had to read or write little-endian values to a file.

So, for example, AML code generation was pretty well contained whether assembling or disassembling.  For the static tables, most of the time very few lines needed changing.  The only places where things got a little weird was in handling all of the resource types in AML/ASL files; the patches to fix SSDT/DSDTs are the only really large ones as a result.

Even with the changes, what look like function calls basically turn into assignment statements on little-endian machines so in theory the only performance impact is when running on big-endian machines.

After all of these changes, ASLTS still passes all of the tests (big- or little-endian), and we always produce correct binary little-endian files regardless of where we are running (this was tested with ~2000 different ACPI binary tables of all types).

I know this is a lot to review.  Hopefully breaking this up into a lot of patches, each specific to a type of table, makes it a little simplet (most of the static table patches are very similar, for example).

Let me know if there are any questions.