### PR TITLE
ACPICA: fix -Wfallthrough

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -1456,7 +1456,7 @@ AslIsExceptionDisabled (
         {
             return (TRUE);
         }
-        /* Fall through */
+        ACPI_FALLTHROUGH;
 
     case ASL_WARNING:
     case ASL_REMARK:

--- a/source/compiler/aslwalks.c
+++ b/source/compiler/aslwalks.c
@@ -516,7 +516,7 @@ AnOperandTypecheckWalkEnd (
                     break;
                 }
 
-            /* Fallthrough */
+                ACPI_FALLTHROUGH;
 
             case ARGI_STORE_TARGET:
 

--- a/source/compiler/dtfield.c
+++ b/source/compiler/dtfield.c
@@ -227,7 +227,7 @@ DtCompileOneField (
             break;
         }
 
-        /* Fall through. */
+        ACPI_FALLTHROUGH;
 
     case DT_FIELD_TYPE_BUFFER:
 

--- a/source/components/disassembler/dmwalk.c
+++ b/source/components/disassembler/dmwalk.c
@@ -400,7 +400,7 @@ AcpiDmBlockType (
             return (BLOCK_NONE);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case AML_PACKAGE_OP:
     case AML_VARIABLE_PACKAGE_OP:
@@ -422,7 +422,7 @@ AcpiDmBlockType (
             return (BLOCK_NONE);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     default:
 
@@ -688,7 +688,7 @@ AcpiDmDescendingOp (
                 return (AE_OK);
             }
 
-            /* Fallthrough */
+            ACPI_FALLTHROUGH;
 
         default:
 
@@ -772,7 +772,7 @@ AcpiDmDescendingOp (
                 AcpiDmNamestring (NextOp->Common.Value.Name);
                 AcpiOsPrintf (", ");
 
-                /*lint -fallthrough */
+                ACPI_FALLTHROUGH;
 
             default:
 

--- a/source/components/dispatcher/dscontrol.c
+++ b/source/components/dispatcher/dscontrol.c
@@ -210,7 +210,7 @@ AcpiDsExecBeginControlOp (
             }
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case AML_IF_OP:
         /*

--- a/source/components/dispatcher/dswexec.c
+++ b/source/components/dispatcher/dswexec.c
@@ -772,8 +772,7 @@ AcpiDsExecEndOp (
                     break;
                 }
 
-                /* Fall through */
-                /*lint -fallthrough */
+                ACPI_FALLTHROUGH;
 
             case AML_INT_EVAL_SUBTREE_OP:
 

--- a/source/components/dispatcher/dswload.c
+++ b/source/components/dispatcher/dswload.c
@@ -375,7 +375,7 @@ AcpiDsLoad1BeginOp (
                 break;
             }
 
-            /*lint -fallthrough */
+            ACPI_FALLTHROUGH;
 
         default:
 

--- a/source/components/dispatcher/dswload2.c
+++ b/source/components/dispatcher/dswload2.c
@@ -366,7 +366,7 @@ AcpiDsLoad2BeginOp (
                 break;
             }
 
-            /*lint -fallthrough */
+            ACPI_FALLTHROUGH;
 
         default:
 

--- a/source/components/executer/exfldio.c
+++ b/source/components/executer/exfldio.c
@@ -616,7 +616,7 @@ AcpiExFieldDatumIo (
          * RegionField case and write the datum to the Operation Region
          */
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case ACPI_TYPE_LOCAL_REGION_FIELD:
         /*

--- a/source/components/executer/exresop.c
+++ b/source/components/executer/exresop.c
@@ -358,7 +358,7 @@ AcpiExResolveOperands (
 
                     TargetOp = AML_DEBUG_OP;
 
-                    /*lint -fallthrough */
+                    ACPI_FALLTHROUGH;
 
                 case ACPI_REFCLASS_ARG:
                 case ACPI_REFCLASS_LOCAL:
@@ -422,7 +422,7 @@ AcpiExResolveOperands (
              * Else not a string - fall through to the normal Reference
              * case below
              */
-            /*lint -fallthrough */
+            ACPI_FALLTHROUGH;
 
         case ARGI_REFERENCE:            /* References: */
         case ARGI_INTEGER_REF:

--- a/source/components/executer/exstore.c
+++ b/source/components/executer/exstore.c
@@ -248,7 +248,7 @@ AcpiExStore (
             return_ACPI_STATUS (AE_OK);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     default:
 
@@ -585,7 +585,7 @@ AcpiExStoreObjectToNode (
                 break;
             }
 
-        /* Fallthrough */
+            ACPI_FALLTHROUGH;
 
         case ACPI_TYPE_DEVICE:
         case ACPI_TYPE_EVENT:

--- a/source/components/hardware/hwgpe.c
+++ b/source/components/hardware/hwgpe.c
@@ -254,7 +254,7 @@ AcpiHwLowSetGpe (
             return (AE_BAD_PARAMETER);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case ACPI_GPE_ENABLE:
 

--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -266,7 +266,7 @@ AcpiUtDeleteInternalObj (
             (void) AcpiEvDeleteGpeBlock (Object->Device.GpeBlock);
         }
 
-        /*lint -fallthrough */
+        ACPI_FALLTHROUGH;
 
     case ACPI_TYPE_PROCESSOR:
     case ACPI_TYPE_THERMAL:

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1537,5 +1537,10 @@ typedef enum
 
 #define ACPI_OPT_END                    -1
 
+/* Definitions for explicit fallthrough */
+
+#ifndef ACPI_FALLTHROUGH
+#define ACPI_FALLTHROUGH do {} while(0)
+#endif
 
 #endif /* __ACTYPES_H__ */

--- a/source/include/platform/acgcc.h
+++ b/source/include/platform/acgcc.h
@@ -196,4 +196,19 @@ typedef __builtin_va_list       va_list;
 
 #define ACPI_USE_NATIVE_MATH64
 
+/* GCC did not support __has_attribute until 5.1. */
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+/*
+ * Explictly mark intentional explicit fallthrough to silence
+ * -Wimplicit-fallthrough in GCC 7.1+.
+ */
+
+#if __has_attribute(__fallthrough__)
+#define ACPI_FALLTHROUGH __attribute__((__fallthrough__))
+#endif
+
 #endif /* __ACGCC_H__ */

--- a/source/tools/acpibin/abmain.c
+++ b/source/tools/acpibin/abmain.c
@@ -234,7 +234,7 @@ main (
 
         AbGbl_DisplayAllMiscompares = TRUE;
 
-        /* Fallthrough */
+        ACPI_FALLTHROUGH;
 
     case 'c':   /* Compare Files */
 

--- a/source/tools/acpihelp/ahdecode.c
+++ b/source/tools/acpihelp/ahdecode.c
@@ -386,7 +386,7 @@ AhDoSpecialNames (
             }
         }
 
-        /* Fallthrough */
+        ACPI_FALLTHROUGH;
 
     case 'L':
     case 'Q':


### PR DESCRIPTION
GCC 7.1 gained -Wimplicit-fallthrough to warn on implicit fallthrough,
as well as __attribute__((__fallthrough__)) and comments to explicitly
denote that cases of fallthrough were intentional. Clang also supports
this warning and statement attribute, but not the comment form.

Robert Moore provides additional context about the lint comments being
removed. They were for "an old version of PC-Lint, which we don't use
anymore." Drop those.

This will help us enable -Wimplicit-fallthrough throughout the Linux
kernel.

Suggested-by: Robert Moore <robert.moore@intel.com>
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>