### PR TITLE
Add CXL 3.0 structures (CXIMS & RDPAS) to the CEDT table

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -525,7 +525,9 @@ enum AcpiCedtType
 {
     ACPI_CEDT_TYPE_CHBS                 = 0,
     ACPI_CEDT_TYPE_CFMWS                = 1,
-    ACPI_CEDT_TYPE_RESERVED             = 2,
+    ACPI_CEDT_TYPE_CXIMS                = 2,
+    ACPI_CEDT_TYPE_RDPAS                = 3,
+    ACPI_CEDT_TYPE_RESERVED             = 4,
 };
 
 /* Values for version field above */
@@ -583,6 +585,7 @@ typedef struct acpi_cedt_cfmws_target_element
 /* Values for Interleave Arithmetic field above */
 
 #define ACPI_CEDT_CFMWS_ARITHMETIC_MODULO   (0)
+#define ACPI_CEDT_CFMWS_ARITHMETIC_XOR      (1)
 
 /* Values for Restrictions field above */
 
@@ -592,6 +595,35 @@ typedef struct acpi_cedt_cfmws_target_element
 #define ACPI_CEDT_CFMWS_RESTRICT_PMEM       (1<<3)
 #define ACPI_CEDT_CFMWS_RESTRICT_FIXED      (1<<4)
 
+/* 2: CXL XOR Interleave Math Structure */
+
+struct acpi_cedt_cxims {
+    ACPI_CEDT_HEADER        Header;
+    UINT16                  Reserved1;
+    UINT8                   Hbig;
+    UINT8                   NrXormaps;
+    UINT64                  XormapList[];
+};
+
+/* 3: CXL RCEC Downstream Port Association Structure */
+
+struct acpi_cedt_rdpas {
+    ACPI_CEDT_HEADER        Header;
+    UINT8                   Reserved1;
+    UINT16                  Length;
+    UINT16                  Segment;
+    UINT16                  Bdf;
+    UINT8                   Protocol;
+    UINT64                  Address;
+};
+
+/* Masks for bdf field above */
+#define ACPI_CEDT_RDPAS_BUS_MASK            0xff00
+#define ACPI_CEDT_RDPAS_DEVICE_MASK         0x00f8
+#define ACPI_CEDT_RDPAS_FUNCTION_MASK       0x0007
+
+#define ACPI_CEDT_RDPAS_PROTOCOL_IO        (0)
+#define ACPI_CEDT_RDPAS_PROTOCOL_CACHEMEM  (1)
 
 /*******************************************************************************
  *


### PR DESCRIPTION
The CXL 3.0 Specification[1] adds two new structures to the CXL Early Discovery Table (CEDT). The CEDT may include zero or more entries of these types:

CXIMS: CXL XOR Interleave Math Structure
       Enables the host to find a targets position in an
       Interleave Target List when XOR Math is used.

RDPAS: RCEC Downstream Post Association Structure
       Enables the host to locate the Downstream Port(s)
       that report errors to a given Root Complex Event
       Collector (RCEC).

[1]https://www.computeexpresslink.org/spec-landing

Signed-off-by: Alison Schofield <alison.schofield@intel.com>