### PR TITLE
Do not attempt to delete an already deleted object

### DIFF
--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -592,9 +592,9 @@ AcpiUtUpdateRefCount (
             "%s: Obj %p Type %.2X Refs %.2X [Decremented]\n",
             ACPI_GET_FUNCTION_NAME, Object, Object->Common.Type, NewCount));
 
-        /* Actually delete the object on a reference count of zero */
+        /* If we haven't already, actually delete the object on a reference count of zero */
 
-        if (NewCount == 0)
+        if (NewCount == 0 && OriginalCount != 0)
         {
             AcpiUtDeleteInternalObj (Object);
         }


### PR DESCRIPTION
The first trip into AcpiUtUpdateRefCount() for an Object with a
reference count of 1 where 'Action==REF_DECREMENT' will result in an
'OriginalCount' of 1 'NewCount' being 0 and thus the object is deleted
via AcpiUtDeleteInternalObj().

If for some reason we make a subsequent trip into
AcpiUtUpdateRefCount() with the same Object, which will now have a
reference count of 0, and again where 'Action==REF_DECREMENT', this
will result in a 'OriginalCount' of 0 and a 'NewCount' of 0. This
condition is currently caught by a check for '!OriginalCount' that
will emit a warning, however, a few lines of code later a second call
to AcpiUtDeleteInternalObj() will be made on the already deleted
object.

On some OSes this second delete can cause issues as the underlying
memory used by the Object may already be in use again after the first
time the object was deleted.

Similar to the logic used to throw the warning, here we are adding a
check to ensure we are only deleting the object the first time the
reference count hits 0 and skipping the call to
AcpiUtDeleteInternalObj() otherwise.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>