### PR TITLE
Add support for Interrupt in acpiexec

### DIFF
--- a/source/components/debugger/dbcmds.c
+++ b/source/components/debugger/dbcmds.c
@@ -156,7 +156,7 @@
 #include "acnamesp.h"
 #include "acresrc.h"
 #include "actables.h"
-
+#include "limits.h"
 
 #define _COMPONENT          ACPI_CA_DEBUGGER
         ACPI_MODULE_NAME    ("dbcmds")
@@ -1290,6 +1290,64 @@ AcpiDbDisplayResources (
     AcpiDbSetOutputDestination (ACPI_DB_CONSOLE_OUTPUT);
 }
 
+
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiDbGenerateGed
+ *
+ * PARAMETERS:  GedArg              - Raw GED number, ascii string
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Simulate firing of a GED
+ *
+ ******************************************************************************/
+
+void
+AcpiDbGenerateInterrupt (
+    char *GsivArg)
+{
+    UINT32      GsivNumber;
+    ACPI_GED_HANDLER_INFO *GedInfo = AcpiGbl_GedHandlerList;
+
+	if (!GedInfo) {
+		AcpiOsPrintf ("No GED handling present\n");
+	}
+
+    GsivNumber = strtoul (GsivArg, NULL, 0);
+
+	while (GedInfo) {
+
+		if (GedInfo->IntId == GsivNumber) {
+			ACPI_OBJECT_LIST ArgList;
+			ACPI_OBJECT Arg0;
+			ACPI_HANDLE EvtHandle = GedInfo->EvtMethod;
+			ACPI_STATUS Status;
+
+			AcpiOsPrintf ("Evaluate GED _EVT (GSIV=%d)\n", GsivNumber);
+
+			if (!EvtHandle) {
+				AcpiOsPrintf ("Undefined _EVT method\n");
+				return;
+			}
+
+			Arg0.Integer.Type = ACPI_TYPE_INTEGER;
+			Arg0.Integer.Value = GsivNumber;
+
+			ArgList.Count = 1;
+			ArgList.Pointer = &Arg0;
+
+			Status = AcpiEvaluateObject (EvtHandle, NULL, &ArgList, NULL);
+			if (ACPI_FAILURE (Status))
+			{
+				AcpiOsPrintf ("Could not evaluate _EVT\n");
+				return;
+			}
+
+		}
+		GedInfo = GedInfo->Next;
+	}
+}
 
 #if (!ACPI_REDUCED_HARDWARE)
 /*******************************************************************************

--- a/source/components/debugger/dbinput.c
+++ b/source/components/debugger/dbinput.c
@@ -264,6 +264,7 @@ enum AcpiExDebuggerCommands
     CMD_THREADS,
 
     CMD_TEST,
+	CMD_INTERRUPT,
 #endif
 };
 
@@ -345,6 +346,7 @@ static const ACPI_DB_COMMAND_INFO   AcpiGbl_DbCommands[] =
     {"THREADS",      3},
 
     {"TEST",         1},
+    {"INTERRUPT",    1},
 #endif
     {NULL,           0}
 };
@@ -461,6 +463,7 @@ static const ACPI_DB_COMMAND_HELP   AcpiGbl_DbCommandHelp[] =
     {1, "  Gpes",                               "Display info on all GPE devices\n"},
     {1, "  Sci",                                "Generate an SCI\n"},
     {1, "  Sleep [SleepState]",                 "Simulate sleep/wake sequence(s) (0-5)\n"},
+    {1, "  Interrupt <GSIV>",                   "Simulate an interrupt\n"},
 #endif
     {0, NULL, NULL}
 };
@@ -1262,6 +1265,11 @@ AcpiDbCommandDispatch (
 
         AcpiOsPrintf ("Event command not implemented\n");
         break;
+
+	case CMD_INTERRUPT:
+
+		AcpiDbGenerateInterrupt (AcpiGbl_DbArgs[1]);
+		break;
 
     case CMD_GPE:
 

--- a/source/include/acdebug.h
+++ b/source/include/acdebug.h
@@ -619,4 +619,8 @@ AcpiDbUint32ToHexString (
     UINT32                  Value,
     char                    *Buffer);
 
+void
+AcpiDbGenerateInterrupt (
+    char                    *GsivArg);
+
 #endif  /* __ACDEBUG_H__ */

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -268,6 +268,7 @@ ACPI_GLOBAL (ACPI_TABLE_HANDLER,        AcpiGbl_TableHandler);
 ACPI_GLOBAL (void *,                    AcpiGbl_TableHandlerContext);
 ACPI_GLOBAL (ACPI_INTERFACE_HANDLER,    AcpiGbl_InterfaceHandler);
 ACPI_GLOBAL (ACPI_SCI_HANDLER_INFO *,   AcpiGbl_SciHandlerList);
