### PR TITLE
Hardware: Fix typo in variable name in AcpiHwLegacyWakePrep ()

### DIFF
--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -376,7 +376,7 @@ AcpiHwLegacyWakePrep (
 
             Pm1aControl |= (AcpiGbl_SleepTypeAS0 <<
                 SleepTypeRegInfo->BitPosition);
-            Pm1aControl |= (AcpiGbl_SleepTypeBS0 <<
+            Pm1bControl |= (AcpiGbl_SleepTypeBS0 <<
                 SleepTypeRegInfo->BitPosition);
 
             /* Write the control registers and ignore any errors */


### PR DESCRIPTION
This fixes a typo in a variable name introduced by one of the earlier changes.
