### PR TITLE
Avoid subobject buffer overflow when validating RSDP signature

### DIFF
--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -795,7 +795,8 @@ AcpiDmDumpDataTable (
             return;
         }
     }
-    else if (ACPI_VALIDATE_RSDP_SIG (Table->Signature))
+    else if (ACPI_VALIDATE_RSDP_SIG (ACPI_CAST_PTR (ACPI_TABLE_RSDP,
+        Table)->Signature))
     {
         Length = AcpiDmDumpRsdp (Table);
     }

--- a/source/components/tables/tbprint.c
+++ b/source/components/tables/tbprint.c
@@ -261,7 +261,8 @@ AcpiTbPrintTableHeader (
             Header->Signature, ACPI_FORMAT_UINT64 (Address),
             Header->Length));
     }
-    else if (ACPI_VALIDATE_RSDP_SIG (Header->Signature))
+    else if (ACPI_VALIDATE_RSDP_SIG (ACPI_CAST_PTR (ACPI_TABLE_RSDP,
+        Header)->Signature))
     {
         /* RSDP has no common fields */
 


### PR DESCRIPTION
Since the Signature member is accessed through an ACPI_TABLE_HEADER, the pointer to it is only to a 4-char array, and so trying to read past the 4th character, as will be done when it is an RSDP, reads beyond the bounds of the accessed member. On CHERI, and thus Arm's experimental Morello prototype architecture, pointers are represented as capabilities, which are unforgeable bounded pointers, providing always-on fine-grained spatial memory safety. By default, subobject bounds enforcement is not enabled, only bounds on allocations, but it is enabled in the CheriBSD (a port of FreeBSD) kernel as intra-object overflow attacks are common on operating system kernels, and so this overflow is detected there and traps.