### PR TITLE
ACPICA: hwvalid: Drop port I/O validation

### DIFF
--- a/source/components/hardware/hwvalid.c
+++ b/source/components/hardware/hwvalid.c
@@ -169,8 +169,8 @@ AcpiHwValidateIoRequest (
  *
  * The table is used to implement the Microsoft port access rules that
  * first appeared in Windows XP. Some ports are always illegal, and some
- * ports are only illegal if the BIOS calls _OSI with a WinXP string or
- * later (meaning that the BIOS itelf is post-XP.)
+ * ports are only illegal if the BIOS calls _OSI with nothing newer than
+ * the specific _OSI strings.
  *
  * This provides ACPICA with the desired port protections and
  * Microsoft compatibility.
@@ -301,8 +301,8 @@ AcpiHwValidateIoRequest (
         if ((Address <= PortInfo->End) && (LastAddress >= PortInfo->Start))
         {
             /* Port illegality may depend on the _OSI calls made by the BIOS */
-
-            if (AcpiGbl_OsiData >= PortInfo->OsiDependency)
+            if (PortInfo->OsiDependency == ACPI_ALWAYS_ILLEGAL ||
+                AcpiGbl_OsiData == PortInfo->OsiDependency)
             {
                 ACPI_DEBUG_PRINT ((ACPI_DB_VALUES,
                     "Denied AML access to port 0x%8.8X%8.8X/%X (%s 0x%.4X-0x%.4X)\n",


### PR DESCRIPTION
Microsoft introduced support in Windows XP for blocking port I/O to various regions.  For Windows compatibility ACPICA has adopted the same protections and will disallow writes to those (presumably) the same regions.

On some systems the AML included with the firmware will issue 4 byte long writes to 0x80.  These writes aren't making it over because of this blockage. The first 4 byte write attempt is rejected, and then subsequently 1 byte at a time each offset is tried. The first at 0x80 works, but then the next 3 bytes are rejected.

This manifests in bizarre failures for devices that expected the AML to write all 4 bytes.  Trying the same AML on Windows 10 or 11 doesn't hit this failure and all 4 bytes are written.

Either some of these regions were wrong or some point after Windows XP some of these regions blocks have been lifted.

In the last 15 years there doesn't seem to be any reports popping up of this error in the Windows event viewer anymore.  There is no documentation at Microsoft's developer site indicating that Windows ACPI interpreter blocks these regions. Between the lack of documentation and the fact that the writes actually do work in Windows 10 and 11, it's quite likely Windows doesn't actually enforce this anymore.

So to help the issue, drop enforcing protected ranges.

Fixes https://github.com/acpica/acpica/issues/816
Signed-off-by: Mario Limonciello <mario.limonciello@amd.com>