### PR TITLE
Flex array transformations, take 2

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1538,7 +1538,7 @@ AcpiDmDumpNfit (
             /* Has a variable number of 64-bit addresses at the end */
 
             InfoTable = AcpiDmTableInfoNfit6;
-            FieldOffset = sizeof (ACPI_NFIT_FLUSH_ADDRESS) - sizeof (UINT64);
+            FieldOffset = sizeof (ACPI_NFIT_FLUSH_ADDRESS);
             break;
 
         case ACPI_NFIT_TYPE_CAPABILITIES:    /* ACPI 6.0A */
@@ -1592,12 +1592,12 @@ AcpiDmDumpNfit (
         case ACPI_NFIT_TYPE_SMBIOS:
 
             Length = Subtable->Length -
-                sizeof (ACPI_NFIT_SMBIOS) + sizeof (UINT8);
+                sizeof (ACPI_NFIT_SMBIOS);
 
             if (Length)
             {
                 Status = AcpiDmDumpTable (Table->Length,
-                    sizeof (ACPI_NFIT_SMBIOS) - sizeof (UINT8),
+                    sizeof (ACPI_NFIT_SMBIOS),
                     SmbiosInfo,
                     Length, AcpiDmTableInfoNfit3a);
                 if (ACPI_FAILURE (Status))

--- a/source/compiler/asltypes.h
+++ b/source/compiler/asltypes.h
@@ -336,7 +336,7 @@ typedef struct asl_file_desc
 typedef struct asl_cache_info
 {
     void                    *Next;
-    char                    Buffer[1];
+    char                    Buffer[];
 
 } ASL_CACHE_INFO;
 

--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -357,7 +357,7 @@ typedef struct acpi_resource_fixed_dma
 typedef struct acpi_resource_vendor
 {
     UINT16                          ByteLength;
-    UINT8                           ByteData[1];
+    UINT8                           ByteData[];
 
 } ACPI_RESOURCE_VENDOR;
 
@@ -368,7 +368,7 @@ typedef struct acpi_resource_vendor_typed
     UINT16                          ByteLength;
     UINT8                           UuidSubtype;
     UINT8                           Uuid[ACPI_UUID_LENGTH];
-    UINT8                           ByteData[1];
+    UINT8                           ByteData[];
 
 } ACPI_RESOURCE_VENDOR_TYPED;
 

--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -300,7 +300,10 @@ typedef struct acpi_resource_dma
     UINT8                           BusMaster;
     UINT8                           Transfer;
     UINT8                           ChannelCount;
-    UINT8                           Channels[1];
+    union {
+        UINT8                       Channel;
+        ACPI_FLEX_ARRAY(UINT8,      Channels);
+    };
 
 } ACPI_RESOURCE_DMA;
 

--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -942,8 +942,10 @@ typedef struct acpi_pci_routing_table
     UINT32                          Pin;
     UINT64                          Address;        /* here for 64-bit alignment */
     UINT32                          SourceIndex;
-    char                            Source[4];      /* pad to 64 bits so sizeof() works in all cases */
-
+    union {
+                                    char Pad[4];    /* pad to 64 bits so sizeof() works in all cases */
+                                    ACPI_FLEX_ARRAY(char, Source);
+    };
 } ACPI_PCI_ROUTING_TABLE;
 
 #endif /* __ACRESTYP_H__ */

--- a/source/include/acrestyp.h
+++ b/source/include/acrestyp.h
@@ -290,7 +290,10 @@ typedef struct acpi_resource_irq
     UINT8                           Shareable;
     UINT8                           WakeCapable;
     UINT8                           InterruptCount;
-    UINT8                           Interrupts[1];
+    union {
+        UINT8                       Interrupt;
+        ACPI_FLEX_ARRAY(UINT8,      Interrupts);
+    };
 
 } ACPI_RESOURCE_IRQ;
 
@@ -541,7 +544,10 @@ typedef struct acpi_resource_extended_irq
     UINT8                           WakeCapable;
     UINT8                           InterruptCount;
     ACPI_RESOURCE_SOURCE            ResourceSource;
-    UINT32                          Interrupts[1];
+    union {
+        UINT32                      Interrupt;
+        ACPI_FLEX_ARRAY(UINT32,     Interrupts);
+    };
 
 } ACPI_RESOURCE_EXTENDED_IRQ;
 

