### PR TITLE
ACPICA: drop unneeded initialization value

### DIFF
--- a/source/components/debugger/dbcmds.c
+++ b/source/components/debugger/dbcmds.c
@@ -193,7 +193,7 @@ AcpiDbDoOneSleepState (
     UINT8                   SleepState);
 
 
-static char                 *AcpiDbTraceMethodName = NULL;
+static char                 *AcpiDbTraceMethodName;
 
 
 /*******************************************************************************

--- a/source/components/debugger/dbhistry.c
+++ b/source/components/debugger/dbhistry.c
@@ -172,9 +172,9 @@ typedef struct HistoryInfo
 
 
 static HISTORY_INFO         AcpiGbl_HistoryBuffer[HISTORY_SIZE];
-static UINT16               AcpiGbl_LoHistory = 0;
-static UINT16               AcpiGbl_NumHistory = 0;
-static UINT16               AcpiGbl_NextHistoryIndex = 0;
+static UINT16               AcpiGbl_LoHistory;
+static UINT16               AcpiGbl_NumHistory;
+static UINT16               AcpiGbl_NextHistoryIndex;
 
 
 /*******************************************************************************


### PR DESCRIPTION
Do not initialize statics to NULL