+ACPI_GLOBAL (ACPI_GED_HANDLER_INFO *,   AcpiGbl_GedHandlerList);
 
 /* Owner ID support */
 

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -767,6 +767,15 @@ typedef struct acpi_field_info
 
 } ACPI_FIELD_INFO;
 
+/* Information about the interrupt ID and _EVT of a GED device */
+
+typedef struct acpi_ged_handler_info
+{
+    struct acpi_ged_handler_info    *Next;
+    UINT32                          IntId;      /* The interrupt ID that triggers the execution ofthe EvtMethod. */
+    ACPI_NAMESPACE_NODE             *EvtMethod; /* The _EVT method to be executed when an interrupt with ID = IntID is received */
+
+} ACPI_GED_HANDLER_INFO;
 
 /*****************************************************************************
  *

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -786,13 +786,13 @@ typedef struct acpi_field_info
     UINT8                           DescriptorType; /* To differentiate various internal objs */\
     UINT8                           Flags; \
     UINT16                          Value; \
-    UINT16                          State;
+    UINT16                          State
 
     /* There are 2 bytes available here until the next natural alignment boundary */
 
 typedef struct acpi_common_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
 } ACPI_COMMON_STATE;
 
 
@@ -801,7 +801,7 @@ typedef struct acpi_common_state
  */
 typedef struct acpi_update_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     union acpi_operand_object       *Object;
 
 } ACPI_UPDATE_STATE;
@@ -812,7 +812,7 @@ typedef struct acpi_update_state
  */
 typedef struct acpi_pkg_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT32                          Index;
     union acpi_operand_object       *SourceObject;
     union acpi_operand_object       *DestObject;
@@ -829,7 +829,7 @@ typedef struct acpi_pkg_state
  */
 typedef struct acpi_control_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT16                          Opcode;
     union acpi_parse_object         *PredicateOp;
     UINT8                           *AmlPredicateStart;     /* Start of if/while predicate */
@@ -844,7 +844,7 @@ typedef struct acpi_control_state
  */
 typedef struct acpi_scope_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     ACPI_NAMESPACE_NODE             *Node;
 
 } ACPI_SCOPE_STATE;
@@ -852,7 +852,7 @@ typedef struct acpi_scope_state
 
 typedef struct acpi_pscope_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT32                          ArgCount;               /* Number of fixed arguments */
     union acpi_parse_object         *Op;                    /* Current op being parsed */
     UINT8                           *ArgEnd;                /* Current argument end */
@@ -868,7 +868,7 @@ typedef struct acpi_pscope_state
  */
 typedef struct acpi_thread_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT8                           CurrentSyncLevel;       /* Mutex Sync (nested acquire) level */
     struct acpi_walk_state          *WalkStateList;         /* Head of list of WalkStates for this thread */
     union acpi_operand_object       *AcquiredMutexList;     /* List of all currently acquired mutexes */
@@ -883,7 +883,7 @@ typedef struct acpi_thread_state
  */
 typedef struct acpi_result_values
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     union acpi_operand_object       *ObjDesc [ACPI_RESULTS_FRAME_OBJ_NUM];
 
 } ACPI_RESULT_VALUES;
@@ -914,7 +914,7 @@ typedef struct acpi_global_notify_handler
  */
 typedef struct acpi_notify_info
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT8                           HandlerListId;
     ACPI_NAMESPACE_NODE             *Node;
     union acpi_operand_object       *HandlerListHead;

--- a/source/include/acnames.h
+++ b/source/include/acnames.h
@@ -164,6 +164,7 @@
 #define METHOD_NAME__DDN        "_DDN"
 #define METHOD_NAME__DIS        "_DIS"
 #define METHOD_NAME__DMA        "_DMA"
+#define METHOD_NAME__EVT        "_EVT"
 #define METHOD_NAME__HID        "_HID"
 #define METHOD_NAME__INI        "_INI"
 #define METHOD_NAME__PLD        "_PLD"

--- a/source/tools/acpiexec/aeinstall.c
+++ b/source/tools/acpiexec/aeinstall.c
@@ -176,6 +176,13 @@ AeInstallPciHandler (
     void                    *Context,
     void                    **ReturnValue);
 
+static ACPI_STATUS
+AeInstallGedHandler (
+    ACPI_HANDLE             ObjHandle,
+    UINT32                  Level,
+    void                    *Context,
+    void                    **ReturnValue);
+
 
 BOOLEAN                     AcpiGbl_DisplayRegionAccess = FALSE;
 ACPI_CONNECTION_INFO        AeMyContext;
@@ -343,6 +350,110 @@ AeInstallRegionHandlers (
     }
 }
 
