### PR TITLE
Constify AcpiGetHandle pathname argument

### DIFF
--- a/source/components/namespace/nsxfname.c
+++ b/source/components/namespace/nsxfname.c
@@ -192,7 +192,7 @@ AcpiNsCopyDeviceId (
 ACPI_STATUS
 AcpiGetHandle (
     ACPI_HANDLE             Parent,
-    ACPI_STRING             Pathname,
+    const char              *Pathname,
     ACPI_HANDLE             *RetHandle)
 {
     ACPI_STATUS             Status;

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -770,7 +770,7 @@ ACPI_EXTERNAL_RETURN_STATUS (
 ACPI_STATUS
 AcpiGetHandle (
     ACPI_HANDLE             Parent,
-    ACPI_STRING             Pathname,
+    const char              *Pathname,
     ACPI_HANDLE             *RetHandle))
 
 ACPI_EXTERNAL_RETURN_STATUS (


### PR DESCRIPTION
Hello,

This pull request contains a single patch, constifying the pathname argument to AcpiGetHandle. The objective is to allow passing a const pathname to the function, in order to avoid having to make a copy of it. This isn't needed by acpica per se, but by another caller in Linux.

It's the first time I'm using Github to do this, let's see how this works...

- Sakari
