### PR TITLE
Add PRMT module header to facilitate parsing

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -2163,6 +2163,13 @@ typedef struct acpi_table_prmt_header
 
 } ACPI_TABLE_PRMT_HEADER;
 
+typedef struct acpi_prmt_module_header
+{
+	UINT16                  Revision;
+	UINT16                  Length;
+
+} ACPI_PRMT_MODULE_HEADER;
+
 typedef struct acpi_prmt_module_info
 {
     UINT16                  Revision;

--- a/source/tools/acpisrc/astable.c
+++ b/source/tools/acpisrc/astable.c
@@ -851,6 +851,7 @@ ACPI_TYPED_IDENTIFIER_TABLE           AcpiIdentifiers[] = {
     {"ACPI_PPTT_ID",                        SRC_TYPE_STRUCT},
     {"ACPI_PPTT_PROCESSOR",                 SRC_TYPE_STRUCT},
     {"ACPI_TABLE_PRMT_HEADER",              SRC_TYPE_STRUCT},
+    {"ACPI_PRMT_MODULE_HEADER",             SRC_TYPE_STRUCT},
     {"ACPI_PRMT_MODULE_INFO",               SRC_TYPE_STRUCT},
     {"ACPI_PRMT_HANDLER_INFO",              SRC_TYPE_STRUCT},
     {"ACPI_RSDP_COMMON",                    SRC_TYPE_STRUCT},


### PR DESCRIPTION
This structure is used in to parse PRMT in other Operating Systems
that relies on using subtable headers in order to parse ACPI tables.
Although the PRMT doesn't have "subtables" it has a list of module
information structures that act as subtables.

Signed-off-by: Erik Kaneda <erik.kaneda@intel.com>