### PR TITLE
Clean up context mutex during object deletion

### DIFF
--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -443,6 +443,14 @@ AcpiUtDeleteInternalObj (
         }
         break;
 
+    case ACPI_TYPE_LOCAL_ADDRESS_HANDLER:
+
+        ACPI_DEBUG_PRINT ((ACPI_DB_ALLOCATIONS,
+            "***** Address handler %p\n", Object));
+
+        AcpiOsDeleteMutex (Object->AddressSpace.ContextMutex);
+        break;
+
     default:
 
         break;


### PR DESCRIPTION
Fixes: c9e011695 ("Fix race in GenericSerialBus (I2C) and GPIO OpRegion parameter handling")
Reported-by: John Garry <john.garry@huawei.com>
Reported-by: Xiang Chen <chenxiang66@hisilicon.com>
Tested-by: Xiang Chen <chenxiang66@hisilicon.com>
Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>