### PR TITLE
Avoid undefined behavior: member access within null pointer

### DIFF
--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -310,7 +310,10 @@
 #define ACPI_USE_STANDARD_HEADERS
 
 #ifdef ACPI_USE_STANDARD_HEADERS
+#include <stddef.h>
 #include <unistd.h>
+
+#define ACPI_OFFSET(d, f)   offsetof(d, f)
 #endif
 
 /* Define/disable kernel-specific declarators */


### PR DESCRIPTION
84449c1eef1c0d092b037dc4c2c60cec5d5cc6c4 fixed this for Linux kernel builds, but not Linux userspace builds.

Before this change we see the following UBSAN stack trace in Fuchsia:
```
      ../../third_party/acpica/source/components/tables/tbfadt.c:536:39: runtime error: member access within null pointer of type 'ACPI_TABLE_FADT' (aka 'struct acpi_table_fadt')
          #0 0x564860b5ee9b in AcpiTbConvertFadt ../../third_party/acpica/source/components/tables/tbfadt.c:536:39
          #1 0x564860b5edb4 in AcpiTbCreateLocalFadt ../../third_party/acpica/source/components/tables/tbfadt.c:461:5
          #2 0x564860b5e5c6 in AcpiTbParseFadt ../../third_party/acpica/source/components/tables/tbfadt.c:371:5
          #3 0x564860b5c485 in AcpiTbParseRootTable ../../third_party/acpica/source/components/tables/tbutils.c:407:13
          #4 0x564860b6401a in AcpiInitializeTables ../../third_party/acpica/source/components/tables/tbxface.c:160:14
          #5 0x5648608fb417 in acpi_host_test::AcpiHostTest::InitAcpiWithTables(char const*) ../../src/devices/board/tests/acpi-host-tests/acpi-host-test.cc:36:5
          #6 0x5648608f9095 in acpi_host_test::AcpiHostTest_DeviceIsChildOfScopeTest_Test::TestBody() ../../src/devices/board/tests/acpi-host-tests/acpi-host-test.cc:85:3
          #7 0x564860c6007e in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../../third_party/googletest/src/googletest/src/gtest.cc:2609:10
          #8 0x564860bbd5df in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../../third_party/googletest/src/googletest/src/gtest.cc:2664:12    #9 0x564860bbd141 in testing::Test::Run() ../../third_party/googletest/src/googletest/src/gtest.cc:2684:5    #10 0x564860bbff0a in testing::TestInfo::Run() ../../third_party/googletest/src/googletest/src/gtest.cc:2864:11    #11 0x564860bc40f1 in testing::TestSuite::Run() ../../third_party/googletest/src/googletest/src/gtest.cc:3023:30    #12 0x564860beba40 in testing::internal::UnitTestImpl::RunAllTests() ../../third_party/googletest/src/googletest/src/gtest.cc:5882:44
          #13 0x564860c7db6e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../../third_party/googletest/src/googletest/src/gtest.cc:2609:10
          #14 0x564860bea71f in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../../third_party/googletest/src/googletest/src/gtest.cc:2664:12    #15 0x564860bea1c5 in testing::UnitTest::Run() ../../third_party/googletest/src/googletest/src/gtest.cc:5456:10    #16 0x5648608fccc0 in RUN_ALL_TESTS() ../../third_party/googletest/src/googletest/include/gtest/gtest.h:2304:73    #17 0x5648608fcb7e in main ../../src/devices/board/tests/acpi-host-tests/acpi-host-test.cc:121:10    #18 0x7f6defa2d189  (/lib/x86_64-linux-gnu/libc.so.6+0x27189) (BuildId: c4f6727c560b1c33527ff9e0ca0cef13a7db64d2)
          #19 0x7f6defa2d244 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27244) (BuildId: c4f6727c560b1c33527ff9e0ca0cef13a7db64d2)
          #20 0x56486082e598  (/usr/local/google/home/tamird/src/fuchsia/out/core.x64/host_x64/acpi-host-test-bin+0x359598) (BuildId: 851423b0e664df6a)
```
Updates #844.