### PR TITLE
Allow disabling of -Werror

### DIFF
--- a/generate/efi/Makefile.config
+++ b/generate/efi/Makefile.config
@@ -150,7 +150,6 @@ CWARNINGFLAGS = \
 	-Wall\
 	-Wbad-function-cast\
 	-Wdeclaration-after-statement\
-	-Werror\
 	-Wformat=2\
 	-Wmissing-declarations\
 	-Wmissing-prototypes\
@@ -162,6 +161,11 @@ CWARNINGFLAGS = \
 	-Wmissing-parameter-type\
 	-Wold-style-declaration\
 	-Wtype-limits
+
+ifneq ($(NOWERROR),TRUE)
+CWARNINGFLAGS += -Werror
+endif
+
 #
 # Extra warning flags (for possible future use)
 #

--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -203,7 +203,6 @@ CWARNINGFLAGS = \
     -Wall\
     -Wbad-function-cast\
     -Wdeclaration-after-statement\
-    -Werror\
     -Wformat=2\
     -Wmissing-declarations\
     -Wmissing-prototypes\
@@ -212,6 +211,10 @@ CWARNINGFLAGS = \
     -Wswitch-default\
     -Wpointer-arith\
     -Wundef
+
+ifneq ($(NOWERROR),TRUE)
+CWARNINGFLAGS += -Werror
+endif
 
 #
 # Common gcc 4+ warning flags

--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -290,6 +290,12 @@ CFLAGS += \
     -I$(ASL_COMPILER)\
     -I$(OBJDIR)
 
+ifeq ($(NOWERROR),TRUE)
+WERROR_FLAGS=
+else
+WERROR_FLAGS=-Werror
+endif
+
 #
 # Common Rules
 #
@@ -360,32 +366,32 @@ $(OBJDIR)/prparserparse.c $(OBJDIR)/prparser.y.h :       $(ASL_COMPILER)/prparse
 #
 $(OBJDIR)/aslcompilerlex.o :   $(OBJDIR)/aslcompilerlex.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/aslcompilerparse.o : $(OBJDIR)/aslcompilerparse.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/dtcompilerparserlex.o :      $(OBJDIR)/dtcompilerparserlex.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/dtcompilerparserparse.o :    $(OBJDIR)/dtcompilerparserparse.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/dtparserlex.o :      $(OBJDIR)/dtparserlex.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/dtparserparse.o :    $(OBJDIR)/dtparserparse.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/prparserlex.o :      $(OBJDIR)/prparserlex.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<
 
 $(OBJDIR)/prparserparse.o :    $(OBJDIR)/prparserparse.c
 	@echo "- " "Intermediate" $<
-	@$(CC) -c $(CFLAGS) -Wall -Werror -o$@ $<
+	@$(CC) -c $(CFLAGS) -Wall $(WERROR_FLAGS) -o$@ $<


### PR DESCRIPTION
For distro maintainers having `-Werror` can delay update of GCC. Since every GCC release might add new warnings that were not yet captured, it might break the build of packages.

With this, distros can now build with `NOWERROR=TRUE` instead of patching either the errors or the makefiles.

The default behavior keeps on using `-Werror`.

Fixes #798