### PR TITLE
Revert "Fix memory leak caused by _CID repair function"

### DIFF
--- a/source/components/namespace/nsrepair2.c
+++ b/source/components/namespace/nsrepair2.c
@@ -565,13 +565,6 @@ AcpiNsRepair_CID (
 
             (*ElementPtr)->Common.ReferenceCount =
                 OriginalRefCount;
-
-            /*
-             * The OriginalElement holds a reference from the package object
-             * that represents _HID. Since a new element was created by _HID,
-             * remove the reference from the _CID package.
-             */
-            AcpiUtRemoveReference (OriginalElement);
         }
 
         ElementPtr++;


### PR DESCRIPTION
This is an upstream ACPICA version of Linux commit 6511a8b5b7a6 ("Revert "ACPICA: Fix memory leak caused by _CID repair function"") that reverted a problematic change in the ACPICA code.

Please consider for merging.
