### PR TITLE
Avoid undefined behavior: load of misaligned address

### DIFF
--- a/source/components/tables/tbutils.c
+++ b/source/components/tables/tbutils.c
@@ -323,6 +323,7 @@ AcpiTbGetRootTableEntry (
     UINT8                   *TableEntry,
     UINT32                  TableEntrySize)
 {
+    UINT32                  Address32;
     UINT64                  Address64;
 
 
@@ -336,8 +337,8 @@ AcpiTbGetRootTableEntry (
          * 32-bit platform, RSDT: Return 32-bit table entry
          * 64-bit platform, RSDT: Expand 32-bit to 64-bit and return
          */
-        return ((ACPI_PHYSICAL_ADDRESS) (*ACPI_CAST_PTR (
-            UINT32, TableEntry)));
+        ACPI_MOVE_32_TO_32(&Address32, TableEntry);
+        return Address32;
     }
     else
     {


### PR DESCRIPTION
Before this change we see the following UBSAN stack trace in Fuchsia:
```
  #0    0x00002234800696e6 in AcpiTbGetRootTableEntry(UINT8*, UINT32) ../../third_party/acpica/source/components/tables/tbutils.c:231 <platform-bus-x86.so>+0x9106e6
  #1.2  0x0000233d72c8777f in ubsan_GetStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:41 <libclang_rt.asan.so>+0x3d77f
  #1.1  0x0000233d72c8777f in MaybePrintStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:51 <libclang_rt.asan.so>+0x3d77f
  #1    0x0000233d72c8777f in ~ScopedReport() compiler-rt/lib/ubsan/ubsan_diag.cpp:387 <libclang_rt.asan.so>+0x3d77f
  #2    0x0000233d72c88385 in handleTypeMismatchImpl() compiler-rt/lib/ubsan/ubsan_handlers.cpp:137 <libclang_rt.asan.so>+0x3e385
  #3    0x0000233d72c87ead in compiler-rt/lib/ubsan/ubsan_handlers.cpp:142 <libclang_rt.asan.so>+0x3dead
  #4    0x00002234800696e6 in AcpiTbGetRootTableEntry(UINT8*, UINT32) ../../third_party/acpica/source/components/tables/tbutils.c:231 <platform-bus-x86.so>+0x9106e6
  #5    0x00002234800691dd in AcpiTbParseRootTable(ACPI_PHYSICAL_ADDRESS) ../../third_party/acpica/source/components/tables/tbutils.c:385 <platform-bus-x86.so>+0x9101dd
  #6    0x0000223480070b06 in AcpiInitializeTables(ACPI_TABLE_DESC*, UINT32, BOOLEAN) ../../third_party/acpica/source/components/tables/tbxface.c:160 <platform-bus-x86.so>+0x917b06
  #7    0x000022347fb803b4 in acpi::AcpiImpl::InitializeAcpi(acpi::AcpiImpl*) ../../src/devices/board/lib/acpi/acpi-impl.cc:200 <platform-bus-x86.so>+0x4273b4
  #8    0x000022347fa30d14 in x86::X86::EarlyAcpiInit(x86::X86*) ../../src/devices/board/drivers/x86/init.cc:34 <platform-bus-x86.so>+0x2d7d14
  #9    0x000022347fa310cf in x86::X86::EarlyInit(x86::X86*) ../../src/devices/board/drivers/x86/init.cc:43 <platform-bus-x86.so>+0x2d80cf
  #10   0x000022347fa79410 in x86::X86::Bind(x86::X86*) ../../src/devices/board/drivers/x86/x86.cc:144 <platform-bus-x86.so>+0x320410
  #11   0x000022347fa78ec0 in x86::X86::CreateAndBind(void*, zx_device_t*) ../../src/devices/board/drivers/x86/x86.cc:123 <platform-bus-x86.so>+0x31fec0
  #12   0x000020dc8908502f in λ(const zx_driver::BindOp::(anon class)*) ../../src/devices/bin/driver_host/zx_driver.cc:36 <<application>>+0x41502f
  #13   0x000020dc89084e03 in fit::internal::target<(lambda at../../src/devices/bin/driver_host/zx_driver.cc:34:61), false, false, void>::invoke(void*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:181 <<application>>+0x414e03
  #14   0x000020dc8935a930 in fit::internal::function_base<16UL, false, void()>::invoke(const fit::internal::function_base<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <<application>>+0x6ea930
  #15   0x000020dc893e2f8a in fit::function_impl<16UL, false, void()>::operator()(const fit::function_impl<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/function.h:300 <<application>>+0x772f8a
  #16   0x000020dc8948dec5 in async::internal::RetainedTask::Handler(async_dispatcher_t*, async_task_t*, zx_status_t) ../../zircon/system/ulib/async/task.cc:25 <<application>>+0x81dec5
  #17   0x000023ab5abcf91e in λ(const driver_runtime::Dispatcher::PostTask::(anon class)*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/dispatcher.cc:715 <libdriver_runtime.so>+0xed91e
  #18   0x000023ab5abcf621 in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:714:7), true, false, void, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int>::invoke(void*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0xed621
  #19   0x000023ab5abaa482 in fit::internal::function_base<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::invoke(const fit::internal::function_base<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0xc8482
  #20   0x000023ab5abaa0f8 in fit::callback_impl<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::operator()(fit::callback_impl<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/function.h:451 <libdriver_runtime.so>+0xc80f8
  #21   0x000023ab5ab81c76 in driver_runtime::CallbackRequest::Call(driver_runtime::CallbackRequest*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/callback_request.h:67 <libdriver_runtime.so>+0x9fc76
  #22   0x000023ab5ab8e7ef in driver_runtime::Dispatcher::DispatchCallback(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >) ../../src/devices/bin/driver_runtime/dispatcher.cc:1093 <libdriver_runtime.so>+0xac7ef
  #23   0x000023ab5ab91d67 in driver_runtime::Dispatcher::DispatchCallbacks(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.cc:1169 <libdriver_runtime.so>+0xafd67
  #24   0x000023ab5abbe9a2 in λ(const driver_runtime::Dispatcher::CreateWithAdder::(anon class)*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.cc:338 <libdriver_runtime.so>+0xdc9a2
  #25   0x000023ab5abbe6d2 in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:337:7), true, false, void, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>>::invoke(void*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0xdc6d2
  #26   0x000023ab5abac1e5 in fit::internal::function_base<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::invoke(const fit::internal::function_base<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0xca1e5
  #27   0x000023ab5ababe32 in fit::function_impl<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::operator()(const fit::function_impl<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/function.h:300 <libdriver_runtime.so>+0xc9e32
  #28   0x000023ab5ab95444 in driver_runtime::Dispatcher::EventWaiter::InvokeCallback(driver_runtime::Dispatcher::EventWaiter*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.h:299 <libdriver_runtime.so>+0xb3444
  #29   0x000023ab5ab94feb in driver_runtime::Dispatcher::EventWaiter::HandleEvent(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, async_dispatcher_t*, async::WaitBase*, zx_status_t, zx_packet_signal_t const*) ../../src/devices/bin/driver_runtime/dispatcher.cc:1259 <libdriver_runtime.so>+0xb2feb
  #30   0x000023ab5abbef74 in AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent(AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>*, async_dispatcher_t*, async::WaitBase*, zx_status_t, zx_packet_signal_t const*) ../../src/devices/bin/driver_runtime/async_loop_owned_event_handler.h:59 <libdriver_runtime.so>+0xdcf74
  #31   0x000023ab5abbf1cb in async::WaitMethod<AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>, &AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent>::CallHandler(async_dispatcher_t*, async_wait_t*, zx_status_t, zx_packet_signal_t const*) ../../zircon/system/ulib/async/include/lib/async/cpp/wait.h:201 <libdriver_runtime.so>+0xdd1cb
  #32   0x000023ab5ac323a9 in async_loop_dispatch_wait(async_loop_t*, async_wait_t*, zx_status_t, zx_packet_signal_t const*) ../../zircon/system/ulib/async-loop/loop.c:381 <libdriver_runtime.so>+0x1503a9
  #33   0x000023ab5ac2ba82 in async_loop_run_once(async_loop_t*, zx_time_t) ../../zircon/system/ulib/async-loop/loop.c:330 <libdriver_runtime.so>+0x149a82
  #34   0x000023ab5ac2b102 in async_loop_run(async_loop_t*, zx_time_t, _Bool) ../../zircon/system/ulib/async-loop/loop.c:288 <libdriver_runtime.so>+0x149102
  #35   0x000023ab5ac2ceb7 in async_loop_run_thread(void*) ../../zircon/system/ulib/async-loop/loop.c:840 <libdriver_runtime.so>+0x14aeb7
  #36   0x000040b3be411f1c in start_c11(void*) ../../zircon/third_party/ulib/musl/pthread/pthread_create.c:55 <libc.so>+0xd7f1c
  #37   0x000040b3be53ce8d in thread_trampoline(uintptr_t, uintptr_t) ../../zircon/system/ulib/runtime/thread.cc:100 <libc.so>+0x202e8d
```