### PR TITLE
Add the flag for online capable in the MADT

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1271,6 +1271,7 @@ typedef struct acpi_madt_multiproc_wakeup_mailbox
 /* MADT Local APIC flags */
 
 #define ACPI_MADT_ENABLED           (1)         /* 00: Processor is usable if set */
+#define ACPI_MADT_ONLINE_CAPABLE    (2)         /* 01: System HW supports enabling processor at runtime */
 
 /* MADT MPS INTI flags (IntiFlags) */
 


### PR DESCRIPTION
This was introduced starting with ACPI 6.3.