### PR TITLE
Use ACPI_FORMAT_UINT64 when printing ACPI_SIZE

### DIFF
--- a/source/components/resources/rscalc.c
+++ b/source/components/resources/rscalc.c
@@ -816,9 +816,9 @@ AcpiRsGetListLength (
         *SizeNeeded += BufferSize;
 
         ACPI_DEBUG_PRINT ((ACPI_DB_RESOURCES,
-            "Type %.2X, AmlLength %.2X InternalLength %.2lX\n",
+            "Type %.2X, AmlLength %.2X InternalLength %.2X%8X\n",
             AcpiUtGetResourceType (AmlBuffer),
-            AcpiUtGetDescriptorLength (AmlBuffer), *SizeNeeded));
+            AcpiUtGetDescriptorLength (AmlBuffer), ACPI_FORMAT_UINT64(*SizeNeeded)));
 
         /*
          * Point to the next resource within the AML stream using the length


### PR DESCRIPTION
This fixes an issue found when building in 32-bit mode

Suggested-by: Robert Moore <robert.moore@intel.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>