### PR TITLE
Fix AEST Processor generic resource substructure data field byte length

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -309,7 +309,7 @@ typedef struct              acpi_aest_processor_tlb
 
 typedef struct              acpi_aest_processor_generic
 {
-    UINT8                   *Resource;
+    UINT32                   Resource;
 
 } ACPI_AEST_PROCESSOR_GENERIC;
 


### PR DESCRIPTION
The byte length of the Data field in the AEST Processor generic resource
substructure defined in ACPI for the Armv8 RAS Extensions 1.1 is 4Byte.
However, it is defined as a pointer type, and on a 64-bit machine,
it is interpreted as 8 bytes. Therefore, it is changed from a pointer
type unsigned integer 1 byte to an unsigned integer 4 bytes.

Signed-off-by: Shuuichirou Ishii <ishii.shuuichir@fujitsu.com>