### PR TITLE
Fix object reference count problem on error path in AcpiExOpcode_1A_0T_1R

### DIFF
--- a/source/components/executer/exoparg1.c
+++ b/source/components/executer/exoparg1.c
@@ -1193,6 +1193,7 @@ AcpiExOpcode_1A_0T_1R (
                             WalkState, ReturnDesc, &TempDesc);
                         if (ACPI_FAILURE (Status))
                         {
+                            ReturnDesc = NULL;
                             goto Cleanup;
                         }
 


### PR DESCRIPTION

Prevent an unwarranted AcpiUtRemoveReference on an attached object
in AcpiExOpcode_1A_0T_1R when AcpiExReadDataFromField returns an
error. The extra decrement of the object's reference count results
in the premature deletion of that object while it is still attached.
Any subsequent reference to that attached object becomes a use-after-
free and can result in an OS crash.

One real world example of how this error path can be encountered is
on evaluation of RefOf() a local region field where there is no
registered handler for that OpRegion.

Signed-off-by: Lenny Szubowicz <lszubowi@redhat.com>