### PR TITLE
Interpreter: fix memory leak by using use existing buffer in _HID repair

### DIFF
--- a/source/components/namespace/nspredef.c
+++ b/source/components/namespace/nspredef.c
@@ -223,13 +223,14 @@ AcpiNsCheckReturnValue (
     ACPI_STATUS                 Status;
     const ACPI_PREDEFINED_INFO  *Predefined;
 
+    ACPI_FUNCTION_TRACE (NsCheckReturnValue);
 
     /* If not a predefined name, we cannot validate the return object */
 
     Predefined = Info->Predefined;
     if (!Predefined)
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -239,7 +240,7 @@ AcpiNsCheckReturnValue (
     if ((ReturnStatus != AE_OK) &&
         (ReturnStatus != AE_CTRL_RETURN_VALUE))
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -259,7 +260,7 @@ AcpiNsCheckReturnValue (
         (!Predefined->Info.ExpectedBtypes) ||
         (Predefined->Info.ExpectedBtypes == ACPI_RTYPE_ALL))
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /*
@@ -325,7 +326,7 @@ Exit:
         Node->Flags |= ANOBJ_EVALUATED;
     }
 
-    return (Status);
+    return_ACPI_STATUS (Status);
 }
 
 

--- a/source/components/namespace/nsprepkg.c
+++ b/source/components/namespace/nsprepkg.c
@@ -214,7 +214,7 @@ AcpiNsCheckPackage (
     UINT32                      i;
 
 
-    ACPI_FUNCTION_NAME (NsCheckPackage);
+    ACPI_FUNCTION_TRACE (NsCheckPackage);
 
 
     /* The package info for this name is in the next table entry */
@@ -245,13 +245,13 @@ AcpiNsCheckPackage (
     {
         if (Package->RetInfo.Type == ACPI_PTYPE1_VAR)
         {
-            return (AE_OK);
+            return_ACPI_STATUS (AE_OK);
         }
 
         ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname, Info->NodeFlags,
             "Return Package has no elements (empty)"));
 
-        return (AE_AML_OPERAND_VALUE);
+        return_ACPI_STATUS (AE_AML_OPERAND_VALUE);
     }
 
     /*
@@ -305,7 +305,7 @@ AcpiNsCheckPackage (
                 Package->RetInfo.ObjectType1, i);
             if (ACPI_FAILURE (Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             Elements++;
@@ -338,7 +338,7 @@ AcpiNsCheckPackage (
                     Package->RetInfo3.ObjectType[i], i);
                 if (ACPI_FAILURE (Status))
                 {
-                    return (Status);
+                    return_ACPI_STATUS (Status);
                 }
             }
             else
@@ -349,7 +349,7 @@ AcpiNsCheckPackage (
                     Package->RetInfo3.TailObjectType, i);
                 if (ACPI_FAILURE (Status))
                 {
-                    return (Status);
+                    return_ACPI_STATUS (Status);
                 }
             }
 
@@ -365,7 +365,7 @@ AcpiNsCheckPackage (
             Info, Elements, ACPI_RTYPE_INTEGER, 0);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         Elements++;
@@ -384,7 +384,7 @@ AcpiNsCheckPackage (
             Info, Elements, ACPI_RTYPE_INTEGER, 0);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         /*
@@ -428,7 +428,7 @@ AcpiNsCheckPackage (
                 Info, ReturnObject, ReturnObjectPtr);
             if (ACPI_FAILURE (Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             /* Update locals to point to the new package (of 1 element) */
@@ -466,7 +466,7 @@ AcpiNsCheckPackage (
                 Package->RetInfo.ObjectType1, 0);
             if (ACPI_FAILURE(Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             /* Validate length of the UUID buffer */
@@ -475,14 +475,14 @@ AcpiNsCheckPackage (
             {
                 ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname,
                     Info->NodeFlags, "Invalid length for UUID Buffer"));
-                return (AE_AML_OPERAND_VALUE);
+                return_ACPI_STATUS (AE_AML_OPERAND_VALUE);
             }
 
             Status = AcpiNsCheckObjectType(Info, Elements + 1,
                 Package->RetInfo.ObjectType2, 0);
             if (ACPI_FAILURE(Status))
             {
-                return (Status);
+                return_ACPI_STATUS (Status);
             }
 
             Elements += 2;
@@ -498,10 +498,10 @@ AcpiNsCheckPackage (
             "Invalid internal return type in table entry: %X",
             Package->RetInfo.Type));
 
-        return (AE_AML_INTERNAL);
+        return_ACPI_STATUS (AE_AML_INTERNAL);
     }
 
