### PR TITLE
Dispatcher: clean up incorrect identation

### DIFF
--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -797,7 +797,7 @@ AcpiDsInitFieldObjects (
     }
 
 #ifdef ACPI_EXEC_APP
-        Flags |= ACPI_NS_OVERRIDE_IF_FOUND;
+    Flags |= ACPI_NS_OVERRIDE_IF_FOUND;
 #endif
     /*
      * Walk the list of entries in the FieldList


### PR DESCRIPTION
There is an assignment statement where the indentation is one
level too deep. Remove 4 spaces to clean this up.

Signed-off-by: Colin Ian King <colin.king@canonical.com>