### PR TITLE
iASL: fix typo in comment, 3st -> 3rd

### DIFF
--- a/source/compiler/aslopcodes.c
+++ b/source/compiler/aslopcodes.c
@@ -676,7 +676,7 @@ OpcDoUnicode (
  *                      Bits 4-0    - 3rd character of mfg code
  *              Byte 2: Bits 7-4    - 1st hex digit of product number
  *                      Bits 3-0    - 2nd hex digit of product number
- *              Byte 3: Bits 7-4    - 3st hex digit of product number
+ *              Byte 3: Bits 7-4    - 3rd hex digit of product number
  *                      Bits 3-0    - Hex digit of the revision number
  *
  ******************************************************************************/


### PR DESCRIPTION
There is a typo in a comment, fix it.

Signed-off-by: Colin Ian King <colin.king@canonical.com>