### PR TITLE
dmtbdump: Delete the Generic Resource Type error message

### DIFF
--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -296,8 +296,6 @@ AcpiDmDumpAest (
             case ACPI_AEST_GENERIC_RESOURCE:
                 InfoTable = AcpiDmTableInfoAestGenRsrc;
                 Length = sizeof (ACPI_AEST_PROCESSOR_GENERIC);
-                AcpiOsPrintf ("Generic Resource Type (%X) is not supported at this time\n",
-                    ProcessorSubtable->ResourceType);
                 break;
 
             /* Error case below */


### PR DESCRIPTION
The ACPI_AEST_GENERIC_RESOURCE macro is already defined in actbl2.h,
and since it is a Resource type that also exists as an AEST
specification, it is not necessary to output error messages.

Signed-off-by: Shuuichirou Ishii <ishii.shuuichir@fujitsu.com>