### PR TITLE
Generic serial bus race fix

### DIFF
--- a/source/components/events/evhandler.c
+++ b/source/components/events/evhandler.c
@@ -677,6 +677,13 @@ AcpiEvInstallSpaceHandler (
 
     /* Init handler obj */
 
+    Status = AcpiOsCreateMutex (&HandlerObj->AddressSpace.ContextMutex);
+    if (ACPI_FAILURE (Status))
+    {
+        AcpiUtRemoveReference (HandlerObj);
+        goto UnlockAndExit;
+    }
+
     HandlerObj->AddressSpace.SpaceId = (UINT8) SpaceId;
     HandlerObj->AddressSpace.HandlerFlags = Flags;
     HandlerObj->AddressSpace.RegionList = NULL;

--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -270,6 +270,8 @@ AcpiEvAddressSpaceDispatch (
     ACPI_OPERAND_OBJECT     *RegionObj2;
     void                    *RegionContext = NULL;
     ACPI_CONNECTION_INFO    *Context;
+    ACPI_MUTEX              ContextMutex;
+    BOOLEAN                 ContextLocked;
     ACPI_PHYSICAL_ADDRESS   Address;
 
 
@@ -296,6 +298,8 @@ AcpiEvAddressSpaceDispatch (
     }
 
     Context = HandlerDesc->AddressSpace.Context;
+    ContextMutex = HandlerDesc->AddressSpace.ContextMutex;
+    ContextLocked = FALSE;
 
     /*
      * It may be the case that the region has never been initialized.
@@ -362,43 +366,6 @@ AcpiEvAddressSpaceDispatch (
     Handler = HandlerDesc->AddressSpace.Handler;
     Address = (RegionObj->Region.Address + RegionOffset);
 
-    /*
-     * Special handling for GenericSerialBus and GeneralPurposeIo:
-     * There are three extra parameters that must be passed to the
-     * handler via the context:
-     *   1) Connection buffer, a resource template from Connection() op
-     *   2) Length of the above buffer
-     *   3) Actual access length from the AccessAs() op
-     *
-     * In addition, for GeneralPurposeIo, the Address and BitWidth fields
-     * are defined as follows:
-     *   1) Address is the pin number index of the field (bit offset from
-     *      the previous Connection)
-     *   2) BitWidth is the actual bit length of the field (number of pins)
-     */
-    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GSBUS) &&
-        Context &&
-        FieldObj)
-    {
-        /* Get the Connection (ResourceTemplate) buffer */
-
-        Context->Connection = FieldObj->Field.ResourceBuffer;
-        Context->Length = FieldObj->Field.ResourceLength;
-        Context->AccessLength = FieldObj->Field.AccessLength;
-    }
-    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GPIO) &&
-        Context &&
-        FieldObj)
-    {
-        /* Get the Connection (ResourceTemplate) buffer */
-
-        Context->Connection = FieldObj->Field.ResourceBuffer;
-        Context->Length = FieldObj->Field.ResourceLength;
-        Context->AccessLength = FieldObj->Field.AccessLength;
-        Address = FieldObj->Field.PinNumberIndex;
-        BitWidth = FieldObj->Field.BitLength;
-    }
-
     ACPI_DEBUG_PRINT ((ACPI_DB_OPREGION,
         "Handler %p (@%p) Address %8.8X%8.8X [%s]\n",
         &RegionObj->Region.Handler->AddressSpace, Handler,
@@ -416,10 +383,75 @@ AcpiEvAddressSpaceDispatch (
         AcpiExExitInterpreter();
     }
 
+    /*
+     * Special handling for GenericSerialBus and GeneralPurposeIo:
+     * There are three extra parameters that must be passed to the
+     * handler via the context:
+     *   1) Connection buffer, a resource template from Connection() op
+     *   2) Length of the above buffer
+     *   3) Actual access length from the AccessAs() op
+     *
+     * Since we pass these extra parameters via the context, which is
+     * shared between threads, we must lock the context to avoid these
+     * parameters being changed from another thread before the handler
+     * has completed running.
+     *
+     * In addition, for GeneralPurposeIo, the Address and BitWidth fields
+     * are defined as follows:
+     *   1) Address is the pin number index of the field (bit offset from
+     *      the previous Connection)
+     *   2) BitWidth is the actual bit length of the field (number of pins)
+     */
+    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GSBUS) &&
+        Context &&
+        FieldObj)
+    {
+
+        Status = AcpiOsAcquireMutex (ContextMutex, ACPI_WAIT_FOREVER);
+        if (ACPI_FAILURE (Status))
+        {
+            goto ReEnterInterpreter;
+        }
+
+        ContextLocked = TRUE;
+
+        /* Get the Connection (ResourceTemplate) buffer */
+
+        Context->Connection = FieldObj->Field.ResourceBuffer;
+        Context->Length = FieldObj->Field.ResourceLength;
+        Context->AccessLength = FieldObj->Field.AccessLength;
+    }
+    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GPIO) &&
+        Context &&
+        FieldObj)
+    {
+
+        Status = AcpiOsAcquireMutex (ContextMutex, ACPI_WAIT_FOREVER);
+        if (ACPI_FAILURE (Status))
+        {
+            goto ReEnterInterpreter;
+        }
+
+        ContextLocked = TRUE;
+
+        /* Get the Connection (ResourceTemplate) buffer */
+
+        Context->Connection = FieldObj->Field.ResourceBuffer;
+        Context->Length = FieldObj->Field.ResourceLength;
+        Context->AccessLength = FieldObj->Field.AccessLength;
+        Address = FieldObj->Field.PinNumberIndex;
+        BitWidth = FieldObj->Field.BitLength;
+    }
+
     /* Call the handler */
 
     Status = Handler (Function, Address, BitWidth, Value, Context,
         RegionObj2->Extra.RegionContext);