-    return (Status);
+    return_ACPI_STATUS (Status);
 
 
 PackageTooSmall:
@@ -512,7 +512,7 @@ PackageTooSmall:
         "Return Package is too small - found %u elements, expected %u",
         Count, ExpectedCount));
 
-    return (AE_AML_OPERAND_VALUE);
+    return_ACPI_STATUS (AE_AML_OPERAND_VALUE);
 }
 
 
@@ -865,6 +865,8 @@ AcpiNsCheckPackageElements (
     UINT32                      i;
 
 
+    ACPI_FUNCTION_TRACE (NsCheckPackageElements);
+
     /*
      * Up to two groups of package elements are supported by the data
      * structure. All elements in each group must be of the same type.
@@ -876,7 +878,7 @@ AcpiNsCheckPackageElements (
             Type1, i + StartIndex);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         ThisElement++;
@@ -888,11 +890,11 @@ AcpiNsCheckPackageElements (
             Type2, (i + Count1 + StartIndex));
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         ThisElement++;
     }
 
-    return (AE_OK);
+    return_ACPI_STATUS (AE_OK);
 }

--- a/source/components/namespace/nsrepair2.c
+++ b/source/components/namespace/nsrepair2.c
@@ -690,9 +690,8 @@ AcpiNsRepair_HID (
     ACPI_OPERAND_OBJECT     **ReturnObjectPtr)
 {
     ACPI_OPERAND_OBJECT     *ReturnObject = *ReturnObjectPtr;
-    ACPI_OPERAND_OBJECT     *NewString;
-    char                    *Source;
     char                    *Dest;
+    char                    *Source;
 
 
     ACPI_FUNCTION_NAME (NsRepair_HID);
@@ -717,14 +716,6 @@ AcpiNsRepair_HID (
         return_ACPI_STATUS (AE_OK);
     }
 
-    /* It is simplest to always create a new string object */
-
-    NewString = AcpiUtCreateStringObject (ReturnObject->String.Length);
-    if (!NewString)
-    {
-        return_ACPI_STATUS (AE_NO_MEMORY);
-    }
-
     /*
      * Remove a leading asterisk if present. For some unknown reason, there
      * are many machines in the field that contains IDs like this.
@@ -735,7 +726,7 @@ AcpiNsRepair_HID (
     if (*Source == '*')
     {
         Source++;
-        NewString->String.Length--;
+        ReturnObject->String.Length--;
 
         ACPI_DEBUG_PRINT ((ACPI_DB_REPAIR,
             "%s: Removed invalid leading asterisk\n", Info->FullPathname));
@@ -749,13 +740,12 @@ AcpiNsRepair_HID (
      * "NNNN####" where N is an uppercase letter or decimal digit, and
      * # is a hex digit.
      */
-    for (Dest = NewString->String.Pointer; *Source; Dest++, Source++)
+    for (Dest = ReturnObject->String.Pointer; *Source; Dest++, Source++)
     {
         *Dest = (char) toupper ((int) *Source);
     }
+    ReturnObject->String.Pointer[ReturnObject->String.Length] = 0;
 
-    AcpiUtRemoveReference (ReturnObject);
-    *ReturnObjectPtr = NewString;
     return_ACPI_STATUS (AE_OK);
 }
 

