### PR TITLE
Headers: Use uintptr_t and offsetof() in Linux kernel builds

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -658,8 +658,12 @@ typedef UINT64                          ACPI_INTEGER;
 /* Pointer/Integer type conversions */
 
 #define ACPI_TO_POINTER(i)              ACPI_CAST_PTR (void, (ACPI_SIZE) (i))
+#ifndef ACPI_TO_INTEGER
 #define ACPI_TO_INTEGER(p)              ACPI_PTR_DIFF (p, (void *) 0)
+#endif
+#ifndef ACPI_OFFSET
 #define ACPI_OFFSET(d, f)               ACPI_PTR_DIFF (&(((d *) 0)->f), (void *) 0)
+#endif
 #define ACPI_PTR_TO_PHYSADDR(i)         ACPI_TO_INTEGER(i)
 
 /* Optimizations for 4-character (32-bit) ACPI_NAME manipulation */

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -252,6 +252,11 @@
 #define ACPI_SPINLOCK               spinlock_t *
 #define ACPI_CPU_FLAGS              unsigned long
 
+#define ACPI_UINTPTR_T              uintptr_t
+
+#define ACPI_TO_INTEGER(p)          ((uintptr_t)(p))
+#define ACPI_OFFSET(d, f)           offsetof(d, f)
+
 /* Use native linux version of AcpiOsAllocateZeroed */
 
 #define USE_NATIVE_ALLOCATE_ZEROED


### PR DESCRIPTION
This is based on the Linux kernel patch at

https://patchwork.kernel.org/project/linux-acpi/patch/2614912.mvXUDI8C0e@kreacher/

To avoid "performing pointer subtraction with a null pointer has
undefined behavior" compiler warnings, use uintptr_t and offsetof()
that are always available during Linux kernel builds to define
ACPI_UINTPTR_T and the ACPI_TO_INTEGER() and ACPI_OFFSET() macros.
