### PR TITLE
Check EBDA pointer from memory

### DIFF
--- a/source/components/tables/tbxfroot.c
+++ b/source/components/tables/tbxfroot.c
@@ -299,7 +299,12 @@ AcpiFindRootPointer (
 
     /* EBDA present? */
 
-    if (PhysicalAddress > 0x400)
+    /*
+     * Check that the EBDA pointer from memory is sane and does not point
+     * above valid low memory
+     */
+    if (PhysicalAddress > 0x400 &&
+        PhysicalAddress < 0xA0000)
     {
         /*
          * 1b) Search EBDA paragraphs (EBDA is required to be a


### PR DESCRIPTION
When testing a custom hypervisor, we noticed that if there is uninitialized memory at word `0x40e`, the retrieved pointer to **EBDA** can point beyond the boundaries of 640KiB of low memory, possibly to a VGA range. These patches are adding
sanity check for this pointer so that this does not happen.
Further the spec says that only the first KiB of **EBDA** memory is scanned, but it is not guaranteed that **EBDA** will be at least 1KiB in size. For these cases I add code that scans only the memory from **EBDA** start (the pointer) to the end of the low memory.