### PR TITLE
FOR ACPICA: ACPI 6.4 SRAT: add Generic Port Affinity type

### DIFF
--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -473,6 +473,7 @@ static const char           *AcpiDmSratSubnames[] =
     "GICC Affinity",
     "GIC ITS Affinity",             /* Acpi 6.2 */
     "Generic Initiator Affinity",   /* Acpi 6.3 */
+    "Generic Port Affinity",        /* Acpi 6.4 */
     "Unknown Subtable Type"         /* Reserved */
 };
 

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -338,6 +338,11 @@ AcpiDmDumpSrat (
             InfoTable = AcpiDmTableInfoSrat5;
             break;
 
+        case ACPI_SRAT_TYPE_GENERIC_PORT_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoSrat6;
+            break;
+
         default:
             AcpiOsPrintf ("\n**** Unknown SRAT subtable type 0x%X\n",
                 Subtable->Type);

--- a/source/common/dmtbinfo3.c
+++ b/source/common/dmtbinfo3.c
@@ -368,21 +368,33 @@ ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat4[] =
     ACPI_DMT_TERMINATOR
 };
 
+/* Common SRAT structure for Generic Affinity Subtables */
+
+#define ACPI_DM_SRAT_GENERIC_AFFINITY \
+    {ACPI_DMT_UINT8,    ACPI_SRAT5_OFFSET (Reserved),               "Reserved1", 0}, \
+    {ACPI_DMT_UINT8,    ACPI_SRAT5_OFFSET (DeviceHandleType),       "Device Handle Type", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_SRAT5_OFFSET (ProximityDomain),        "Proximity Domain", 0}, \
+    {ACPI_DMT_BUF16,    ACPI_SRAT5_OFFSET (DeviceHandle),           "Device Handle", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_SRAT5_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG}, \
+    {ACPI_DMT_FLAG0,    ACPI_SRAT5_FLAG_OFFSET (Flags,0),           "Enabled", 0}, \
+    {ACPI_DMT_FLAG1,    ACPI_SRAT5_FLAG_OFFSET (Flags,0),           "Architectural Transactions", 0}, \
+    {ACPI_DMT_UINT32,   ACPI_SRAT5_OFFSET (Reserved1),              "Reserved2", 0}
+
 /* 5: Generic Initiator Affinity Structure (ACPI 6.3) */
 
 ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat5[] =
 {
-    {ACPI_DMT_UINT8,    ACPI_SRAT5_OFFSET (Reserved),               "Reserved1", 0},
-    {ACPI_DMT_UINT8,    ACPI_SRAT5_OFFSET (DeviceHandleType),       "Device Handle Type", 0},
-    {ACPI_DMT_UINT32,   ACPI_SRAT5_OFFSET (ProximityDomain),        "Proximity Domain", 0},
-    {ACPI_DMT_BUF16,    ACPI_SRAT5_OFFSET (DeviceHandle),           "Device Handle", 0},
-    {ACPI_DMT_UINT32,   ACPI_SRAT5_OFFSET (Flags),                  "Flags (decoded below)", DT_FLAG},
-    {ACPI_DMT_FLAG0,    ACPI_SRAT5_FLAG_OFFSET (Flags,0),           "Enabled", 0},
-    {ACPI_DMT_FLAG1,    ACPI_SRAT5_FLAG_OFFSET (Flags,0),           "Architectural Transactions", 0},
-    {ACPI_DMT_UINT32,   ACPI_SRAT5_OFFSET (Reserved1),              "Reserved2", 0},
+    ACPI_DM_SRAT_GENERIC_AFFINITY,
     ACPI_DMT_TERMINATOR
 };
 
+/* 6: Generic Port Affinity Structure (ACPI 6.4) */
+
+ACPI_DMTABLE_INFO           AcpiDmTableInfoSrat6[] =
+{
+    ACPI_DM_SRAT_GENERIC_AFFINITY,
+    ACPI_DMT_TERMINATOR
+};
 
 /*******************************************************************************
  *

--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -2062,6 +2062,11 @@ DtCompileSrat (
             InfoTable = AcpiDmTableInfoSrat5;
             break;
 
+        case ACPI_SRAT_TYPE_GENERIC_PORT_AFFINITY:
+
+            InfoTable = AcpiDmTableInfoSrat6;
+            break;
+
         default:
 
             DtFatal (ASL_MSG_UNKNOWN_SUBTABLE, SubtableStart, "SRAT");

--- a/source/include/acdisasm.h
+++ b/source/include/acdisasm.h
@@ -609,6 +609,7 @@ extern ACPI_DMTABLE_INFO        AcpiDmTableInfoSrat2[];
 extern ACPI_DMTABLE_INFO        AcpiDmTableInfoSrat3[];
 extern ACPI_DMTABLE_INFO        AcpiDmTableInfoSrat4[];
 extern ACPI_DMTABLE_INFO        AcpiDmTableInfoSrat5[];
+extern ACPI_DMTABLE_INFO        AcpiDmTableInfoSrat6[];
 extern ACPI_DMTABLE_INFO        AcpiDmTableInfoStao[];
 extern ACPI_DMTABLE_INFO        AcpiDmTableInfoStaoStr[];
 extern ACPI_DMTABLE_INFO        AcpiDmTableInfoSvkl[];

--- a/source/include/actbl3.h
+++ b/source/include/actbl3.h
@@ -352,7 +352,8 @@ enum AcpiSratType
     ACPI_SRAT_TYPE_GICC_AFFINITY        = 3,
     ACPI_SRAT_TYPE_GIC_ITS_AFFINITY     = 4, /* ACPI 6.2 */
     ACPI_SRAT_TYPE_GENERIC_AFFINITY     = 5, /* ACPI 6.3 */
-    ACPI_SRAT_TYPE_RESERVED             = 6  /* 5 and greater are reserved */
+    ACPI_SRAT_TYPE_GENERIC_PORT_AFFINITY = 6, /* ACPI 6.4 */
+    ACPI_SRAT_TYPE_RESERVED              = 7  /* 7 and greater are reserved */
 };
 
 /*
@@ -447,8 +448,11 @@ typedef struct acpi_srat_gic_its_affinity
 
 } ACPI_SRAT_GIC_ITS_AFFINITY;
 
-
-/* 5: Generic Initiator Affinity Structure (ACPI 6.3) */
+/*
+ * Common structure for SRAT subtable types:
+ * 5: ACPI_SRAT_TYPE_GENERIC_AFFINITY
+ * 6: ACPI_SRAT_TYPE_GENERIC_PORT_AFFINITY
+ */
 
 typedef struct acpi_srat_generic_affinity
 {


### PR DESCRIPTION
Add a new subtable type for SRAT Generic Port Affinity.
It uses the same subtable structure as the existing Generic
Initiator Affinity type.

Signed-off-by: Alison Schofield <alison.schofield@intel.com>