--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -1219,7 +1219,10 @@ typedef struct acpi_dmar_andd
     ACPI_DMAR_HEADER        Header;
     UINT8                   Reserved[3];
     UINT8                   DeviceNumber;
-    char                    DeviceName[1];
+    union {
+        char                  __pad;
+        ACPI_FLEX_ARRAY(char, DeviceName);
+    };
 
 } ACPI_DMAR_ANDD;
 

--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -1272,7 +1272,7 @@ typedef struct acpi_table_drtm
 typedef struct acpi_drtm_vtable_list
 {
     UINT32                  ValidatedTableCount;
-    UINT64                  ValidatedTables[1];
+    UINT64                  ValidatedTables[];
 
 } ACPI_DRTM_VTABLE_LIST;
 
@@ -1291,7 +1291,7 @@ typedef struct acpi_drtm_resource
 typedef struct acpi_drtm_resource_list
 {
     UINT32                  ResourceCount;
-    ACPI_DRTM_RESOURCE      Resources[1];
+    ACPI_DRTM_RESOURCE      Resources[];
 
 } ACPI_DRTM_RESOURCE_LIST;
 
@@ -1319,7 +1319,7 @@ typedef struct acpi_table_ecdt
     ACPI_GENERIC_ADDRESS    Data;               /* Address of EC data register */
     UINT32                  Uid;                /* Unique ID - must be same as the EC _UID method */
     UINT8                   Gpe;                /* The GPE for the EC */
-    UINT8                   Id[1];              /* Full namepath of the EC in the ACPI namespace */
+    UINT8                   Id[];               /* Full namepath of the EC in the ACPI namespace */
 
 } ACPI_TABLE_ECDT;
 

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -572,7 +572,7 @@ typedef struct acpi_iort_node
     UINT32                  Identifier;
     UINT32                  MappingCount;
     UINT32                  MappingOffset;
-    char                    NodeData[1];
+    char                    NodeData[];
 
 } ACPI_IORT_NODE;
 
@@ -638,7 +638,7 @@ typedef struct acpi_iort_memory_access
 typedef struct acpi_iort_its_group
 {
     UINT32                  ItsCount;
-    UINT32                  Identifiers[1];         /* GIC ITS identifier array */
+    UINT32                  Identifiers[];          /* GIC ITS identifier array */
 
 } ACPI_IORT_ITS_GROUP;
 
@@ -648,7 +648,7 @@ typedef struct acpi_iort_named_component
     UINT32                  NodeFlags;
     UINT64                  MemoryProperties;       /* Memory access properties */
     UINT8                   MemoryAddressLimit;     /* Memory address size limit */
-    char                    DeviceName[1];          /* Path of namespace object */
+    char                    DeviceName[];           /* Path of namespace object */
 
 } ACPI_IORT_NAMED_COMPONENT;
 
@@ -664,7 +664,7 @@ typedef struct acpi_iort_root_complex
     UINT32                  PciSegmentNumber;
     UINT8                   MemoryAddressLimit;     /* Memory address size limit */
     UINT16                  PasidCapabilities;      /* PASID Capabilities */
-    UINT8                   Reserved[1];            /* Reserved, must be zero */
+    UINT8                   Reserved[];             /* Reserved, must be zero */
 
 } ACPI_IORT_ROOT_COMPLEX;
 
@@ -688,7 +688,7 @@ typedef struct acpi_iort_smmu
     UINT32                  ContextInterruptOffset;
     UINT32                  PmuInterruptCount;
     UINT32                  PmuInterruptOffset;
-    UINT64                  Interrupts[1];          /* Interrupt array */
+    UINT64                  Interrupts[];           /* Interrupt array */
 
 } ACPI_IORT_SMMU;
 
@@ -1240,7 +1240,7 @@ typedef struct acpi_madt_local_sapic
     UINT8                   Reserved[3];        /* Reserved, must be zero */
     UINT32                  LapicFlags;
     UINT32                  Uid;                /* Numeric UID - ACPI 3.0 */
-    char                    UidString[1];       /* String UID  - ACPI 3.0 */
+    char                    UidString[];        /* String UID  - ACPI 3.0 */
 
 } ACPI_MADT_LOCAL_SAPIC;
 
@@ -2056,7 +2056,7 @@ typedef struct acpi_nfit_smbios
 {
     ACPI_NFIT_HEADER        Header;
     UINT32                  Reserved;           /* Reserved, must be zero */
-    UINT8                   Data[1];            /* Variable length */
+    UINT8                   Data[];             /* Variable length */
 
 } ACPI_NFIT_SMBIOS;
 
