### PR TITLE
Use ACPI_FALLTHROUGH

### DIFF
--- a/source/components/utilities/utprint.c
+++ b/source/components/utilities/utprint.c
@@ -730,7 +730,7 @@ vsnprintf (
         case 'X':
 
             Type |= ACPI_FORMAT_UPPER;
-            /* FALLTHROUGH */
+            ACPI_FALLTHROUGH;
 
         case 'x':
 


### PR DESCRIPTION
Replace /* FALLTHROUGH */ comment with ACPI_FALLTHROUGH

Signed-off-by: Wei Ming Chen <jj251510319013@gmail.com>