### PR TITLE
Headers: Fix build when ACPI_USE_SYSTEM_INTTYPES is not set

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -239,6 +239,9 @@ typedef short                           INT16;
 typedef COMPILER_DEPENDENT_UINT64       UINT64;
 typedef COMPILER_DEPENDENT_INT64        INT64;
 
+typedef unsigned long                   uintptr_t;
+#define offsetof(TYPE, MEMBER)          ((size_t)&((TYPE *)0)->MEMBER)
+
 #endif /* ACPI_USE_SYSTEM_INTTYPES */
 
 /*


### PR DESCRIPTION
This fixes a build issue introduced by commit 0084a2ede3ed ("Headers: Avoid NULL pointer arithmetic").

Please consider for merging.
