### PR TITLE
preprocess.h: fix spelling mistake in comment

### DIFF
--- a/source/compiler/preprocess.h
+++ b/source/compiler/preprocess.h
@@ -355,7 +355,7 @@ PrEvaluateExpression (
 
 
 /*
- * prutils - Preprocesor utilities
+ * prutils - Preprocessor utilities
  */
 char *
 PrGetNextToken (


### PR DESCRIPTION
Preprocesor -> Preprocessor

Signed-off-by: Colin Ian King <colin.king@canonical.com>