### PR TITLE
Restore Acer 4752 Wake-on-LAN

### DIFF
--- a/source/components/events/evevent.c
+++ b/source/components/events/evevent.c
@@ -312,8 +312,7 @@ AcpiEvFixedEventInitialize (
         {
             Status = AcpiWriteBitRegister (
                 AcpiGbl_FixedEventInfo[i].EnableRegisterId,
-                (i == ACPI_EVENT_PCIE_WAKE) ?
-                ACPI_ENABLE_EVENT : ACPI_DISABLE_EVENT);
+                ACPI_DISABLE_EVENT);
             if (ACPI_FAILURE (Status))
             {
                 return (Status);
@@ -437,8 +436,7 @@ AcpiEvFixedEventDispatch (
     {
         (void) AcpiWriteBitRegister (
             AcpiGbl_FixedEventInfo[Event].EnableRegisterId,
-            (Event == ACPI_EVENT_PCIE_WAKE) ?
-	    ACPI_ENABLE_EVENT : ACPI_DISABLE_EVENT);
+	    ACPI_DISABLE_EVENT);
 
         ACPI_ERROR ((AE_INFO,
             "No installed handler for fixed event - %s (%u), disabling",


### PR DESCRIPTION
32d875705 broke Acer 4752 WOL. With 32d875705 to get WOL to work on the Acer one must following poweroff, remove the power cord from the machine and reattach the power cord to the machine. Then send a magic WOL packet to the machine's MAC address. This commit fixes this.

Fixes:		32d875705
Tested on:	FreeBSD 14-CURRENT