### PR TITLE
dispatcher: Fix error code path in AcpiDsCallControlMethod()

### DIFF
--- a/source/components/dispatcher/dsmethod.c
+++ b/source/components/dispatcher/dsmethod.c
@@ -705,7 +705,7 @@ AcpiDsCallControlMethod (
     if (!Info)
     {
         Status = AE_NO_MEMORY;
-        goto Cleanup;
+        goto PopWalkState;
     }
 
     Info->Parameters = &ThisWalkState->Operands[0];
@@ -717,7 +717,7 @@ AcpiDsCallControlMethod (
     ACPI_FREE (Info);
     if (ACPI_FAILURE (Status))
     {
-        goto Cleanup;
+        goto PopWalkState;
     }
 
     NextWalkState->MethodNestingDepth = ThisWalkState->MethodNestingDepth + 1;
@@ -763,6 +763,12 @@ AcpiDsCallControlMethod (
 
     return_ACPI_STATUS (Status);
 
+
+PopWalkState:
+
+    /* On error, pop the walk state to be deleted from thread */
+
+    AcpiDsPopWalkState(Thread);
 
 Cleanup:
 


### PR DESCRIPTION
A use-after-free in AcpiPsParseAml() after a failing invocaion of AcpiDsCallControlMethod() is reported by KASAN [1] and code inspection reveals that next_walk_state pushed to the thread by AcpiDsCallControlMethod() is freed on errors, but it is not popped from the thread beforehand.  Thus AcpiDsGetCurrentWalkState() called by AcpiPsParseAml() subsequently returns it as the new walk state which is incorrect.

To address this, make AcpiDsCallControlMethod() call AcpiDsPopWalkState() to pop next_walk_state from the thread before returning an error.

This is based on the Linux patch at:

https://patchwork.kernel.org/project/linux-acpi/patch/2669303.mvXUDI8C0e@kreacher/
