### PR TITLE
iASL: Fix a missing comma between two literal strings

### DIFF
--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -408,7 +408,7 @@ const char                      *AslTableCompilerMsgs [] =
 /*    ASL_MSG_INVALID_LABEL */              "Invalid field label detected",
 /*    ASL_MSG_BUFFER_LIST */                "Invalid buffer initializer list",
 /*    ASL_MSG_ENTRY_LIST */                 "Invalid entry initializer list",
-/*    ASL_MSG_UNKNOWN_FORMAT */             "Unknown format value"
+/*    ASL_MSG_UNKNOWN_FORMAT */             "Unknown format value",
 /*    ASL_MSG_RESERVED_VALUE */             "Value for field is reserved or unknown",
 };
 


### PR DESCRIPTION
A recent commit added a new literal string to the AslTableCompilerMsgs[]
array but the previous string is missing a comma and so the two strings
are ending up being concatenated. Fix this by adding the missing comma.

Addresses-Coverity: ("Missing comma in a string array initialization")
Fixes: 81eb9c383e6d ("iASL: Add support for the BDAT ACPI table")
Signed-off-by: Colin Ian King <colin.king@canonical.com>