+/*******************************************************************************
+ *
+ * FUNCTION:    AeInstallGedHandler
+ *
+ * PARAMETERS:  ACPI_WALK_NAMESPACE callback
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Walk entire namespace, install a handler for every GED
+ *              device found.
+ *
+ ******************************************************************************/
+static ACPI_STATUS
+AeInstallGedHandler (
+    ACPI_HANDLE             ObjHandle,
+    UINT32                  Level,
+    void                    *Context,
+    void                    **ReturnValue)
+{
+
+	ACPI_BUFFER             ReturnBuffer;
+	ACPI_STATUS Status;
+	ACPI_RESOURCE *ResourceList;
+	ACPI_RESOURCE_EXTENDED_IRQ *extended_irq_rsc;
+    ACPI_NAMESPACE_NODE     *Node;
+	ACPI_NAMESPACE_NODE		*EvtMethodNode;
+
+    ACPI_FUNCTION_ENTRY();
+
+	/* Obtain the Namespace Node of this GED object handle. */
+	Node = AcpiNsValidateHandle (ObjHandle);
+	if (!Node)
+	{
+		return (AE_BAD_PARAMETER);
+	}
+
+	/*
+	 * A GED device must have one _EVT method.
+	 * Obtain the _EVT method and store it in the global
+	 * GED register.
+	 */
+	Status = AcpiNsSearchOneScope (
+		*ACPI_CAST_PTR (ACPI_NAME, METHOD_NAME__EVT),
+		Node,
+		ACPI_TYPE_METHOD,
+		&EvtMethodNode
+	);
+	if (ACPI_FAILURE (Status))
+	{
+		AcpiOsPrintf ("Failed to obtain _EVT method for the GED device.\n");
+		return Status;
+	}
+
+	ReturnBuffer.Pointer = NULL;
+    ReturnBuffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
+
+	Status = AcpiGetCurrentResources (ObjHandle, &ReturnBuffer);
+	if (ACPI_FAILURE (Status))
+	{
+		AcpiOsPrintf ("AcpiGetCurrentResources failed: %s\n",
+			AcpiFormatException (Status));
+		return Status;
+	}
+
+	/* Traverse the _CRS resource list */
+	ResourceList = ACPI_CAST_PTR (ACPI_RESOURCE, ReturnBuffer.Pointer);
+	while (ResourceList->Type != ACPI_RESOURCE_TYPE_END_TAG) {
+
+		switch (ResourceList->Type) {
+		 case ACPI_RESOURCE_TYPE_EXTENDED_IRQ: {
+
+			/*
+			 * Found an Interrupt resource. Link the interrupt resource
+			 * and the _EVT method of this GED device in the GED event handler list.
+			 */
+			ACPI_GED_HANDLER_INFO *GedHandler =
+			ACPI_ALLOCATE (sizeof (ACPI_SCI_HANDLER_INFO));
+			if (!GedHandler)
+			{
+				return AE_NO_MEMORY;
+			}
+
+			GedHandler->Next = AcpiGbl_GedHandlerList;
+			AcpiGbl_GedHandlerList = GedHandler;
+
+			extended_irq_rsc = &ResourceList->Data.ExtendedIrq;
+
+			GedHandler->IntId = extended_irq_rsc->Interrupts[0];
+			GedHandler->EvtMethod = EvtMethodNode;
+
+			AcpiOsPrintf ("Interrupt ID %d\n", extended_irq_rsc->Interrupts[0]);
+
+			break;
+		 }
+		 default:
+
+			AcpiOsPrintf ("Resource type %X\n", ResourceList->Type);
+		}
+
+		ResourceList = ACPI_NEXT_RESOURCE (ResourceList);
+	}
+
+	return AE_OK;
+}
 
 /*******************************************************************************
  *
@@ -352,7 +463,7 @@ AeInstallRegionHandlers (
  *
  * RETURN:      Status
  *
- * DESCRIPTION: Install handlers for all EC and PCI devices in the namespace
+ * DESCRIPTION: Install handlers for all EC, PCI and GED devices in the namespace
  *
  ******************************************************************************/
 
@@ -368,6 +479,11 @@ AeInstallDeviceHandlers (
     /* Install a PCI handler */
 
     AcpiGetDevices ("PNP0A08", AeInstallPciHandler, NULL, NULL);
+
+    /* Install a GED handler */
+
+    AcpiGetDevices ("ACPI0013", AeInstallGedHandler, NULL, NULL);
+
     return (AE_OK);
 }
 


### PR DESCRIPTION
Acpiexec lacked support for GED devices (relevant for HW-reduced platforms), where an interrupt (of a given GSIV) triggers the execution of the _EVT method of that GED.

This patch set introduces support for interrupt simulation in acpiexec.
