### PR TITLE
iasl: Set AcpiGbl_ParseOpRoot to NULL when freed

### DIFF
--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -789,6 +789,7 @@ AdDoExternalFileList (
             AcpiDmFinishNamespaceLoad (AcpiGbl_ParseOpRoot,
                 AcpiGbl_RootNode, OwnerId);
             AcpiPsDeleteParseTree (AcpiGbl_ParseOpRoot);
+            AcpiGbl_ParseOpRoot = NULL;
 
             ExternalListHead = ExternalListHead->Next;
         }


### PR DESCRIPTION
Most invocations of `AcpiPsDeleteParseTree (AcpiGbl_ParseOpRoot);` are followed by `AcpiGbl_ParseOpRoot = NULL;`, but there was one which was missing this. Fixes #841.