### PR TITLE
Events: Fix fixed pcie wake event

### DIFF
--- a/source/components/events/evevent.c
+++ b/source/components/events/evevent.c
@@ -310,13 +310,23 @@ AcpiEvFixedEventInitialize (
 
         if (AcpiGbl_FixedEventInfo[i].EnableRegisterId != 0xFF)
         {
-            Status = AcpiWriteBitRegister (
-                AcpiGbl_FixedEventInfo[i].EnableRegisterId,
-                (i == ACPI_EVENT_PCIE_WAKE) ?
-                ACPI_ENABLE_EVENT : ACPI_DISABLE_EVENT);
-            if (ACPI_FAILURE (Status))
-            {
-                return (Status);
+            if (i == ACPI_EVENT_PCIE_WAKE &&
+                (AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+                Status = AcpiWriteBitRegister (
+                    AcpiGbl_FixedEventInfo[i].EnableRegisterId,
+                    ACPI_ENABLE_EVENT);
+                if (ACPI_FAILURE (Status))
+                {
+                    return (Status);
+                }
+            } else {
+                Status = AcpiWriteBitRegister (
+                    AcpiGbl_FixedEventInfo[i].EnableRegisterId,
+                    ACPI_DISABLE_EVENT);
+                if (ACPI_FAILURE (Status))
+                {
+                    return (Status);
+                }
             }
         }
     }

--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -220,6 +220,13 @@ AcpiHwLegacySleep (
         return_ACPI_STATUS (Status);
     }
 
+    /* Enable pcie wake event if support */
+    if ((AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+        (void) AcpiWriteBitRegister (
+		AcpiGbl_FixedEventInfo[ACPI_EVENT_PCIE_WAKE].EnableRegisterId,
+		ACPI_DISABLE_EVENT);
+    }
+
     /* Get current value of PM1A control */
 
     Status = AcpiHwRegisterRead (ACPI_REGISTER_PM1_CONTROL,
@@ -475,11 +482,11 @@ AcpiHwLegacyWake (
             AcpiGbl_FixedEventInfo[ACPI_EVENT_SLEEP_BUTTON].StatusRegisterId,
             ACPI_CLEAR_STATUS);
 
-    /* Enable pcie wake event if support */
+    /* Clear and disable pcie wake event if support */
     if ((AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
         (void) AcpiWriteBitRegister (
 		AcpiGbl_FixedEventInfo[ACPI_EVENT_PCIE_WAKE].EnableRegisterId,
-		ACPI_DISABLE_EVENT);
+		ACPI_ENABLE_EVENT);
         (void) AcpiWriteBitRegister (
 		AcpiGbl_FixedEventInfo[ACPI_EVENT_PCIE_WAKE].StatusRegisterId,
 		ACPI_CLEAR_STATUS);


### PR DESCRIPTION
Some platforms support the PCIEXP_WAKE_STS bit in the PM1 Status register and the PCIEXP_WAKE_EN bit in the PM1 Enable register. But ACPI_FADT_PCI_EXPRESS_WAKE is not set in fixed feature flag of FADT, skip disabling it during fixed event initialization.

Second, fixed pcie wakeup event should be enabled before entering sleep state just as GPEs with wakeup ability, or the system will be not waked up by pcie devices due to its disabled state, and it should be cleared on waking up so that the event is disabled at runtime (it is not a runtime event).

Fixes: 32d875705c8e ("Events: Support fixed pcie wake event")