### PR TITLE
cleanup double word in comment

### DIFF
--- a/source/components/executer/exfldio.c
+++ b/source/components/executer/exfldio.c
@@ -262,7 +262,7 @@ AcpiExSetupRegion (
 #ifdef ACPI_UNDER_DEVELOPMENT
     /*
      * If the Field access is AnyAcc, we can now compute the optimal
-     * access (because we know know the length of the parent region)
+     * access (because we know the length of the parent region)
      */
     if (!(ObjDesc->Common.Flags & AOPOBJ_DATA_VALID))
     {

--- a/source/components/hardware/hwregs.c
+++ b/source/components/hardware/hwregs.c
@@ -633,7 +633,7 @@ AcpiHwGetBitRegisterInfo (
  * RETURN:      Status
  *
  * DESCRIPTION: Write the PM1 A/B control registers. These registers are
- *              different than than the PM1 A/B status and enable registers
+ *              different than the PM1 A/B status and enable registers
  *              in that different values can be written to the A/B registers.
  *              Most notably, the SLP_TYP bits can be different, as per the
  *              values returned from the _Sx predefined methods.


### PR DESCRIPTION
Remove the second 'know' and 'than'.

Signed-off-by: Tom Rix <trix@redhat.com>