### PR TITLE
ACPI 6.5: MADT: add support for trace buffer extension in GICC

### DIFF
--- a/source/common/dmtbinfo2.c
+++ b/source/common/dmtbinfo2.c
@@ -863,6 +863,7 @@ ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt11[] =
     {ACPI_DMT_UINT8,    ACPI_MADT11_OFFSET (EfficiencyClass),       "Efficiency Class", 0},
     {ACPI_DMT_UINT8,    ACPI_MADT11_OFFSET (Reserved2[0]),          "Reserved", 0},
     {ACPI_DMT_UINT16,   ACPI_MADT11_OFFSET (SpeInterrupt),          "SPE Overflow Interrupt", 0},
+    {ACPI_DMT_UINT16,   ACPI_MADT11_OFFSET (TrbeInterrupt),         "TRBE Interrupt", 0},
     ACPI_DMT_TERMINATOR
 };
 

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1289,7 +1289,7 @@ typedef struct acpi_madt_local_x2apic_nmi
 } ACPI_MADT_LOCAL_X2APIC_NMI;
 
 
-/* 11: Generic Interrupt - GICC (ACPI 5.0 + ACPI 6.0 + ACPI 6.3 changes) */
+/* 11: Generic Interrupt - GICC (ACPI 5.0 + ACPI 6.0 + ACPI 6.3 + ACPI 6.5 changes) */
 
 typedef struct acpi_madt_generic_interrupt
 {
@@ -1310,6 +1310,7 @@ typedef struct acpi_madt_generic_interrupt
     UINT8                   EfficiencyClass;
     UINT8                   Reserved2[1];
     UINT16                  SpeInterrupt;       /* ACPI 6.3 */
+    UINT16                  TrbeInterrupt;      /* ACPI 6.5 */
 
 } ACPI_MADT_GENERIC_INTERRUPT;
 


### PR DESCRIPTION
Signed-off-by: Xiongfeng Wang <wangxiongfeng2@huawei.com>