### PR TITLE
Possible index out of range when resolving operands

### DIFF
--- a/source/components/dispatcher/dswexec.c
+++ b/source/components/dispatcher/dswexec.c
@@ -575,9 +575,11 @@ AcpiDsExecEndOp (
         {
             /* Resolve all operands */
 
-            Status = AcpiExResolveOperands (WalkState->Opcode,
-                &(WalkState->Operands [WalkState->NumOperands -1]),
-                WalkState);
+	    Status = AE_OK;
+	    if (WalkState->NumOperands > 0)
+            	Status = AcpiExResolveOperands (WalkState->Opcode,
+                	 &(WalkState->Operands [WalkState->NumOperands -1]),
+                	 WalkState);
         }
 
         if (ACPI_SUCCESS (Status))


### PR DESCRIPTION
UBSAN in the Linux kernel reports the following:

UBSAN: Undefined behaviour in drivers/acpi/acpica/dswexec.c:394:12

The line number does not match upstream due the age of the version
of ACPICA in use.  However, that turns out to be these lines:

            Status = AcpiExResolveOperands (WalkState->Opcode,
                &(WalkState->Operands [WalkState->NumOperands -1]),
                WalkState);

When WalkState->NumOperands is used, if by any chance it is zero,
we will end up with an index of (-1) into WalkState->Operands, which
is incorrect.  Put a check around this so that if for some reason
we do end up with zero operands, we do not try to resolve things
that do not exist.

Signed-off-by: Al Stone <ahs3@redhat.com>