### PR TITLE
Utilities: Avoid deleting the same object twice in a row

### DIFF
--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -594,6 +594,7 @@ AcpiUtUpdateRefCount (
             ACPI_WARNING ((AE_INFO,
                 "Obj %p, Reference Count is already zero, cannot decrement\n",
                 Object));
+	    return;
         }
 
         ACPI_DEBUG_PRINT_RAW ((ACPI_DB_ALLOCATIONS,


### PR DESCRIPTION
This fixes the issue originally reported by Mark Asselstine <mark.asselstine@windriver.com> in pull request #652.
