### PR TITLE
Executer: Fix the REFCLASS_REFOF case in AcpiExOpcode_1A_0T_1R ()

### DIFF
--- a/source/components/executer/exoparg1.c
+++ b/source/components/executer/exoparg1.c
@@ -1193,7 +1193,7 @@ AcpiExOpcode_1A_0T_1R (
                             WalkState, ReturnDesc, &TempDesc);
                         if (ACPI_FAILURE (Status))
                         {
-                            goto Cleanup;
+                            return_ACPI_STATUS (Status);
                         }
 
                         ReturnDesc = TempDesc;


### PR DESCRIPTION
This fixes the attached object reference counting error reported by Lenny Szubowicz <lszubowi@redhat.com> in pull request #685.