### PR TITLE
Hardware: Avoid evaluating methods too early during system resume

### DIFF
--- a/source/components/hardware/hwesleep.c
+++ b/source/components/hardware/hwesleep.c
@@ -312,18 +312,15 @@ ACPI_STATUS
 AcpiHwExtendedWakePrep (
     UINT8                   SleepState)
 {
-    ACPI_STATUS             Status;
     UINT8                   SleepTypeValue;
 
 
     ACPI_FUNCTION_TRACE (HwExtendedWakePrep);
 
 
-    Status = AcpiGetSleepTypeData (ACPI_STATE_S0,
-        &AcpiGbl_SleepTypeA, &AcpiGbl_SleepTypeB);
-    if (ACPI_SUCCESS (Status))
+    if (AcpiGbl_SleepTypeAS0 != ACPI_SLEEP_TYPE_INVALID)
     {
-        SleepTypeValue = ((AcpiGbl_SleepTypeA << ACPI_X_SLEEP_TYPE_POSITION) &
+        SleepTypeValue = ((AcpiGbl_SleepTypeAS0 << ACPI_X_SLEEP_TYPE_POSITION) &
             ACPI_X_SLEEP_TYPE_MASK);
 
         (void) AcpiWrite ((UINT64) (SleepTypeValue | ACPI_X_SLEEP_ENABLE),

--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -339,7 +339,7 @@ ACPI_STATUS
 AcpiHwLegacyWakePrep (
     UINT8                   SleepState)
 {
-    ACPI_STATUS             Status;
+    ACPI_STATUS             Status = AE_OK;
     ACPI_BIT_REGISTER_INFO  *SleepTypeRegInfo;
     ACPI_BIT_REGISTER_INFO  *SleepEnableRegInfo;
     UINT32                  Pm1aControl;
@@ -353,9 +353,7 @@ AcpiHwLegacyWakePrep (
      * This is unclear from the ACPI Spec, but it is required
      * by some machines.
      */
-    Status = AcpiGetSleepTypeData (ACPI_STATE_S0,
-        &AcpiGbl_SleepTypeA, &AcpiGbl_SleepTypeB);
-    if (ACPI_SUCCESS (Status))
+    if (AcpiGbl_SleepTypeAS0 != ACPI_SLEEP_TYPE_INVALID)
     {
         SleepTypeRegInfo =
             AcpiHwGetBitRegisterInfo (ACPI_BITREG_SLEEP_TYPE);
@@ -376,9 +374,9 @@ AcpiHwLegacyWakePrep (
 
             /* Insert the SLP_TYP bits */
 
-            Pm1aControl |= (AcpiGbl_SleepTypeA <<
+            Pm1aControl |= (AcpiGbl_SleepTypeAS0 <<
                 SleepTypeRegInfo->BitPosition);
-            Pm1bControl |= (AcpiGbl_SleepTypeB <<
+            Pm1aControl |= (AcpiGbl_SleepTypeBS0 <<
                 SleepTypeRegInfo->BitPosition);
 
             /* Write the control registers and ignore any errors */

--- a/source/components/hardware/hwxfsleep.c
+++ b/source/components/hardware/hwxfsleep.c
@@ -471,6 +471,12 @@ AcpiEnterSleepStatePrep (
         return_ACPI_STATUS (Status);
     }
 
+    Status = AcpiGetSleepTypeData (ACPI_STATE_S0,
+        &AcpiGbl_SleepTypeAS0, &AcpiGbl_SleepTypeBS0);
+    if (ACPI_FAILURE (Status)) {
+        AcpiGbl_SleepTypeAS0 = ACPI_SLEEP_TYPE_INVALID;
+    }
+
     /* Execute the _PTS method (Prepare To Sleep) */
 
     ArgList.Count = 1;

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -365,6 +365,8 @@ ACPI_INIT_GLOBAL (ACPI_COMMENT_NODE,   *AcpiGbl_LastListHead, NULL);
 extern ACPI_BIT_REGISTER_INFO           AcpiGbl_BitRegisterInfo[ACPI_NUM_BITREG];
 ACPI_GLOBAL (UINT8,                     AcpiGbl_SleepTypeA);
 ACPI_GLOBAL (UINT8,                     AcpiGbl_SleepTypeB);
+ACPI_GLOBAL (UINT8,                     AcpiGbl_SleepTypeAS0);
+ACPI_GLOBAL (UINT8,                     AcpiGbl_SleepTypeBS0);
 
 
 /*****************************************************************************


### PR DESCRIPTION
This is an upstream ACPICA version of the Linux kernel patch at

https://patchwork.kernel.org/project/linux-acpi/patch/2618833.mvXUDI8C0e@kreacher/

Please consider for merging.