### PR TITLE
improve method call analysis

### DIFF
--- a/source/compiler/aslanalyze.c
+++ b/source/compiler/aslanalyze.c
@@ -470,7 +470,7 @@ AnCheckMethodReturnValue (
                 "Method returns [%s], %s operator requires [%s]",
                 AslGbl_StringBuffer, OpInfo->Name, AslGbl_StringBuffer2);
 
-            AslError (ASL_ERROR, ASL_MSG_INVALID_TYPE, ArgOp, AslGbl_MsgBuffer);
+            AslError (ASL_WARNING, ASL_MSG_INVALID_TYPE, ArgOp, AslGbl_MsgBuffer);
         }
     }
 

--- a/source/compiler/aslmethod.c
+++ b/source/compiler/aslmethod.c
@@ -288,6 +288,7 @@ MtMethodAnalysisWalkBegin (
         NextType = Next->Asl.Child;
 
         MethodInfo->ValidReturnTypes = MtProcessTypeOp (NextType);
+        Op->Asl.AcpiBtype |= MethodInfo->ValidReturnTypes;
 
         /* Get the ParameterType node */
 


### PR DESCRIPTION
This pull request adds improvement to method call analysis by saving the btype in the parse node and relaxing certain cases of type checking