### PR TITLE
Replace fake flexible arrays with actual flexible array members

### DIFF
--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -927,8 +927,10 @@ typedef struct acpi_pci_routing_table
     UINT32                          Pin;
     UINT64                          Address;        /* here for 64-bit alignment */
     UINT32                          SourceIndex;
-    char                            Source[4];      /* pad to 64 bits so sizeof() works in all cases */
-
+    union {
+                                    char Pad[4];    /* pad to 64 bits so sizeof() works in all cases */
+                                    ACPI_FLEX_ARRAY(char, Source);
+    };
 } ACPI_PCI_ROUTING_TABLE;
 
 #endif /* __ACRESTYP_H__ */

--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -538,7 +538,7 @@ typedef struct acpi_resource_extended_irq
     UINT8                           WakeCapable;
     UINT8                           InterruptCount;
     ACPI_RESOURCE_SOURCE            ResourceSource;
-    UINT32                          Interrupts[1];
+    UINT32                          Interrupts[];
 
 } ACPI_RESOURCE_EXTENDED_IRQ;
 

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1550,7 +1550,7 @@ enum AcpiMadtLpcPicVersion {
 
 typedef struct acpi_madt_oem_data
 {
-    UINT8                   OemData[];
+    ACPI_FLEX_ARRAY(UINT8, OemData);
 } ACPI_MADT_OEM_DATA;
 
 

--- a/source/include/platform/acenv.h
+++ b/source/include/platform/acenv.h
@@ -419,6 +419,17 @@
 #endif
 
 /*
+ * Flexible array members are not allowed to be part of a union under
+ * C99, but this is not for any technical reason. Work around the
+ * limitation.
+ */
+#define ACPI_FLEX_ARRAY(TYPE, NAME)             \
+        struct {                                \
+                struct { } __Empty_ ## NAME;    \
+                TYPE NAME[];                    \
+        }
+
+/*
  * Configurable calling conventions:
  *
  * ACPI_SYSTEM_XFACE        - Interfaces to host OS (handlers, threads)


### PR DESCRIPTION
This continues earlier C99 work to modernize the code to work correctly with compile-time and run-time bounds checkers.