### PR TITLE
Add support for FFH Opregion special context data

### DIFF
--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -329,6 +329,14 @@ AcpiEvAddressSpaceDispatch (
             Ctx->SubspaceId = (UINT8) RegionObj->Region.Address;
         }
 
+        if (RegionObj->Region.SpaceId == ACPI_ADR_SPACE_FIXED_HARDWARE)
+        {
+            ACPI_FFH_INFO *Ctx = HandlerDesc->AddressSpace.Context;
+
+            Ctx->Length = RegionObj->Region.Length;
+            Ctx->Offset = RegionObj->Region.Address;
+        }
+
         /*
          * We must exit the interpreter because the region setup will
          * potentially execute control methods (for example, the _REG method

--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -296,7 +296,8 @@ AcpiExReadDataFromField (
         (ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_SMBUS ||
          ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GSBUS ||
          ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_IPMI  ||
-         ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_RT))
+         ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_RT ||
+         ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_FIXED_HARDWARE))
     {
         /* SMBus, GSBus, IPMI serial */
 
@@ -469,7 +470,8 @@ AcpiExWriteDataToField (
         (ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_SMBUS ||
          ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_GSBUS ||
          ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_IPMI  ||
-         ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_RT))
+         ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_RT ||
+         ObjDesc->Field.RegionObj->Region.SpaceId == ACPI_ADR_SPACE_FIXED_HARDWARE))
     {
         /* SMBus, GSBus, IPMI serial */
 

--- a/source/components/executer/exserial.c
+++ b/source/components/executer/exserial.c
@@ -484,6 +484,12 @@ AcpiExWriteSerialBus (
         Function = ACPI_WRITE;
         break;
 
+    case ACPI_ADR_SPACE_FIXED_HARDWARE:
+
+        BufferLength = ACPI_FFH_INPUT_BUFFER_SIZE;
+        Function = ACPI_WRITE;
+        break;
+
     default:
         return_ACPI_STATUS (AE_AML_INVALID_SPACE_ID);
     }

--- a/source/include/acconfig.h
+++ b/source/include/acconfig.h
@@ -335,6 +335,8 @@
 
 #define ACPI_PRM_INPUT_BUFFER_SIZE      26
 
+#define ACPI_FFH_INPUT_BUFFER_SIZE      256
+
 /* _SxD and _SxW control methods */
 
 #define ACPI_NUM_SxD_METHODS            4

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1336,6 +1336,12 @@ typedef struct acpi_pcc_info {
     UINT8                           *InternalBuffer;
 } ACPI_PCC_INFO;
 
+/* Special Context data for FFH Opregion (ACPI 6.5) */
+
+typedef struct acpi_ffh_info {
+    UINT64                          Offset;
+    UINT64                          Length;
+} ACPI_FFH_INFO;
 
 typedef
 ACPI_STATUS (*ACPI_ADR_SPACE_SETUP) (


### PR DESCRIPTION
FFH(Fixed Function Hardware) Opregion is approved to be added in ACPIC 6.5 via
code first approach[1]. It requires special context data similar to GPIO and
Generic Serial Bus as it needs to know platform specific offset and length.

Add support for the special context data needed by FFH Opregion.

FFH OpRegion enables advanced use of FFH on some architectures. For example,
it could be used to easily proxy AML code to architecture-specific behavior
(to ensure it is OS initiated)

Actual behavior of FFH is ofcourse architecture specific and depends on
the FFH bindings. The offset and length could have arch specific meaning
or usage.

[1] https://bugzilla.tianocore.org/show_bug.cgi?id=3598

Signed-off-by: Sudeep Holla <sudeep.holla@arm.com>