### PR TITLE
iASL: Fix unaligned accesses to local cache allocations

### DIFF
--- a/source/compiler/aslcache.c
+++ b/source/compiler/aslcache.c
@@ -183,6 +183,11 @@ UtLocalCacheCalloc (
     UINT32                  CacheSize = ASL_STRING_CACHE_SIZE;
 
 
+#ifdef ACPI_MISALIGNMENT_NOT_SUPPORTED
+    /* Used for objects other than strings, so keep allocations aligned */
+    Length = ACPI_ROUND_UP_TO_NATIVE_WORD (Length);
+#endif
+
     if (Length > CacheSize)
     {
         CacheSize = Length;


### PR DESCRIPTION
Despite the documentation talking of strings, and the various constants and variables used in the function also doing so, UtLocalCacheCalloc gets used for things other than strings, such as FlInitOneFile using it to allocate an ASL_GLOBAL_FILE_NODE. The easiest way to fix that for a bump the pointer allocator is to just round up every allocation's size; there are more complex alternatives, as allocations smaller than the maximum native alignment only need to be rounded up to the next power of two, but optimising for that case seems unnecessarily complicated.

It might make sense to split this into a string allocator and a separate generic object allocator (to complement the existing specific object allocators) to ensure strings can still be packed tightly in memory, but that is a more invasive change that may not be worth it for the small decrease in memory footprint.