--- a/source/components/namespace/nsrepair2.c
+++ b/source/components/namespace/nsrepair2.c
@@ -321,16 +321,18 @@ AcpiNsComplexRepairs (
     ACPI_STATUS             Status;
 
 
+    ACPI_FUNCTION_TRACE (NsComplexRepairs);
+
     /* Check if this name is in the list of repairable names */
 
     Predefined = AcpiNsMatchComplexRepair (Node);
     if (!Predefined)
     {
-        return (ValidateStatus);
+        return_ACPI_STATUS (ValidateStatus);
     }
 
     Status = Predefined->RepairFunction (Info, ReturnObjectPtr);
-    return (Status);
+    return_ACPI_STATUS (Status);
 }
 
 
@@ -526,20 +528,21 @@ AcpiNsRepair_CID (
     UINT16                  OriginalRefCount;
     UINT32                  i;
 
+    ACPI_FUNCTION_TRACE (NsRepair_CID);
 
     /* Check for _CID as a simple string */
 
     if (ReturnObject->Common.Type == ACPI_TYPE_STRING)
     {
         Status = AcpiNsRepair_HID (Info, ReturnObjectPtr);
-        return (Status);
+        return_ACPI_STATUS (Status);
     }
 
     /* Exit if not a Package */
 
     if (ReturnObject->Common.Type != ACPI_TYPE_PACKAGE)
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /* Examine each element of the _CID package */
@@ -553,7 +556,7 @@ AcpiNsRepair_CID (
         Status = AcpiNsRepair_HID (Info, ElementPtr);
         if (ACPI_FAILURE (Status))
         {
-            return (Status);
+            return_ACPI_STATUS (Status);
         }
 
         if (OriginalElement != *ElementPtr)
@@ -567,7 +570,7 @@ AcpiNsRepair_CID (
         ElementPtr++;
     }
 
-    return (AE_OK);
+    return_ACPI_STATUS (AE_OK);
 }
 
 
@@ -699,7 +702,7 @@ AcpiNsRepair_HID (
 
     if (ReturnObject->Common.Type != ACPI_TYPE_STRING)
     {
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     if (ReturnObject->String.Length == 0)
@@ -711,7 +714,7 @@ AcpiNsRepair_HID (
         /* Return AE_OK anyway, let driver handle it */
 
         Info->ReturnFlags |= ACPI_OBJECT_REPAIRED;
-        return (AE_OK);
+        return_ACPI_STATUS (AE_OK);
     }
 
     /* It is simplest to always create a new string object */
@@ -719,7 +722,7 @@ AcpiNsRepair_HID (
     NewString = AcpiUtCreateStringObject (ReturnObject->String.Length);
     if (!NewString)
     {
-        return (AE_NO_MEMORY);
+        return_ACPI_STATUS (AE_NO_MEMORY);
     }
 
     /*
@@ -753,7 +756,7 @@ AcpiNsRepair_HID (
 
     AcpiUtRemoveReference (ReturnObject);
     *ReturnObjectPtr = NewString;
-    return (AE_OK);
+    return_ACPI_STATUS (AE_OK);
 }
 
 


### PR DESCRIPTION
There was a memory leak that ocurred when a _CID object is defined as
a package containing string objects. When _CID is checked for any
possible repairs, it calls a helper function to repair _HID (because
_CID basically contains multiple _HID entries).

The _HID repair function assumes that string objects are standalone
objects that are not contained inside of any packages. The _HID
repair function replaces the string object with a brand new object
and attempts to delete the old object by decrementing the reference
count of the old object. Strings inside of packages have a reference
count of 2 so the _HID repair function leaves this object in a
dangling state and causes a memory leak.

Instead of allocating a brand new object and removing the old object,
use the existing object when repairing the _HID object.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>