### PR TITLE
acpisrc: Add missing conversion for VIOT support

### DIFF
--- a/source/tools/acpisrc/astable.c
+++ b/source/tools/acpisrc/astable.c
@@ -863,6 +863,7 @@ ACPI_TYPED_IDENTIFIER_TABLE           AcpiIdentifiers[] = {
     {"ACPI_TPM2_TRAILER",                   SRC_TYPE_STRUCT},
     {"ACPI_TPM23_TRAILER",                  SRC_TYPE_STRUCT},
     {"ACPI_TPM2_ARM_SMC",                   SRC_TYPE_STRUCT},
+    {"ACPI_VIOT_HEADER",                    SRC_TYPE_STRUCT},
     {"ACPI_VIOT_PCI_RANGE",                 SRC_TYPE_STRUCT},
     {"ACPI_VIOT_MMIO",                      SRC_TYPE_STRUCT},
     {"ACPI_VIOT_VIRTIO_IOMMU_PCI",          SRC_TYPE_STRUCT},


### PR DESCRIPTION
I just realized while writing the Linux support that I forgot one identifier, causing build failure after conversion to Linux headers. Sorry about that, I hope it's not too late for this release.