### PR TITLE
Avoid undefined behavior: member access within misaligned address

### DIFF
--- a/source/components/resources/rscalc.c
+++ b/source/components/resources/rscalc.c
@@ -740,14 +740,19 @@ AcpiRsGetListLength (
             }
             break;
 
-        case ACPI_RESOURCE_NAME_SERIAL_BUS:
+        case ACPI_RESOURCE_NAME_SERIAL_BUS: {
+            /* Avoid undefined behavior: member access within misaligned address */
+
+            AML_RESOURCE_COMMON_SERIALBUS CommonSerialBus;
+            memcpy(&CommonSerialBus, AmlResource, sizeof(CommonSerialBus));
 
             MinimumAmlResourceLength = AcpiGbl_ResourceAmlSerialBusSizes[
-                AmlResource->CommonSerialBus.Type];
+                CommonSerialBus.Type];
             ExtraStructBytes +=
-                AmlResource->CommonSerialBus.ResourceLength -
+                CommonSerialBus.ResourceLength -
                 MinimumAmlResourceLength;
             break;
+        }
 
         case ACPI_RESOURCE_NAME_PIN_CONFIG:
 
@@ -816,8 +821,13 @@ AcpiRsGetListLength (
         if (AcpiUtGetResourceType (AmlBuffer) ==
             ACPI_RESOURCE_NAME_SERIAL_BUS)
         {
+            /* Avoid undefined behavior: member access within misaligned address */
+
+            AML_RESOURCE_COMMON_SERIALBUS CommonSerialBus;
+            memcpy(&CommonSerialBus, AmlResource, sizeof(CommonSerialBus));
+
             BufferSize = AcpiGbl_ResourceStructSerialBusSizes[
-                AmlResource->CommonSerialBus.Type] + ExtraStructBytes;
+                CommonSerialBus.Type] + ExtraStructBytes;
         }
         else
         {


### PR DESCRIPTION
Before this change we see the following UBSAN stack trace in Fuchsia:
```
  #0    0x0000219ce3426bd7 in AcpiRsGetListLength(UINT8*, UINT32, ACPI_SIZE*) ../../third_party/acpica/source/components/resources/rscalc.c:631 <platform-bus-x86.so>+0x2cbbd7
  #1.2  0x00002240d84b077f in ubsan_GetStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:41 <libclang_rt.asan.so>+0x3d77f
  #1.1  0x00002240d84b077f in MaybePrintStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:51 <libclang_rt.asan.so>+0x3d77f
  #1    0x00002240d84b077f in ~ScopedReport() compiler-rt/lib/ubsan/ubsan_diag.cpp:387 <libclang_rt.asan.so>+0x3d77f
  #2    0x00002240d84b1385 in handleTypeMismatchImpl() compiler-rt/lib/ubsan/ubsan_handlers.cpp:137 <libclang_rt.asan.so>+0x3e385
  #3    0x00002240d84b0ead in compiler-rt/lib/ubsan/ubsan_handlers.cpp:142 <libclang_rt.asan.so>+0x3dead
  #4    0x0000219ce3426bd7 in AcpiRsGetListLength(UINT8*, UINT32, ACPI_SIZE*) ../../third_party/acpica/source/components/resources/rscalc.c:631 <platform-bus-x86.so>+0x2cbbd7
  #5    0x0000219ce3423777 in AcpiRsCreateResourceList(ACPI_OPERAND_OBJECT*, ACPI_BUFFER*) ../../third_party/acpica/source/components/resources/rscreate.c:178 <platform-bus-x86.so>+0x2c8777
  #6    0x0000219ce342f1b2 in AcpiRsGetMethodData(ACPI_HANDLE, const char*, ACPI_BUFFER*) ../../third_party/acpica/source/components/resources/rsutils.c:770 <platform-bus-x86.so>+0x2d41b2
  #7    0x0000219ce342f52d in AcpiWalkResources(ACPI_HANDLE, char*, ACPI_WALK_RESOURCE_CALLBACK, void*) ../../third_party/acpica/source/components/resources/rsxface.c:731 <platform-bus-x86.so>+0x2d452d
  #8    0x0000219ce3246d48 in acpi::AcpiImpl::WalkResources(acpi::AcpiImpl*, ACPI_HANDLE, const char*, acpi::Acpi::ResourcesCallable) ../../src/devices/board/lib/acpi/acpi-impl.cc:41 <platform-bus-x86.so>+0xebd48
  #9    0x0000219ce324c94d in acpi::DeviceBuilder::GatherResources(acpi::DeviceBuilder*, acpi::Acpi*, fidl::AnyArena&, acpi::Manager*, acpi::DeviceBuilder::GatherResourcesCallback) ../../src/devices/board/lib/acpi/device-builder.cc:52 <platform-bus-x86.so>+0xf194d
  #10   0x0000219ce32d8af2 in acpi::Manager::ConfigureDiscoveredDevices(acpi::Manager*) ../../src/devices/board/lib/acpi/manager.cc:75 <platform-bus-x86.so>+0x17daf2
  #11   0x0000219ce3200b44 in publish_acpi_devices(acpi::Manager*, zx_device_t*, zx_device_t*) ../../src/devices/board/drivers/x86/acpi-nswalk.cc:102 <platform-bus-x86.so>+0xa5b44
  #12   0x0000219ce32126f7 in x86::X86::DoInit(x86::X86*) ../../src/devices/board/drivers/x86/x86.cc:65 <platform-bus-x86.so>+0xb76f7
  #13.1 0x0000219ce321c8ea in λ(x86::X86::DdkInit::(anon class)*) ../../src/devices/board/drivers/x86/x86.cc:82 <platform-bus-x86.so>+0xc18ea
  #13   0x0000219ce321c8ea in fit::internal::target<(lambda at../../src/devices/board/drivers/x86/x86.cc:81:19), false, false, void>::invoke(void*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:181 <platform-bus-x86.so>+0xc18ea
  #14.2 0x0000219ce3461b2c in fit::internal::function_base<16UL, false, void()>::invoke(const fit::internal::function_base<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <platform-bus-x86.so>+0x306b2c
  #14.1 0x0000219ce3461b2c in fit::function_impl<16UL, false, void()>::operator()(const fit::function_impl<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/function.h:300 <platform-bus-x86.so>+0x306b2c
  #14   0x0000219ce3461b2c in async::internal::RetainedTask::Handler(async_dispatcher_t*, async_task_t*, zx_status_t) ../../zircon/system/ulib/async/task.cc:25 <platform-bus-x86.so>+0x306b2c
  #15.1 0x000022cc55016d91 in λ(const driver_runtime::Dispatcher::PostTask::(anon class)*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/dispatcher.cc:715 <libdriver_runtime.so>+0x4bd91
  #15   0x000022cc55016d91 in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:714:7), true, false, void, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int>::invoke(void*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0x4bd91
  #16   0x000022cc5500fbc9 in fit::internal::function_base<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::invoke(const fit::internal::function_base<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0x44bc9
  #17   0x000022cc5500f8dd in fit::callback_impl<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::operator()(fit::callback_impl<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/function.h:451 <libdriver_runtime.so>+0x448dd
  #18   0x000022cc550006a6 in driver_runtime::CallbackRequest::Call(driver_runtime::CallbackRequest*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/callback_request.h:67 <libdriver_runtime.so>+0x356a6
  #19   0x000022cc550074c8 in driver_runtime::Dispatcher::DispatchCallback(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >) ../../src/devices/bin/driver_runtime/dispatcher.cc:1093 <libdriver_runtime.so>+0x3c4c8
  #20   0x000022cc550082c1 in driver_runtime::Dispatcher::DispatchCallbacks(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.cc:1169 <libdriver_runtime.so>+0x3d2c1
  #21.1 0x000022cc5501381e in λ(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>, const driver_runtime::Dispatcher::CreateWithAdder::(anon class)*) ../../src/devices/bin/driver_runtime/dispatcher.cc:338 <libdriver_runtime.so>+0x4881e
  #21   0x000022cc5501381e in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:337:7), true, false, void, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>>::invoke(void*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0x4881e
  #22   0x000022cc5500fe7e in fit::internal::function_base<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::invoke(const fit::internal::function_base<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0x44e7e
  #23.1 0x000022cc55009964 in fit::function_impl<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::operator()(const fit::function_impl<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/function.h:300 <libdriver_runtime.so>+0x3e964
  #23   0x000022cc55009964 in driver_runtime::Dispatcher::EventWaiter::InvokeCallback(driver_runtime::Dispatcher::EventWaiter*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.h:299 <libdriver_runtime.so>+0x3e964
  #24   0x000022cc5500935d in driver_runtime::Dispatcher::EventWaiter::HandleEvent(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, async_dispatcher_t*, async::WaitBase*, zx_status_t, zx_packet_signal_t const*) ../../src/devices/bin/driver_runtime/dispatcher.cc:1259 <libdriver_runtime.so>+0x3e35d
  #25.1 0x000022cc55013c00 in AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent(AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>*, zx_status_t, zx_packet_signal_t const*, async_dispatcher_t*, async::WaitBase*) ../../src/devices/bin/driver_runtime/async_loop_owned_event_handler.h:59 <libdriver_runtime.so>+0x48c00
  #25   0x000022cc55013c00 in async::WaitMethod<AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>, &AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent>::CallHandler(async_dispatcher_t*, async_wait_t*, zx_status_t, zx_packet_signal_t const*) ../../zircon/system/ulib/async/include/lib/async/cpp/wait.h:201 <libdriver_runtime.so>+0x48c00
  #26.1 0x000022cc55035ead in async_loop_run_once(async_loop_t*, zx_time_t) ../../zircon/system/ulib/async-loop/loop.c:415 <libdriver_runtime.so>+0x6aead
  #26   0x000022cc55035ead in async_loop_run(async_loop_t*, zx_time_t, _Bool) ../../zircon/system/ulib/async-loop/loop.c:288 <libdriver_runtime.so>+0x6aead
  #27   0x000022cc5503778f in async_loop_run_thread(void*) ../../zircon/system/ulib/async-loop/loop.c:840 <libdriver_runtime.so>+0x6c78f
  #28   0x000042d43f9f1edc in start_c11(void*) ../../zircon/third_party/ulib/musl/pthread/pthread_create.c:55 <libc.so>+0xd7edc
  #29   0x000042d43fb2296d in thread_trampoline(uintptr_t, uintptr_t) ../../zircon/system/ulib/runtime/thread.cc:100 <libc.so>+0x20896d
```
and
```
      #0    0x000022db2bfa3753 in AcpiRsGetListLength(UINT8*, UINT32, ACPI_SIZE*) ../../third_party/acpica/source/components/resources/rscalc.c:704 <platform-bus-x86.so>+0x2cb753
      #1.2  0x000020c421f9777f in ubsan_GetStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:41 <libclang_rt.asan.so>+0x3d77f
      #1.1  0x000020c421f9777f in MaybePrintStackTrace() compiler-rt/lib/ubsan/ubsan_diag.cpp:51 <libclang_rt.asan.so>+0x3d77f
      #1    0x000020c421f9777f in ~ScopedReport() compiler-rt/lib/ubsan/ubsan_diag.cpp:387 <libclang_rt.asan.so>+0x3d77f
      #2    0x000020c421f98385 in handleTypeMismatchImpl() compiler-rt/lib/ubsan/ubsan_handlers.cpp:137 <libclang_rt.asan.so>+0x3e385
      #3    0x000020c421f97ead in compiler-rt/lib/ubsan/ubsan_handlers.cpp:142 <libclang_rt.asan.so>+0x3dead
      #4    0x000022db2bfa3753 in AcpiRsGetListLength(UINT8*, UINT32, ACPI_SIZE*) ../../third_party/acpica/source/components/resources/rscalc.c:704 <platform-bus-x86.so>+0x2cb753
      #5    0x000022db2bfa0777 in AcpiRsCreateResourceList(ACPI_OPERAND_OBJECT*, ACPI_BUFFER*) ../../third_party/acpica/source/components/resources/rscreate.c:178 <platform-bus-x86.so>+0x2c8777
      #6    0x000022db2bfac0f2 in AcpiRsGetMethodData(ACPI_HANDLE, const char*, ACPI_BUFFER*) ../../third_party/acpica/source/components/resources/rsutils.c:770 <platform-bus-x86.so>+0x2d40f2
      #7    0x000022db2bfac46d in AcpiWalkResources(ACPI_HANDLE, char*, ACPI_WALK_RESOURCE_CALLBACK, void*) ../../third_party/acpica/source/components/resources/rsxface.c:731 <platform-bus-x86.so>+0x2d446d
      #8    0x000022db2bdc3d48 in acpi::AcpiImpl::WalkResources(acpi::AcpiImpl*, ACPI_HANDLE, const char*, acpi::Acpi::ResourcesCallable) ../../src/devices/board/lib/acpi/acpi-impl.cc:41 <platform-bus-x86.so>+0xebd48
      #9    0x000022db2bdc994d in acpi::DeviceBuilder::GatherResources(acpi::DeviceBuilder*, acpi::Acpi*, fidl::AnyArena&, acpi::Manager*, acpi::DeviceBuilder::GatherResourcesCallback) ../../src/devices/board/lib/acpi/device-builder.cc:52 <platform-bus-x86.so>+0xf194d
      #10   0x000022db2be55af2 in acpi::Manager::ConfigureDiscoveredDevices(acpi::Manager*) ../../src/devices/board/lib/acpi/manager.cc:75 <platform-bus-x86.so>+0x17daf2
      #11   0x000022db2bd7db44 in publish_acpi_devices(acpi::Manager*, zx_device_t*, zx_device_t*) ../../src/devices/board/drivers/x86/acpi-nswalk.cc:102 <platform-bus-x86.so>+0xa5b44
      #12   0x000022db2bd8f6f7 in x86::X86::DoInit(x86::X86*) ../../src/devices/board/drivers/x86/x86.cc:65 <platform-bus-x86.so>+0xb76f7
      #13.1 0x000022db2bd998ea in λ(x86::X86::DdkInit::(anon class)*) ../../src/devices/board/drivers/x86/x86.cc:82 <platform-bus-x86.so>+0xc18ea
      #13   0x000022db2bd998ea in fit::internal::target<(lambda at../../src/devices/board/drivers/x86/x86.cc:81:19), false, false, void>::invoke(void*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:181 <platform-bus-x86.so>+0xc18ea
      #14.2 0x000022db2bfdea6c in fit::internal::function_base<16UL, false, void()>::invoke(const fit::internal::function_base<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <platform-bus-x86.so>+0x306a6c
      #14.1 0x000022db2bfdea6c in fit::function_impl<16UL, false, void()>::operator()(const fit::function_impl<16UL, false, void ()>*) ../../sdk/lib/fit/include/lib/fit/function.h:300 <platform-bus-x86.so>+0x306a6c
      #14   0x000022db2bfdea6c in async::internal::RetainedTask::Handler(async_dispatcher_t*, async_task_t*, zx_status_t) ../../zircon/system/ulib/async/task.cc:25 <platform-bus-x86.so>+0x306a6c
      #15.1 0x0000216d819f2d91 in λ(const driver_runtime::Dispatcher::PostTask::(anon class)*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/dispatcher.cc:715 <libdriver_runtime.so>+0x4bd91
      #15   0x0000216d819f2d91 in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:714:7), true, false, void, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int>::invoke(void*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0x4bd91
      #16   0x0000216d819ebbc9 in fit::internal::function_base<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::invoke(const fit::internal::function_base<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0x44bc9
      #17   0x0000216d819eb8dd in fit::callback_impl<24UL, true, void(std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest>>, int)>::operator()(fit::callback_impl<24UL, true, void (std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int)>*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, int) ../../sdk/lib/fit/include/lib/fit/function.h:451 <libdriver_runtime.so>+0x448dd
      #18   0x0000216d819dc6a6 in driver_runtime::CallbackRequest::Call(driver_runtime::CallbackRequest*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >, zx_status_t) ../../src/devices/bin/driver_runtime/callback_request.h:67 <libdriver_runtime.so>+0x356a6
      #19   0x0000216d819e34c8 in driver_runtime::Dispatcher::DispatchCallback(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::CallbackRequest, std::__2::default_delete<driver_runtime::CallbackRequest> >) ../../src/devices/bin/driver_runtime/dispatcher.cc:1093 <libdriver_runtime.so>+0x3c4c8
      #20   0x0000216d819e42c1 in driver_runtime::Dispatcher::DispatchCallbacks(driver_runtime::Dispatcher*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.cc:1169 <libdriver_runtime.so>+0x3d2c1
      #21.1 0x0000216d819ef81e in λ(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>, const driver_runtime::Dispatcher::CreateWithAdder::(anon class)*) ../../src/devices/bin/driver_runtime/dispatcher.cc:338 <libdriver_runtime.so>+0x4881e
      #21   0x0000216d819ef81e in fit::internal::target<(lambda at../../src/devices/bin/driver_runtime/dispatcher.cc:337:7), true, false, void, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>>::invoke(void*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:128 <libdriver_runtime.so>+0x4881e
      #22   0x0000216d819ebe7e in fit::internal::function_base<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::invoke(const fit::internal::function_base<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/internal/function.h:505 <libdriver_runtime.so>+0x44e7e
      #23.1 0x0000216d819e5964 in fit::function_impl<8UL, true, void(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter>>, fbl::RefPtr<driver_runtime::Dispatcher>)>::operator()(const fit::function_impl<8UL, true, void (std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>)>*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../sdk/lib/fit/include/lib/fit/function.h:300 <libdriver_runtime.so>+0x3e964
      #23   0x0000216d819e5964 in driver_runtime::Dispatcher::EventWaiter::InvokeCallback(driver_runtime::Dispatcher::EventWaiter*, std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, fbl::RefPtr<driver_runtime::Dispatcher>) ../../src/devices/bin/driver_runtime/dispatcher.h:299 <libdriver_runtime.so>+0x3e964
      #24   0x0000216d819e535d in driver_runtime::Dispatcher::EventWaiter::HandleEvent(std::__2::unique_ptr<driver_runtime::Dispatcher::EventWaiter, std::__2::default_delete<driver_runtime::Dispatcher::EventWaiter> >, async_dispatcher_t*, async::WaitBase*, zx_status_t, zx_packet_signal_t const*) ../../src/devices/bin/driver_runtime/dispatcher.cc:1259 <libdriver_runtime.so>+0x3e35d
      #25.1 0x0000216d819efc00 in AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent(AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>*, zx_status_t, zx_packet_signal_t const*, async_dispatcher_t*, async::WaitBase*) ../../src/devices/bin/driver_runtime/async_loop_owned_event_handler.h:59 <libdriver_runtime.so>+0x48c00
      #25   0x0000216d819efc00 in async::WaitMethod<AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>, &AsyncLoopOwnedEventHandler<driver_runtime::Dispatcher::EventWaiter>::HandleEvent>::CallHandler(async_dispatcher_t*, async_wait_t*, zx_status_t, zx_packet_signal_t const*) ../../zircon/system/ulib/async/include/lib/async/cpp/wait.h:201 <libdriver_runtime.so>+0x48c00
      #26.1 0x0000216d81a11ead in async_loop_run_once(async_loop_t*, zx_time_t) ../../zircon/system/ulib/async-loop/loop.c:415 <libdriver_runtime.so>+0x6aead
      #26   0x0000216d81a11ead in async_loop_run(async_loop_t*, zx_time_t, _Bool) ../../zircon/system/ulib/async-loop/loop.c:288 <libdriver_runtime.so>+0x6aead
      #27   0x0000216d81a1378f in async_loop_run_thread(void*) ../../zircon/system/ulib/async-loop/loop.c:840 <libdriver_runtime.so>+0x6c78f
      #28   0x0000417ba4b4bedc in start_c11(void*) ../../zircon/third_party/ulib/musl/pthread/pthread_create.c:55 <libc.so>+0xd7edc
      #29   0x0000417ba4c7c96d in thread_trampoline(uintptr_t, uintptr_t) ../../zircon/system/ulib/runtime/thread.cc:100 <libc.so>+0x20896d
```