### PR TITLE
Revert "Merge pull request #663 from SchmErik/ghi-659"

### DIFF
--- a/source/compiler/aslexternal.c
+++ b/source/compiler/aslexternal.c
@@ -282,57 +282,6 @@ ExDoExternal (
 
 /*******************************************************************************
  *
- * FUNCTION:    ExFindUnvisitedExternal
- *
- * PARAMETERS:  Name             - Name to find in the external list
- *
- * RETURN:      ACPI_PARSE_OBJECT
- *
- * DESCRIPTION: Find an entry in the external list that matches the Name
- *              argument
- *
- ******************************************************************************/
-
-static ACPI_PARSE_OBJECT *
-ExFindUnvisitedExternal (
-    char                    *Name)
-{
-    ACPI_PARSE_OBJECT       *Current;
-    ACPI_PARSE_OBJECT       *NameOp;
-    char                    *ExternalName;
-
-
-    Current = AslGbl_ExternalsListHead;
-    while (Current)
-    {
-        /* Skip if External node already handled */
-
-        if (Current->Asl.Child->Asl.CompileFlags & OP_VISITED)
-        {
-            Current = Current->Asl.Next;
-            continue;
-        }
-
-        NameOp = Current->Asl.Child->Asl.Child;
-        ExternalName = AcpiNsGetNormalizedPathname (NameOp->Asl.Node, TRUE);
-        if (strcmp (Name, ExternalName))
-        {
-            ACPI_FREE (ExternalName);
-            Current = Current->Asl.Next;
-            continue;
-        }
-        else
-        {
-            ACPI_FREE (ExternalName);
-            return Current;
-        }
-    }
-    return NULL;
-}
-
-
-/*******************************************************************************
- *
  * FUNCTION:    ExInsertArgCount
  *
  * PARAMETERS:  Op              - Op for a method invocation
@@ -352,6 +301,7 @@ ExInsertArgCount (
     ACPI_PARSE_OBJECT       *NameOp;
     ACPI_PARSE_OBJECT       *Child;
     ACPI_PARSE_OBJECT       *ArgCountOp;
+    char *                  ExternalName;
     char *                  CallName;
     UINT16                  ArgCount = 0;
     ACPI_STATUS             Status;
@@ -359,45 +309,64 @@ ExInsertArgCount (
 
     CallName = AcpiNsGetNormalizedPathname (Op->Asl.Node, TRUE);
 
-    Next = ExFindUnvisitedExternal (CallName);
-    if (!Next)
+    Next = AslGbl_ExternalsListHead;
+    while (Next)
     {
-       goto Cleanup;
+        ArgCount = 0;
+
+        /* Skip if External node already handled */
+
+        if (Next->Asl.Child->Asl.CompileFlags & OP_VISITED)
+        {
+            Next = Next->Asl.Next;
+            continue;
+        }
+
+        NameOp = Next->Asl.Child->Asl.Child;
+        ExternalName = AcpiNsGetNormalizedPathname (NameOp->Asl.Node, TRUE);
+
+        if (strcmp (CallName, ExternalName))
+        {
+            ACPI_FREE (ExternalName);
+            Next = Next->Asl.Next;
+            continue;
+        }
+
+        Next->Asl.Child->Asl.CompileFlags |= OP_VISITED;
+
+        /*
+         * Since we will reposition Externals to the Root, set Namepath
+         * to the fully qualified name and recalculate the aml length
+         */
+        Status = UtInternalizeName (ExternalName,
+            &NameOp->Asl.Value.String);
+
+        ACPI_FREE (ExternalName);
+        if (ACPI_FAILURE (Status))
+        {
+            AslError (ASL_ERROR, ASL_MSG_COMPILER_INTERNAL,
+                NULL, "- Could not Internalize External");
+            break;
+        }
+
+        NameOp->Asl.AmlLength = strlen (NameOp->Asl.Value.String);
+
+        /* Get argument count */
+
+        Child = Op->Asl.Child;
+        while (Child)
+        {
+            ArgCount++;
+            Child = Child->Asl.Next;
+        }
+
+        /* Setup ArgCount operand */
+
+        ArgCountOp = Next->Asl.Child->Asl.Child->Asl.Next->Asl.Next;
+        ArgCountOp->Asl.Value.Integer = ArgCount;
+        break;
     }
 
-    Next->Asl.Child->Asl.CompileFlags |= OP_VISITED;
-    NameOp = Next->Asl.Child->Asl.Child;
-
-    /*
-     * Since we will reposition Externals to the Root, set Namepath
-     * to the fully qualified name and recalculate the aml length
-     */
-    Status = UtInternalizeName (CallName,
-        &NameOp->Asl.Value.String);
-    if (ACPI_FAILURE (Status))
-    {
-        AslError (ASL_ERROR, ASL_MSG_COMPILER_INTERNAL,
-            NULL, "- Could not Internalize External");
-        goto Cleanup;
-    }
-
-    NameOp->Asl.AmlLength = strlen (NameOp->Asl.Value.String);
-
-    /* Get argument count */
-
-    Child = Op->Asl.Child;
-    while (Child)
-    {
-        ArgCount++;
-        Child = Child->Asl.Next;
-    }
-
-    /* Setup ArgCount operand */
-
-    ArgCountOp = Next->Asl.Child->Asl.Child->Asl.Next->Asl.Next;
-    ArgCountOp->Asl.Value.Integer = ArgCount;
-
-Cleanup:
     ACPI_FREE (CallName);
 }
 
@@ -420,9 +389,6 @@ ExAmlExternalWalkBegin (
     UINT32                  Level,
     void                    *Context)
 {
-    ACPI_PARSE_OBJECT       *ExternalListOp;
-    char                    *Name;
-
 
     /* External list head saved in the definition block op */
 
@@ -433,20 +399,6 @@ ExAmlExternalWalkBegin (
 
     if (!AslGbl_ExternalsListHead)
     {
-        return (AE_OK);
-    }
-
-    if (Op->Asl.ParseOpcode == PARSEOP_NAMESEG ||
-        Op->Asl.ParseOpcode == PARSEOP_NAMESTRING)
-    {
-        Name = AcpiNsGetNormalizedPathname (Op->Asl.Node, TRUE);
-        ExternalListOp = ExFindUnvisitedExternal (Name);
-        if (ExternalListOp)
-        {
-            ExternalListOp->Asl.Child->Asl.CompileFlags |= OP_VISITED;
-        }
-
-        ACPI_FREE (Name);
         return (AE_OK);
     }
 


### PR DESCRIPTION
This reverts commit 52a82369950b8a728c40e58ccd1f026298563b7a, reversing
changes made to 79acf21c5d667214aa94ad645ba2f68e0c2c536c.

This pull request was intended to resolve a bug in the compiler but
further exposed a different bug in the compiler. Revert the material
from this pull request for now in order to diagnost the issue. It would
be nice to come up with solutions that simplify the logic in iASL's
external analysis.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>