### PR TITLE
actypes.h: Expand the ACPI_ACCESS_ definitions

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -687,9 +687,14 @@ typedef UINT64                          ACPI_INTEGER;
  * Can be used with AccessSize field of ACPI_GENERIC_ADDRESS and
  * ACPI_RESOURCE_GENERIC_REGISTER.
  */
-#define ACPI_ACCESS_BIT_WIDTH(AccessSize)   (1 << ((AccessSize) + 2))
-#define ACPI_ACCESS_BYTE_WIDTH(AccessSize)  (1 << ((AccessSize) - 1))
-
+#define ACPI_ACCESS_BIT_SHIFT		2
+#define ACPI_ACCESS_BYTE_SHIFT		-1
+#define ACPI_ACCESS_BIT_MAX		(31 - ACPI_ACCESS_BIT_SHIFT)
+#define ACPI_ACCESS_BYTE_MAX		(31 - ACPI_ACCESS_BYTE_SHIFT)
+#define ACPI_ACCESS_BIT_DEFAULT		(8 - ACPI_ACCESS_BIT_SHIFT)
+#define ACPI_ACCESS_BYTE_DEFAULT	(8 - ACPI_ACCESS_BYTE_SHIFT)
+#define ACPI_ACCESS_BIT_WIDTH(size)	(1 << ((size) + ACPI_ACCESS_BIT_SHIFT))
+#define ACPI_ACCESS_BYTE_WIDTH(size)	(1 << ((size) + ACPI_ACCESS_BYTE_SHIFT))
 
 /*******************************************************************************
  *


### PR DESCRIPTION
The current `ACPI_ACCESS_*_WIDTH` defines do not provide a way to
test that size is small enough to not cause an overflow when
applied to a 32-bit integer.

Rather than adding more magic numbers, add `ACPI_ACCESS_*_SHIFT`,
`ACPI_ACCESS_*_MAX`, and `ACPI_ACCESS_*_DEFAULT` #defines and
redefine `ACPI_ACCESS_*_WIDTH` in terms of the new #defines.

This was inititally reported on Linux where a size of 102 in
`ACPI_ACCESS_BIT_WIDTH` caused an overflow error in the SPCR
initialization code.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>