### PR TITLE
Revert "executer/exsystem: Warn about sleeps greater than 10 ms"

### DIFF
--- a/source/components/executer/exsystem.c
+++ b/source/components/executer/exsystem.c
@@ -339,18 +339,6 @@ AcpiExSystemDoSleep (
     AcpiExExitInterpreter ();
 
     /*
-     * Warn users about excessive sleep times, so ASL code can be improved to
-     * use polling or similar techniques.
-     */
-    if (HowLongMs > 10)
-    {
-        ACPI_WARNING ((AE_INFO,
-            "Firmware issue: Excessive sleep time (0x%8.8X%8.8X ms > 10 ms)"
-            " in ACPI Control Method",
-            ACPI_FORMAT_UINT64 (HowLongMs)));
-    }
-
-    /*
      * For compatibility with other ACPI implementations and to prevent
      * accidental deep sleeps, limit the sleep time to something reasonable.
      */


### PR DESCRIPTION
This is analogous to Linux commit c244dc1bc92e Revert "ACPICA: executer/exsystem: Warn about sleeps greater than 10 ms".