+
+    if (ContextLocked)
+    {
+        AcpiOsReleaseMutex (ContextMutex);
+    }
 
     if (ACPI_FAILURE (Status))
     {
@@ -438,6 +470,7 @@ AcpiEvAddressSpaceDispatch (
         }
     }
 
+ReEnterInterpreter:
     if (!(HandlerDesc->AddressSpace.HandlerFlags &
         ACPI_ADDR_HANDLER_DEFAULT_INSTALLED))
     {

--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -402,7 +402,8 @@ AcpiEvAddressSpaceDispatch (
      *      the previous Connection)
      *   2) BitWidth is the actual bit length of the field (number of pins)
      */
-    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GSBUS) &&
+    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GSBUS ||
+         RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GPIO) &&
         Context &&
         FieldObj)
     {
@@ -420,27 +421,12 @@ AcpiEvAddressSpaceDispatch (
         Context->Connection = FieldObj->Field.ResourceBuffer;
         Context->Length = FieldObj->Field.ResourceLength;
         Context->AccessLength = FieldObj->Field.AccessLength;
-    }
-    if ((RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GPIO) &&
-        Context &&
-        FieldObj)
-    {
 
-        Status = AcpiOsAcquireMutex (ContextMutex, ACPI_WAIT_FOREVER);
-        if (ACPI_FAILURE (Status))
+        if (RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GPIO)
         {
-            goto ReEnterInterpreter;
+            Address = FieldObj->Field.PinNumberIndex;
+            BitWidth = FieldObj->Field.BitLength;
         }
-
-        ContextLocked = TRUE;
-
-        /* Get the Connection (ResourceTemplate) buffer */
-
-        Context->Connection = FieldObj->Field.ResourceBuffer;
-        Context->Length = FieldObj->Field.ResourceLength;
-        Context->AccessLength = FieldObj->Field.AccessLength;
-        Address = FieldObj->Field.PinNumberIndex;
-        BitWidth = FieldObj->Field.BitLength;
     }
 
     /* Call the handler */

--- a/source/components/events/evxfregn.c
+++ b/source/components/events/evxfregn.c
@@ -362,6 +362,7 @@ AcpiRemoveAddressSpaceHandler (
 
             /* Now we can delete the handler object */
 
+            AcpiOsReleaseMutex (HandlerObj->AddressSpace.ContextMutex);
             AcpiUtRemoveReference (HandlerObj);
             goto UnlockAndExit;
         }

--- a/source/include/acobject.h
+++ b/source/include/acobject.h
@@ -521,6 +521,7 @@ typedef struct acpi_object_addr_handler
     ACPI_ADR_SPACE_HANDLER          Handler;
     ACPI_NAMESPACE_NODE             *Node;              /* Parent device */
     void                            *Context;
+    ACPI_MUTEX                      ContextMutex;
     ACPI_ADR_SPACE_SETUP            Setup;
     union acpi_operand_object       *RegionList;        /* Regions using this handler */
     union acpi_operand_object       *Next;


### PR DESCRIPTION
The handling of the GenericSerialBus (I2C) and GPIO OpRegions in AcpiEvAddressSpaceDispatch() passes a number of extra parameters to the address-space handler through the address-space Context pointer (instead of using more function parameters).

The Context is shared between threads, so if multiple threads try to call the handler for the same address-space at the same time, then a second thread could change the parameters of a first thread while the handler is running for the first thread.

An example of this race hitting is the Lenovo Yoga Tablet2 1015L, where there are both AttribBytes accesses and AttribByte accesses to the same address-space. The AttribBytes access stores the number of bytes to transfer in Context->AccessLength. Where as for the AttribByte access the number of bytes to transfer is always 1 and FieldObj->Field.AccessLength is unused (so 0). Both types of accesses racing from different threads leads to the following problem:

1. Thread a. starts an AttribBytes access, stores a non 0 value from FieldObj->Field.AccessLength in Context->AccessLength
2. Thread b. starts an AttribByte access, stores 0 in Context->AccessLength
3. Thread a. calls i2c_acpi_space_handler() (under Linux). Which sees that the access-type is ACPI_GSB_ACCESS_ATTRIB_MULTIBYTE and calls acpi_gsb_i2c_read_bytes(..., Context->AccessLength)
4. At this point Context->AccessLength is 0 (set by thread b.) rather then the FieldObj->Field.AccessLength value from thread a. This 0 length reads leads to the following errors being logged:

```
 i2c i2c-0: adapter quirk: no zero length (addr 0x0078, size 0, read)
 i2c i2c-0: i2c read 0 bytes from client@0x78 starting at reg 0x0 failed, error: -95

```
Note this is just an example of the problems which this race can cause. There are likely many more (sporadic) problems caused by this race.

This commit adds a new ContextMutex to acpi_object_addr_handler and makes AcpiEvAddressSpaceDispatch() take that mutex when using the shared Context to pass extra parameters to an address-space handler, fixing this race.

Note the new mutex must be taken *after* exiting the interpreter, therefor the existing AcpiExExitInterpreter() call is moved to above the code which stores the extra parameters in the Context.