### PR TITLE
ACPICA: Fix operand resolution

### DIFF
--- a/source/components/dispatcher/dswexec.c
+++ b/source/components/dispatcher/dswexec.c
@@ -569,9 +569,11 @@ AcpiDsExecEndOp (
 
         /*
          * All opcodes require operand resolution, with the only exceptions
-         * being the ObjectType and SizeOf operators.
+         * being the ObjectType and SizeOf operators as well as opcodes that
+         * take no arguments.
          */
-        if (!(WalkState->OpInfo->Flags & AML_NO_OPERAND_RESOLVE))
+        if (!(WalkState->OpInfo->Flags & AML_NO_OPERAND_RESOLVE) &&
+            (WalkState->OpInfo->Flags & AML_HAS_ARGS))
         {
             /* Resolve all operands */
 


### PR DESCRIPTION
In our tests we get UBSAN warning coming from ACPI parser. This is
caused by trying to resolve operands when there is none.

Signed-off-by: Amadeusz Sławiński <amadeuszx.slawinski@linux.intel.com>
Reviewed-by: Cezary Rojewski <cezary.rojewski@intel.com>