@@ -2122,7 +2122,7 @@ typedef struct acpi_nfit_flush_address
     UINT32                  DeviceHandle;
     UINT16                  HintCount;
     UINT8                   Reserved[6];        /* Reserved, must be zero */
-    UINT64                  HintAddress[1];     /* Variable length */
+    UINT64                  HintAddress[];      /* Variable length */
 
 } ACPI_NFIT_FLUSH_ADDRESS;
 

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1552,7 +1552,7 @@ enum AcpiMadtLpcPicVersion {
 
 typedef struct acpi_madt_oem_data
 {
-    UINT8                   OemData[0];
+    ACPI_FLEX_ARRAY(UINT8,  OemData);
 } ACPI_MADT_OEM_DATA;
 
 

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -2045,7 +2045,7 @@ typedef struct acpi_nfit_interleave
     UINT16                  Reserved;           /* Reserved, must be zero */
     UINT32                  LineCount;
     UINT32                  LineSize;
-    UINT32                  LineOffset[1];      /* Variable length */
+    UINT32                  LineOffset[];       /* Variable length */
 
 } ACPI_NFIT_INTERLEAVE;
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -1574,4 +1574,8 @@ typedef enum
 #define ACPI_FALLTHROUGH do {} while(0)
 #endif
 
+#ifndef ACPI_FLEX_ARRAY
+#define ACPI_FLEX_ARRAY(TYPE, NAME)     TYPE NAME[0]
+#endif
+
 #endif /* __ACTYPES_H__ */

--- a/source/include/amlresrc.h
+++ b/source/include/amlresrc.h
@@ -503,7 +503,10 @@ typedef struct aml_resource_extended_irq
     AML_RESOURCE_LARGE_HEADER_COMMON
     UINT8                           Flags;
     UINT8                           InterruptCount;
-    UINT32                          Interrupts[1];
+    union {
+        UINT32                      Interrupt;
+        ACPI_FLEX_ARRAY(UINT32,     Interrupts);
+    };
     /* ResSourceIndex, ResSource optional fields follow */
 
 } AML_RESOURCE_EXTENDED_IRQ;

--- a/source/include/platform/acefiex.h
+++ b/source/include/platform/acefiex.h
@@ -508,7 +508,7 @@ typedef struct {
     ACPI_EFI_TIME LastAccessTime;
     ACPI_EFI_TIME ModificationTime;
     UINT64 Attribute;
-    CHAR16 FileName[1];
+    CHAR16 FileName[];
 } ACPI_EFI_FILE_INFO;
 
 #define SIZE_OF_ACPI_EFI_FILE_INFO  ACPI_OFFSET(ACPI_EFI_FILE_INFO, FileName)

--- a/source/include/platform/acgcc.h
+++ b/source/include/platform/acgcc.h
@@ -211,4 +211,15 @@ typedef __builtin_va_list       va_list;
 #define ACPI_FALLTHROUGH __attribute__((__fallthrough__))
 #endif
 
+/*
+ * Flexible array members are not allowed to be part of a union under
+ * C99, but this is not for any technical reason. Work around the
+ * limitation.
+ */
+#define ACPI_FLEX_ARRAY(TYPE, NAME)             \
+        struct {                                \
+                struct { } __Empty_ ## NAME;    \
+                TYPE NAME[];                    \
+        }
+
 #endif /* __ACGCC_H__ */


### PR DESCRIPTION
Hello!

This is a more comprehensive series to address all the technical debt related to 1-element and 0-length arrays in ACPICA code, with the goal of making this behave correctly in the Linux kernel when built with GCC and Clang's new `-fstrict-flex-arrays=3` option.

I did per-patch A/B build output analysis checking for `.text` and `.data` section changes, solving or noting any differences in each patch. Specifically, this series seems to have found possibly 2 bugs in existing size calculations, noted in their individual patches:
- `AcpiDmDumpNfit()`'s calculation of `ACPI_NFIT_INTERLEAVE` appears to have been originally wrong, but is now fixed.
- `AcpiDmDumpDmar()`'s calculation of `ACPI_DMAR_ANDD` seems suspicious, but the existing result appears to be used as a table offset. It's unclear if this is a bug or intentional, so I left padding in the struct to keep the binary output unchanged.

The helper to work around the C spec's limitation for flexible array members has been limited to only GCC (and Clang), until MSVC can fix their handling.