### PR TITLE
specify size for OemData array to avoid compile error

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1550,7 +1550,7 @@ enum AcpiMadtLpcPicVersion {
 
 typedef struct acpi_madt_oem_data
 {
-    UINT8                   OemData[];
+    UINT8                   OemData[8];
 } ACPI_MADT_OEM_DATA;
 
 


### PR DESCRIPTION
specify size for OemData array to avoid compile error

    The sizeof OemData array is not specified which will lead to compiling
    error of "flexible array member in a struct with no named members".
    From ACPI Spec Table 5.19, the largest data struct for Oem is 8. So,
    specify OemData array size to 8.

    Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>