### PR TITLE
Add the CXIMS structure definition to the CEDT table

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -525,7 +525,8 @@ enum AcpiCedtType
 {
     ACPI_CEDT_TYPE_CHBS                 = 0,
     ACPI_CEDT_TYPE_CFMWS                = 1,
-    ACPI_CEDT_TYPE_RESERVED             = 2,
+    ACPI_CEDT_TYPE_CXIMS                = 2,
+    ACPI_CEDT_TYPE_RESERVED             = 3,
 };
 
 /* Values for version field above */
@@ -583,6 +584,7 @@ typedef struct acpi_cedt_cfmws_target_element
 /* Values for Interleave Arithmetic field above */
 
 #define ACPI_CEDT_CFMWS_ARITHMETIC_MODULO   (0)
+#define ACPI_CEDT_CFMWS_ARITHMETIC_XOR      (1)
 
 /* Values for Restrictions field above */
 
@@ -592,6 +594,15 @@ typedef struct acpi_cedt_cfmws_target_element
 #define ACPI_CEDT_CFMWS_RESTRICT_PMEM       (1<<3)
 #define ACPI_CEDT_CFMWS_RESTRICT_FIXED      (1<<4)
 
+/* 2: CXL XOR Interleave Math Structure */
+
+struct acpi_cedt_cxims {
+    ACPI_CEDT_HEADER        Header;
+    UINT16                  Reserved1;
+    UINT8                   Hbig;
+    UINT8                   NrXormaps;
+    UINT64                  XormapList[];
+};
 
 /*******************************************************************************
  *


### PR DESCRIPTION
The CXL XOR Interleave Math Structure (CXIMS) is added to the
CXL Early Discovery Table (CEDT). This new structure is defined
in an ECN to the CXL 2.0 specification.

https://www.computeexpresslink.org/spec-landing

Signed-off-by: Alison Schofield <alison.schofield@intel.com>