### PR TITLE
Common: Fix a typo

### DIFF
--- a/source/common/cmfsize.c
+++ b/source/common/cmfsize.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Module Name: cfsize - Common get file size function
+ * Module Name: cmfsize - Common get file size function
  *
  *****************************************************************************/
 


### PR DESCRIPTION
This module is 'cmfsize', not 'cfsize'.
Fix it.

Signed-off-by: Christophe JAILLET <christophe.jaillet@wanadoo.fr>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>