### PR TITLE
check null return of ACPI_ALLOCATE_ZEROED in AcpiDbDisplayObjects

### DIFF
--- a/source/components/debugger/dbnames.c
+++ b/source/components/debugger/dbnames.c
@@ -883,6 +883,9 @@ AcpiDbDisplayObjects (
     if (!ObjTypeArg)
     {
         ObjectInfo = ACPI_ALLOCATE_ZEROED (sizeof (ACPI_OBJECT_INFO));
+            
+        if (!ObjectInfo)
+                return (AE_NO_MEMORY);
 
         /* Walk the namespace from the root */
 


### PR DESCRIPTION
ACPI_ALLOCATE_ZEROED may fails, ObjectInfo might be null and will cause null pointer dereference later.