### PR TITLE
Namespace: Avoid walking the Namespace if it is not there

### DIFF
--- a/source/components/namespace/nswalk.c
+++ b/source/components/namespace/nswalk.c
@@ -322,6 +322,10 @@ AcpiNsWalkNamespace (
     if (StartNode == ACPI_ROOT_OBJECT)
     {
         StartNode = AcpiGbl_RootNode;
+        if (!StartNode)
+        {
+            return_ACPI_STATUS (AE_NO_NAMESPACE);
+        }
     }
 
     /* Null child means "get first node" */


### PR DESCRIPTION
Prevent AcpiNsWalkNamespace () from crashing when called with
StartNode equal to ACPI_ROOT_OBJECT if the Namespace has not
been instantiated yet and AcpiGbl_RootNode is NULL.
