### PR TITLE
* use ACPI_ERROR() instead of fprintf() as the OS might not use or pr…

### DIFF
--- a/source/components/executer/exconfig.c
+++ b/source/components/executer/exconfig.c
@@ -471,7 +471,7 @@ AcpiExLoadOp (
     }
     if (Target->Common.Type != ACPI_TYPE_INTEGER)
     {
-        fprintf (stderr, "Type not integer: %X\n", Target->Common.Type);
+        ACPI_ERROR ((AE_INFO, "Type not integer: %X", Target->Common.Type));
         return_ACPI_STATUS (AE_AML_OPERAND_TYPE);
     }
 


### PR DESCRIPTION
…ovide fprintf() and/or stderr