### PR TITLE
nsrepair: handle cases without a return value correctly

### DIFF
--- a/source/components/namespace/nsrepair.c
+++ b/source/components/namespace/nsrepair.c
@@ -328,9 +328,10 @@ AcpiNsSimpleRepair (
      */
     if (!ReturnObject)
     {
-        if (ExpectedBtypes && (!(ExpectedBtypes & ACPI_RTYPE_NONE)))
+        if (ExpectedBtypes)
         {
-            if (PackageIndex != ACPI_NOT_PACKAGE_ELEMENT)
+            if (!(ExpectedBtypes & ACPI_RTYPE_NONE) &&
+                PackageIndex != ACPI_NOT_PACKAGE_ELEMENT)
             {
                 ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname,
                     ACPI_WARN_ALWAYS, "Found unexpected NULL package element"));
@@ -342,13 +343,14 @@ AcpiNsSimpleRepair (
                     return (AE_OK); /* Repair was successful */
                 }
             }
-            else
+
+            if (ExpectedBtypes != ACPI_RTYPE_NONE)
             {
                 ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname,
-                    ACPI_WARN_ALWAYS, "Missing expected return value"));
+                                       ACPI_WARN_ALWAYS,
+                                       "Missing expected return value"));
+                return (AE_AML_NO_RETURN_VALUE);
             }
-
-            return (AE_AML_NO_RETURN_VALUE);
         }
     }
 


### PR DESCRIPTION
Previously AcpiNsSimpleRepair() would crash if ExpectedBtypes contained any combination of ACPI_RTYPE_NONE with a different type, e.g | ACPI_RTYPE_INTEGER because of slightly incorrect logic in the !ReturnObject branch, which wouldn't return AE_AML_NO_RETURN_VALUE for such cases.

Found by Linux Verification Center (linuxtesting.org) with the SVACE static analysis tool.

Signed-off-by: Daniil Tatianin <d-tatianin@yandex-team.ru>