### PR TITLE
Fix unsigned/signed int32 variable assignments and comparisons

### DIFF
--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -270,7 +270,7 @@ AslDoOptions (
     BOOLEAN                 IsResponseFile)
 {
     ACPI_STATUS             Status;
-    UINT32                  j;
+    INT32                  j;
 
 
     /* Get the command line options */

--- a/source/tools/acpixtract/acpixtract.c
+++ b/source/tools/acpixtract/acpixtract.c
@@ -561,7 +561,7 @@ AxListAllTables (
     FILE                    *InputFile;
     unsigned char           Header[48];
     UINT32                  ByteCount = 0;
-    UINT32                  ThisLineByteCount;
+    INT32                   ThisLineByteCount;
     unsigned int            State = AX_STATE_FIND_HEADER;
 
 


### PR DESCRIPTION
Two instances where UINT32 variables should be INT32 types to match them with the values returned from function calls and values being checked for termination states.