### PR TITLE
iasl: check Offset before Subtable dereference

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1058,16 +1058,16 @@ NextSubtable:
         Subtable = ACPI_ADD_PTR (ACPI_SUBTABLE_HEADER, Subtable,
             Subtable->Length);
 
-        DbgPrint (ASL_PARSE_OUTPUT, "//[5) Next Subtable %p, length %X]\n",
-            Subtable, Subtable->Length);
-        DbgPrint (ASL_PARSE_OUTPUT, "//[5B) Offset from table start: 0x%8.8X%8.8X (%p)]\n",
-            ACPI_FORMAT_UINT64 (ACPI_CAST_PTR (char, Subtable) - ACPI_CAST_PTR (char, Table)), Subtable);
-
         Offset = ACPI_CAST_PTR (char, Subtable) - ACPI_CAST_PTR (char, Table);
         if (Offset >= Table->Length)
         {
             return;
         }
+
+        DbgPrint (ASL_PARSE_OUTPUT, "//[5) Next Subtable %p, length %X]\n",
+            Subtable, Subtable->Length);
+        DbgPrint (ASL_PARSE_OUTPUT, "//[5B) Offset from table start: 0x%8.8X%8.8X (%p)]\n",
+            ACPI_FORMAT_UINT64 (ACPI_CAST_PTR (char, Subtable) - ACPI_CAST_PTR (char, Table)), Subtable);
     }
 }
 


### PR DESCRIPTION
In AcpiDmDumpMadt(), compute and check the Offset before attempting to dereference Subtable fields to prevent a read overflow.

I found this issue while debugging #841. Effectively, some debug statements were trying to dereference data from the updated Subtable pointer before checking if the Offset made it past the end of the table. This PR just moves some lines around to compute and check Offset before trying to access data for debug printing. 