### PR TITLE
Revert "Replace fake flexible arrays with actual flexible array members"

### DIFF
--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -538,7 +538,7 @@ typedef struct acpi_resource_extended_irq
     UINT8                           WakeCapable;
     UINT8                           InterruptCount;
     ACPI_RESOURCE_SOURCE            ResourceSource;
-    UINT32                          Interrupts[];
+    UINT32                          Interrupts[1];
 
 } ACPI_RESOURCE_EXTENDED_IRQ;
 
@@ -927,10 +927,8 @@ typedef struct acpi_pci_routing_table
     UINT32                          Pin;
     UINT64                          Address;        /* here for 64-bit alignment */
     UINT32                          SourceIndex;
-    union {
-                                    char Pad[4];    /* pad to 64 bits so sizeof() works in all cases */
-                                    ACPI_FLEX_ARRAY(char, Source);
-    };
+    char                            Source[4];      /* pad to 64 bits so sizeof() works in all cases */
+
 } ACPI_PCI_ROUTING_TABLE;
 
 #endif /* __ACRESTYP_H__ */

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1552,7 +1552,7 @@ enum AcpiMadtLpcPicVersion {
 
 typedef struct acpi_madt_oem_data
 {
-    ACPI_FLEX_ARRAY(UINT8, OemData);
+    UINT8                   OemData[];
 } ACPI_MADT_OEM_DATA;
 
 

--- a/source/include/platform/acenv.h
+++ b/source/include/platform/acenv.h
@@ -419,17 +419,6 @@
 #endif
 
 /*
- * Flexible array members are not allowed to be part of a union under
- * C99, but this is not for any technical reason. Work around the
- * limitation.
- */
-#define ACPI_FLEX_ARRAY(TYPE, NAME)             \
-        struct {                                \
-                struct { } __Empty_ ## NAME;    \
-                TYPE NAME[];                    \
-        }
-
-/*
  * Configurable calling conventions:
  *
  * ACPI_SYSTEM_XFACE        - Interfaces to host OS (handlers, threads)


### PR DESCRIPTION
Reverts acpica/acpica#813

Causes many build errors on MS Visual C:

Severity	Code	Description	Project	File	Line	Suppression State
Error	C2016	C requires that a struct or union has at least one member (compiling source file ..\..\source\COMPONENTS\Disassembler\dmwalk.c)	AcpiExec	c:\acpica\source\include\acrestyp.h	932	
