### PR TITLE
iASL: fix typo in error message, erro -> error

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -1188,7 +1188,7 @@ AslLogExpectedException (
 
     if (MessageId > 6999)
     {
-        printf ("\"%s\" is not a valid warning/remark/erro ID\n",
+        printf ("\"%s\" is not a valid warning/remark/error ID\n",
             MessageIdString);
         return (AE_BAD_PARAMETER);
     }
@@ -1336,7 +1336,7 @@ AslElevateException (
 
     if (MessageId > 6999)
     {
-        printf ("\"%s\" is not a valid warning/remark/erro ID\n",
+        printf ("\"%s\" is not a valid warning/remark/error ID\n",
             MessageIdString);
         return (AE_BAD_PARAMETER);
     }


### PR DESCRIPTION
There are a couple of spelling mistakes, fix them.

Signed-off-by: Colin Ian King <colin.king@canonical.com>