### PR TITLE
Headers: Delete bogus NodeArray array of pointers from AEST table

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -229,7 +229,6 @@
 typedef struct acpi_table_aest
 {
     ACPI_TABLE_HEADER       Header;
-    void                    *NodeArray[];
 
 } ACPI_TABLE_AEST;
 


### PR DESCRIPTION
Like many tables, this is a header followed by multiple subtables of
varying self-identifying types, and ACPICA does not normally add a field
for the subtables, instead relying on pointer arithmetic past the end of
the first header struct, since indexing a flexible array member is
meaningless for variable-length entries. If we really wanted a field for
this, we could use a UINT8 flexible array member, but it contradicts the
current style. Using void *, however, is categorically wrong, as ACPI
tables never contain native C-language pointers.
