### PR TITLE
iASL: NHLT: Fix variable shadowing

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1757,12 +1757,12 @@ AcpiDmDumpNhlt (
 
                 if (CapabilitiesSize > 0)
                 {
-                    UINT8* Capabilities = ACPI_ADD_PTR (UINT8, Table, Offset);
+                    UINT8* CapabilitiesBuf = ACPI_ADD_PTR (UINT8, Table, Offset);
                     /* Do the Capabilities array (of bytes) */
 
                     AcpiOsPrintf ("\n    /* Specific_Config table #%u */\n", j+1);
 
-                    Status = AcpiDmDumpTable (TableLength, Offset, Capabilities,
+                    Status = AcpiDmDumpTable (TableLength, Offset, CapabilitiesBuf,
                         CapabilitiesSize, AcpiDmTableInfoNhlt3a);
                     if (ACPI_FAILURE (Status))
                     {


### PR DESCRIPTION
Variable named Capabilities was declared twice in one function that caused
variable shadowing. Renaming one of them will fix this issue.