### PR TITLE
Hardware: Do not flush CPU cache when entering S4 and S5

### DIFF
--- a/source/components/hardware/hwesleep.c
+++ b/source/components/hardware/hwesleep.c
@@ -261,7 +261,10 @@ AcpiHwExtendedSleep (
 
     /* Flush caches, as per ACPI specification */
 
-    ACPI_FLUSH_CPU_CACHE ();
+    if (SleepState < ACPI_STATE_S4)
+    {
+        ACPI_FLUSH_CPU_CACHE ();
+    }
 
     Status = AcpiOsEnterSleep (SleepState, SleepControl, 0);
     if (Status == AE_CTRL_TERMINATE)

--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -262,7 +262,10 @@ AcpiHwLegacySleep (
 
     /* Flush caches, as per ACPI specification */
 
-    ACPI_FLUSH_CPU_CACHE ();
+    if (SleepState < ACPI_STATE_S4)
+    {
+        ACPI_FLUSH_CPU_CACHE ();
+    }
 
     Status = AcpiOsEnterSleep (SleepState, Pm1aControl, Pm1bControl);
     if (Status == AE_CTRL_TERMINATE)

--- a/source/components/hardware/hwxfsleep.c
+++ b/source/components/hardware/hwxfsleep.c
@@ -353,8 +353,6 @@ AcpiEnterSleepStateS4bios (
         return_ACPI_STATUS (Status);
     }
 
-    ACPI_FLUSH_CPU_CACHE ();
-
     Status = AcpiHwWritePort (AcpiGbl_FADT.SmiCommand,
         (UINT32) AcpiGbl_FADT.S4BiosRequest, 8);
     if (ACPI_FAILURE (Status))


### PR DESCRIPTION
This is based on the Linux kernel patch at:

https://patchwork.kernel.org/project/linux-acpi/patch/20211206122952.74139-2-kirill.shutemov@linux.intel.com/
