### PR TITLE
Fix potential infinite loop due to type mismatch

### DIFF
--- a/source/compiler/aslerror.c
+++ b/source/compiler/aslerror.c
@@ -1125,7 +1125,7 @@ void
 AslCheckExpectedExceptions (
     void)
 {
-    UINT8                   i;
+    UINT32                  i;
     ASL_EXPECTED_MSG_NODE   *Current = AslGbl_ExpectedErrorCodeList;
     ASL_LOCATION_NODE       *LocationNode;
 


### PR DESCRIPTION
The for-loop is using a UINT8 counter and comparing the upper
limit against a UINT32 AslGbl_ExpectedMessagesIndex maximum. In
the case where AslGbl_ExpectedMessagesIndex is > 255 the counter i
will wrap around to zero and the loop will never exit. I suspect
the AslGbl_ExpectedMessagesIndex is never that high, but fixing
this does future proof the code and cleans up static analysis
warnings.

Addresses-Coverity: ("Infinite loop")
Signed-off-by: Colin Ian King <colin.king@canonical.com>