### PR TITLE
Add missing macro ACPI_FUNCTION_TRACE() for AcpiNsRepair_HID()

### DIFF
--- a/source/components/namespace/nsrepair2.c
+++ b/source/components/namespace/nsrepair2.c
@@ -702,7 +702,7 @@ AcpiNsRepair_HID (
     char                    *Dest;
 
 
-    ACPI_FUNCTION_NAME (NsRepair_HID);
+    ACPI_FUNCTION_TRACE (NsRepair_HID);
 
 
     /* We only care about string _HID objects (not integers) */


### PR DESCRIPTION
The following commit add function tracing macros for the namespace repiar mechanism.

  commit 87b8dba05b4cf8c111948327023c710e2b6b5a05
  Add function trace macros to improve namespace debugging

But it missed the trace macro for the entry of NsRepair_HID(). Let's add it.

Signed-off-by: Xiongfeng Wang <wangxiongfeng2@huawei.com>