### PR TITLE
Fix UB from arithmetic with null pointer

### DIFF
--- a/source/components/dispatcher/dswstate.c
+++ b/source/components/dispatcher/dswstate.c
@@ -787,7 +787,7 @@ AcpiDsInitAmlWalk (
     WalkState->ParserState.Aml =
     WalkState->ParserState.AmlStart = AmlStart;
     WalkState->ParserState.AmlEnd =
-    WalkState->ParserState.PkgEnd = AmlStart + AmlLength;
+    WalkState->ParserState.PkgEnd = AmlStart ? AmlStart + AmlLength : NULL;
 
     /* The NextOp of the NextWalk will be the beginning of the method */
 


### PR DESCRIPTION
If AmlStart is null then AmlStart + AmlLength is technically undefined
behavior. I saw this when running UBSAN with this code. If AmlStart is
null then end should be null as well.