### PR TITLE
Fix memory leak caused by _CID repair function

### DIFF
--- a/source/components/namespace/nsrepair2.c
+++ b/source/components/namespace/nsrepair2.c
@@ -565,6 +565,13 @@ AcpiNsRepair_CID (
 
             (*ElementPtr)->Common.ReferenceCount =
                 OriginalRefCount;
+
+            /*
+             * The OriginalElement holds a reference from the package object
+             * that represents _HID. Since a new element was created by _HID,
+             * remove the reference from the _CID package.
+             */
+            AcpiUtRemoveReference (OriginalElement);
         }
 
         ElementPtr++;


### PR DESCRIPTION
According to the ACPI spec, _CID returns a package containing
hardware ID's. Each element of an ASL package contains a reference
count from the parent package as well as the element itself.

Name (TEST, Package() {
    "String object" // this package element has a reference count of 2
})

A memory leak was caused in the _CID repair function because it did
not decrement the reference count created by the package. Fix the
memory leak by calling AcpiUtRemoveReference on _CID package elements
that represent a hardware ID (_HID).

Tested-by: Shawn Guo <shawn.guo@linaro.org>

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>