### PR TITLE
Headers: Avoid NULL pointer arithmetic

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -658,8 +658,8 @@ typedef UINT64                          ACPI_INTEGER;
 /* Pointer/Integer type conversions */
 
 #define ACPI_TO_POINTER(i)              ACPI_CAST_PTR (void, (ACPI_SIZE) (i))
-#define ACPI_TO_INTEGER(p)              ACPI_PTR_DIFF (p, (void *) 0)
-#define ACPI_OFFSET(d, f)               ACPI_PTR_DIFF (&(((d *) 0)->f), (void *) 0)
+#define ACPI_TO_INTEGER(p)              ((uintptr_t)(p))
+#define ACPI_OFFSET(d, f)               offsetof(d, f)
 #define ACPI_PHYSADDR_TO_PTR(i)         ACPI_TO_POINTER(i)
 #define ACPI_PTR_TO_PHYSADDR(i)         ACPI_TO_INTEGER(i)
 


### PR DESCRIPTION
This is an upstream ACPICA version of the following Linux kernel patch from Arnd Bergmann:

https://patchwork.kernel.org/project/linux-acpi/patch/20210927121338.938994-1-arnd@kernel.org/

Please consider merging.