### PR TITLE
Add non-clang CFLAGS only on non-clang compilers

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -227,22 +227,39 @@ CWARNINGFLAGS += \
     -Wold-style-definition\
     -Wno-format-nonliteral\
     -Wredundant-decls
-#
-# Per-host flags and exclusions
-#
-ifneq ($(ACPI_HOST), _FreeBSD)
-    CWARNINGFLAGS += \
-        -Wempty-body
 
-    ifneq ($(ACPI_HOST), _APPLE)
-        CWARNINGFLAGS += \
-            -Woverride-init\
-            -Wlogical-op\
-            -Wmissing-parameter-type\
-            -Wold-style-declaration\
-            -Wtype-limits
-    endif
-endif
+# output directory for tests below
+#
+# Taken from the Linux kernel
+TMPOUT = $(if $(KBUILD_EXTMOD),$(firstword $(KBUILD_EXTMOD))/).tmp_$$$$
+
+# try-run
+# Usage: option = $(call try-run, $(CC)...-o "$$TMP",option-ok,otherwise)
+# Exit code chooses option. "$$TMP" serves as a temporary file and is
+# automatically cleaned up.
+#
+# Taken from the Linux kernel
+try-run = $(shell set -e;		\
+	TMP=$(TMPOUT)/tmp;		\
+	TMPO=$(TMPOUT)/tmp.o;		\
+	mkdir -p $(TMPOUT);		\
+	trap "rm -rf $(TMPOUT)" EXIT;	\
+	if ($(1)) >/dev/null 2>&1;	\
+	then echo "$(2)";		\
+	else echo "$(3)";		\
+	fi)
+
+# Returns either the given flag if supported, or nothing
+#
+# Taken from the Linux kernel, but modified to fit our needs
+cc-option = $(call try-run, $(CC) -Werror $(1) -c -x c /dev/null -o "$$TMP",$(1),)
+
+CWARNINGFLAGS += $(call cc-option,-Wempty-body)
+CWARNINGFLAGS += $(call cc-option,-Wlogical-op)
+CWARNINGFLAGS += $(call cc-option,-Wmissing-parameter-type)
+CWARNINGFLAGS += $(call cc-option,-Wold-style-declaration)
+CWARNINGFLAGS += $(call cc-option,-Woverride-init)
+CWARNINGFLAGS += $(call cc-option,-Wtype-limits)
 
 #
 # Extra warning flags (for possible future use)


### PR DESCRIPTION
When using clang on Linux, the Makefile was passing unsupported flags to
the compiler. Fix this by only passing those unsupported by clang if
$(CC) is not clang.

I was not sure if the FreeBSD/Apple distinction is still wanted after this patch, but I left it in for now.