### PR TITLE
Revert "Interpreter: fix memory leak by using use existing buffer in …

### DIFF
--- a/source/components/namespace/nsrepair2.c
+++ b/source/components/namespace/nsrepair2.c
@@ -690,8 +690,9 @@ AcpiNsRepair_HID (
     ACPI_OPERAND_OBJECT     **ReturnObjectPtr)
 {
     ACPI_OPERAND_OBJECT     *ReturnObject = *ReturnObjectPtr;
-    char                    *Dest;
+    ACPI_OPERAND_OBJECT     *NewString;
     char                    *Source;
+    char                    *Dest;
 
 
     ACPI_FUNCTION_NAME (NsRepair_HID);
@@ -716,6 +717,14 @@ AcpiNsRepair_HID (
         return_ACPI_STATUS (AE_OK);
     }
 
+    /* It is simplest to always create a new string object */
+
+    NewString = AcpiUtCreateStringObject (ReturnObject->String.Length);
+    if (!NewString)
+    {
+        return_ACPI_STATUS (AE_NO_MEMORY);
+    }
+
     /*
      * Remove a leading asterisk if present. For some unknown reason, there
      * are many machines in the field that contains IDs like this.
@@ -726,7 +735,7 @@ AcpiNsRepair_HID (
     if (*Source == '*')
     {
         Source++;
-        ReturnObject->String.Length--;
+        NewString->String.Length--;
 
         ACPI_DEBUG_PRINT ((ACPI_DB_REPAIR,
             "%s: Removed invalid leading asterisk\n", Info->FullPathname));
@@ -740,12 +749,13 @@ AcpiNsRepair_HID (
      * "NNNN####" where N is an uppercase letter or decimal digit, and
      * # is a hex digit.
      */
-    for (Dest = ReturnObject->String.Pointer; *Source; Dest++, Source++)
+    for (Dest = NewString->String.Pointer; *Source; Dest++, Source++)
     {
         *Dest = (char) toupper ((int) *Source);
     }
-    ReturnObject->String.Pointer[ReturnObject->String.Length] = 0;
 
+    AcpiUtRemoveReference (ReturnObject);
+    *ReturnObjectPtr = NewString;
     return_ACPI_STATUS (AE_OK);
 }
 


### PR DESCRIPTION
…_HID repair"

This reverts commit 52d1da5dcbd79a722b70f02a1a83f04088f51ff6.

The 'exisitng buffer' in this case is the firmware provided table, and
we should not modify that in place. This fixes a crash on arm64 with
initrd table overrides, in which case the DSDT is not mapped with
read/write permissions.

Cc: Robert Moore <robert.moore@intel.com>
Cc: Erik Kaneda <erik.kaneda@intel.com>
Cc: "Rafael J. Wysocki" <rafael.j.wysocki@intel.com>
Cc: Len Brown <lenb@kernel.org>
Reported-by: Shawn Guo <shawn.guo@linaro.org>
Signed-off-by: Ard Biesheuvel <ardb@kernel.org>