### PR TITLE
Move ACPI_FUNCTION_ENTRY to function entry

### DIFF
--- a/source/components/resources/rsaddr.c
+++ b/source/components/resources/rsaddr.c
@@ -431,12 +431,12 @@ AcpiRsGetAddressCommon (
     ACPI_RESOURCE           *Resource,
     AML_RESOURCE            *Aml)
 {
+    ACPI_FUNCTION_ENTRY();
+
     /* Avoid undefined behavior: member access within misaligned address */
 
     AML_RESOURCE_ADDRESS Address;
     memcpy(&Address, Aml, sizeof(Address));
-
-    ACPI_FUNCTION_ENTRY();
 
     /* Validate the Resource Type */
 


### PR DESCRIPTION
This changed in f98909b7928cac8c5328e4852ad5a7ea671204fb, seemingly by accident.