### PR TITLE
Fix buffer overflow when disassembling anonymous ResourceTemplate()

### DIFF
--- a/source/components/disassembler/dmwalk.c
+++ b/source/components/disassembler/dmwalk.c
@@ -959,7 +959,15 @@ AcpiDmDescendingOp (
                 NextOp->Common.DisasmFlags |= ACPI_PARSEOP_IGNORE;
                 ASL_CV_CLOSE_PAREN (Op, Level);
 
-                /* Emit description comment for Name() with a predefined ACPI name */
+                if (Op->Asl.Parent->Common.AmlOpcode == AML_NAME_OP)
+                {
+                    /*
+                     * Emit description comment showing the full ACPI name
+                     * of the ResourceTemplate only if it was defined using a
+                     * Name statement.
+                     */
+                     AcpiDmPredefinedDescription (Op->Asl.Parent);
+                }
 
                 AcpiDmPredefinedDescription (Op->Asl.Parent);
 


### PR DESCRIPTION
AcpiDmPredefinedDescription only works if acpi_parse_object is Named
rather than Common.

Without this check, an ASAN build of the disassembler will fail
with an out of bounds error when trying to disassemble code like

  Store(ResourceTemplate() {
    QWordMemory (
      ResourceProducer, PosDecode, MinFixed, MaxFixed, Cacheable,
      ReadWrite, 0, 0, 6, 0, 7, , , , AddressRangeMemory, TypeStatic)
  }, Local2)

This particular case was reduced from code in seabios