### PR TITLE
compiler/dttable1.c: Fix dead assignment

### DIFF
--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -2592,7 +2592,6 @@ DtCompileIvrs (
 
             DtInsertSubtable (MainSubtable, Subtable);
             DtPushSubtable (Subtable);
-            ParentTable = MainSubtable;
             break;
 
         case ACPI_IVRS_TYPE_HID:


### PR DESCRIPTION
The value stored to 'ParentTable' is never used.

Signed-off-by: Elyes Haouas <ehaouas@noos.fr>