### PR TITLE
Update FreeBSD-specific header

### DIFF
--- a/source/include/platform/acfreebsd.h
+++ b/source/include/platform/acfreebsd.h
@@ -166,6 +166,9 @@
 
 #define ACPI_UINTPTR_T      uintptr_t
 
+#define ACPI_TO_INTEGER(p)  ((uintptr_t)(p))
+#define ACPI_OFFSET(d, f)   __offsetof(d, f)
+
 #define ACPI_USE_DO_WHILE_0
 #define ACPI_USE_LOCAL_CACHE
 #define ACPI_USE_NATIVE_DIVIDE

--- a/source/include/platform/acfreebsd.h
+++ b/source/include/platform/acfreebsd.h
@@ -211,6 +211,7 @@
 
 #if __STDC_HOSTED__
 #include <ctype.h>
+#include <unistd.h>
 #endif
 
 #define ACPI_CAST_PTHREAD_T(pthread)    ((ACPI_THREAD_ID) ACPI_TO_INTEGER (pthread))


### PR DESCRIPTION
- cda7b36af505c7e65b0dbbf7c3d340a6101ca103 broke build on FreeBSD because ``_exit(2)`` requires ``unistd.h``.  It seems Linux was okay because ``source/include/platform/aclinux.h`` included it.  Note other platforms will require similar change.
- Define ``ACPI_TO_INTEGER()`` and ``ACPI_OFFSET()`` macros.  This change should fix #407.