### PR TITLE
Avoid undefined behavior: member access within misaligned address

### DIFF
--- a/source/components/resources/rsaddr.c
+++ b/source/components/resources/rsaddr.c
@@ -433,11 +433,15 @@ AcpiRsGetAddressCommon (
 {
     ACPI_FUNCTION_ENTRY ();
 
+    /* Avoid undefined behavior: member access within misaligned address */
+
+    AML_RESOURCE_ADDRESS Address;
+    memcpy(&Address, Aml, sizeof(Address));
 
     /* Validate the Resource Type */
 
-    if ((Aml->Address.ResourceType > 2) &&
-        (Aml->Address.ResourceType < 0xC0))
+    if ((Address.ResourceType > 2) &&
+        (Address.ResourceType < 0xC0))
     {
         return (FALSE);
     }
@@ -464,7 +468,7 @@ AcpiRsGetAddressCommon (
         /* Generic resource type, just grab the TypeSpecific byte */
 
         Resource->Data.Address.Info.TypeSpecific =
-            Aml->Address.SpecificFlags;
+            Address.SpecificFlags;
     }
 
     return (TRUE);


### PR DESCRIPTION
Before this change we see the following UBSAN stack trace in Fuchsia:
```
  #0    0x0000220c98288eba in AcpiRsGetAddressCommon(ACPI_RESOURCE*, AML_RESOURCE*) ../../third_party/acpica/source/components/resources/rsaddr.c:331 <platform-bus-x86.so>+0x8f6eba
  #1.2  0x000023625f46077f in ubsan_GetStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:41 <libclang_rt.asan.so>+0x3d77f
  #1.1  0x000023625f46077f in MaybePrintStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:51 <libclang_rt.asan.so>+0x3d77f
  #1    0x000023625f46077f in ~ScopedReport() compiler-rt/lib/ubsan/ubsan_diag.cpp:387 <libclang_rt.asan.so>+0x3d77f
  #2    0x000023625f461385 in handleTypeMismatchImpl() compiler-rt/lib/ubsan/ubsan_handlers.cpp:137 <libclang_rt.asan.so>+0x3e385
  #3    0x000023625f460ead in compiler-rt/lib/ubsan/ubsan_handlers.cpp:142 <libclang_rt.asan.so>+0x3dead
  #4    0x0000220c98288eba in AcpiRsGetAddressCommon(ACPI_RESOURCE*, AML_RESOURCE*) ../../third_party/acpica/source/components/resources/rsaddr.c:331 <platform-bus-x86.so>+0x8f6eba
  #5    0x0000220c9828ea57 in AcpiRsConvertAmlToResource(ACPI_RESOURCE*, AML_RESOURCE*, ACPI_RSCONVERT_INFO*) ../../third_party/acpica/source/components/resources/rsmisc.c:352 <platform-bus-x86.so>+0x8fca57
  #6    0x0000220c9828992c in AcpiRsConvertAmlToResources(UINT8*, UINT32, UINT32, UINT8, void**) ../../third_party/acpica/source/components/resources/rslist.c:132 <platform-bus-x86.so>+0x8f792c
  #7    0x0000220c982d1cfc in AcpiUtWalkAmlResources(ACPI_WALK_STATE*, UINT8*, ACPI_SIZE, ACPI_WALK_AML_CALLBACK, void**) ../../third_party/acpica/source/components/utilities/utresrc.c:234 <platform-bus-x86.so>+0x93fcfc
  #8    0x0000220c98281e46 in AcpiRsCreateResourceList(ACPI_OPERAND_OBJECT*, ACPI_BUFFER*) ../../third_party/acpica/source/components/resources/rscreate.c:199 <platform-bus-x86.so>+0x8efe46
  #9    0x0000220c98293b51 in AcpiRsGetMethodData(ACPI_HANDLE, const char*, ACPI_BUFFER*) ../../third_party/acpica/source/components/resources/rsutils.c:770 <platform-bus-x86.so>+0x901b51
  #10   0x0000220c9829438d in AcpiWalkResources(ACPI_HANDLE, char*, ACPI_WALK_RESOURCE_CALLBACK, void*) ../../third_party/acpica/source/components/resources/rsxface.c:731 <platform-bus-x86.so>+0x90238d
  #11   0x0000220c97db272b in acpi::AcpiImpl::WalkResources(acpi::AcpiImpl*, ACPI_HANDLE, const char*, acpi::Acpi::ResourcesCallable) ../../src/devices/board/lib/acpi/acpi-impl.cc:41 <platform-bus-x86.so>+0x42072b
  #12   0x0000220c97dcec59 in acpi::DeviceBuilder::GatherResources(acpi::DeviceBuilder*, acpi::Acpi*, fidl::AnyArena&, acpi::Manager*, acpi::DeviceBuilder::GatherResourcesCallback) ../../src/devices/board/lib/acpi/device-builder.cc:52 <platform-bus-x86.so>+0x43cc59
  #13   0x0000220c97f94a3f in acpi::Manager::ConfigureDiscoveredDevices(acpi::Manager*) ../../src/devices/board/lib/acpi/manager.cc:75 <platform-bus-x86.so>+0x602a3f
  #14   0x0000220c97c642c7 in publish_acpi_devices(acpi::Manager*, zx_device_t*, zx_device_t*) ../../src/devices/board/drivers/x86/acpi-nswalk.cc:102 <platform-bus-x86.so>+0x2d22c7
  #15   0x0000220c97caf3e6 in x86::X86::DoInit(x86::X86*) ../../src/devices/board/drivers/x86/x86.cc:65 <platform-bus-x86.so>+0x31d3e6
  #16   0x0000220c97cd72ae in λ(x86::X86::DdkInit::(anon class)*) ../../src/devices/board/drivers/x86/x86.cc:82 <platform-bus-x86.so>+0x3452ae
  #17   0x0000220c97cd7223 in fit::internal::target<(lambda at../../src/devices/board/drivers/x86/x86.cc:81:19), false, false, void>::invoke(void*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:181 <platform-bus-x86.so>+0x345223
  #18   0x0000220c97f48eb0 in fit::internal::function_base<16UL, false, void()>::invoke(const fit::internal::function_base<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <platform-bus-x86.so>+0x5b6eb0
  #19   0x0000220c97f48d2a in fit::function_impl<16UL, false, void()>::operator()(const fit::function_impl<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/function.h:300 <platform-bus-x86.so>+0x5b6d2a
  #20   0x0000220c982f9245 in async::internal::RetainedTask::Handler(async_dispatcher_t*, async_task_t*, zx_status_t) ../../zircon/system/ulib/async/task.cc:25 <platform-bus-x86.so>+0x967245
  #21   0x000022e2aa1cd91e in λ(const driver_runtime::Dispatcher::PostTask::(anon class)*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/dispatcher.cc:715 <libdriver_runtime.so>+0xed91e
  #22   0x000022e2aa1cd621 in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:714:7), true, false, void, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int>::invoke(void*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0xed621
  #23   0x000022e2aa1a8482 in fit::internal::function_base<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::invoke(const fit::internal::function_base<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0xc8482
  #24   0x000022e2aa1a80f8 in fit::callback_impl<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::operator()(fit::callback_impl<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/function.h:451 <libdriver_runtime.so>+0xc80f8
  #25   0x000022e2aa17fc76 in driver_runtime::CallbackRequest::Call(driver_runtime::CallbackRequest*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/callback_request.h:67 <libdriver_runtime.so>+0x9fc76
  #26   0x000022e2aa18c7ef in driver_runtime::Dispatcher::DispatchCallback(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >) ../../src/devices/bin/driver_runtime/dispatcher.cc:1093 <libdriver_runtime.so>+0xac7ef
  #27   0x000022e2aa18fd67 in driver_runtime::Dispatcher::DispatchCallbacks(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.cc:1169 <libdriver_runtime.so>+0xafd67
  #28   0x000022e2aa1bc9a2 in λ(const driver_runtime::Dispatcher::CreateWithAdder::(anon class)*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.cc:338 <libdriver_runtime.so>+0xdc9a2
  #29   0x000022e2aa1bc6d2 in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:337:7), true, false, void, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>>::invoke(void*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0xdc6d2
  #30   0x000022e2aa1aa1e5 in fit::internal::function_base<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::invoke(const fit::internal::function_base<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0xca1e5
  #31   0x000022e2aa1a9e32 in fit::function_impl<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::operator()(const fit::function_impl<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/function.h:300 <libdriver_runtime.so>+0xc9e32
  #32   0x000022e2aa193444 in driver_runtime::Dispatcher::EventWaiter::InvokeCallback(driver_runtime::Dispatcher::EventWaiter*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.h:299 <libdriver_runtime.so>+0xb3444
  #33   0x000022e2aa192feb in driver_runtime::Dispatcher::EventWaiter::HandleEvent(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, async_dispatcher_t*, async::WaitBase*, zx_status_t, zx_packet_signal_t const*) ../../src/devices/bin/driver_runtime/dispatcher.cc:1259 <libdriver_runtime.so>+0xb2feb
  #34   0x000022e2aa1bcf74 in AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent(AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>*, async_dispatcher_t*, async::WaitBase*, zx_status_t, zx_packet_signal_t const*) ../../src/devices/bin/driver_runtime/async_loop_owned_event_handler.h:59 <libdriver_runtime.so>+0xdcf74
  #35   0x000022e2aa1bd1cb in async::WaitMethod<AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>, &AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent>::CallHandler(async_dispatcher_t*, async_wait_t*, zx_status_t, zx_packet_signal_t const*) ../../zircon/system/ulib/async/include/lib/async/cpp/wait.h:201 <libdriver_runtime.so>+0xdd1cb
  #36   0x000022e2aa2303a9 in async_loop_dispatch_wait(async_loop_t*, async_wait_t*, zx_status_t, zx_packet_signal_t const*) ../../zircon/system/ulib/async-loop/loop.c:381 <libdriver_runtime.so>+0x1503a9
  #37   0x000022e2aa229a82 in async_loop_run_once(async_loop_t*, zx_time_t) ../../zircon/system/ulib/async-loop/loop.c:330 <libdriver_runtime.so>+0x149a82
  #38   0x000022e2aa229102 in async_loop_run(async_loop_t*, zx_time_t, _Bool) ../../zircon/system/ulib/async-loop/loop.c:288 <libdriver_runtime.so>+0x149102
  #39   0x000022e2aa22aeb7 in async_loop_run_thread(void*) ../../zircon/system/ulib/async-loop/loop.c:840 <libdriver_runtime.so>+0x14aeb7
  #40   0x000041a874980f1c in start_c11(void*) ../../zircon/third_party/ulib/musl/pthread/pthread_create.c:55 <libc.so>+0xd7f1c
  #41   0x000041a874aabe8d in thread_trampoline(uintptr_t, uintptr_t) ../../zircon/system/ulib/runtime/thread.cc:100 <libc.so>+0x202e8d
```