### PR TITLE
actbl2: Fix compilation of ACPI_MADT_OEM_DATA on gcc and clang

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1550,7 +1550,7 @@ enum AcpiMadtLpcPicVersion {
 
 typedef struct acpi_madt_oem_data
 {
-    UINT8                   OemData[];
+    UINT8                   OemData[0];
 } ACPI_MADT_OEM_DATA;
 
 


### PR DESCRIPTION
Flexible arrays are not allowed in structs that would otherwise be empty (see https://godbolt.org/z/EqKqTMETT). Because of that, use a zero-length array.

Before this, GCC and clang failed to compile ACPICA.

Signed-off-by: Pedro Falcato <pedro.falcato@gmail.com>