### PR TITLE
Pcc opregion support

### DIFF
--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -320,6 +320,15 @@ AcpiEvAddressSpaceDispatch (
             return_ACPI_STATUS (AE_NOT_EXIST);
         }
 
+	if (RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_COMM)
+	{
+	    ACPI_PCC_INFO *Ctx = HandlerDesc->AddressSpace.Context;
+
+	    Ctx->InternalBuffer = FieldObj->Field.InternalPccBuffer;
+	    Ctx->Length = RegionObj->Region.Length;
+	    Ctx->SubspaceId = RegionObj->Region.Address;
+	}
+
         /*
          * We must exit the interpreter because the region setup will
          * potentially execute control methods (for example, the _REG method

--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -492,9 +492,7 @@ AcpiExWriteDataToField (
             ObjDesc->Field.BaseByteOffset,
             SourceDesc->Buffer.Pointer, DataLength);
 
-        if ((ObjDesc->Field.RegionObj->Region.Address == PCC_MASTER_SUBSPACE &&
-           MASTER_SUBSPACE_COMMAND (ObjDesc->Field.BaseByteOffset)) ||
-           GENERIC_SUBSPACE_COMMAND (ObjDesc->Field.BaseByteOffset))
+        if (MASTER_SUBSPACE_COMMAND (ObjDesc->Field.BaseByteOffset))
         {
             /* Perform the write */
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1319,6 +1319,14 @@ typedef struct acpi_connection_info
 
 } ACPI_CONNECTION_INFO;
 
+/* Special Context data for PCC Opregion (ACPI 6.3) */
+
+typedef struct acpi_pcc_info {
+    UINT8                           SubspaceId;
+    UINT16                          Length;
+    UINT8                           *InternalBuffer;
+} ACPI_PCC_INFO;
+
 
 typedef
 ACPI_STATUS (*ACPI_ADR_SPACE_SETUP) (


### PR DESCRIPTION
Hi,

The first change is based on the fact that no one has reported any usage of PCC type 1/2 opregion,
One of the platform I use has PCC type 3 Opregion and is currently crashing at boot with log as in the commit.
So it needs to fixed ASAP.