### PR TITLE
Events: Fix fixed pcie wake event

### DIFF
--- a/source/components/events/evevent.c
+++ b/source/components/events/evevent.c
@@ -310,13 +310,23 @@ AcpiEvFixedEventInitialize (
 
         if (AcpiGbl_FixedEventInfo[i].EnableRegisterId != 0xFF)
         {
-            Status = AcpiWriteBitRegister (
-                AcpiGbl_FixedEventInfo[i].EnableRegisterId,
-                (i == ACPI_EVENT_PCIE_WAKE) ?
-                ACPI_ENABLE_EVENT : ACPI_DISABLE_EVENT);
-            if (ACPI_FAILURE (Status))
-            {
-                return (Status);
+            if (i == ACPI_EVENT_PCIE_WAKE &&
+                (AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+                Status = AcpiWriteBitRegister (
+                    AcpiGbl_FixedEventInfo[i].EnableRegisterId,
+                    ACPI_ENABLE_EVENT);
+                if (ACPI_FAILURE (Status))
+                {
+                    return (Status);
+                }
+            } else {
+                Status = AcpiWriteBitRegister (
+                    AcpiGbl_FixedEventInfo[i].EnableRegisterId,
+                    ACPI_DISABLE_EVENT);
+                if (ACPI_FAILURE (Status))
+                {
+                    return (Status);
+                }
             }
         }
     }
@@ -376,6 +386,11 @@ AcpiEvFixedEventDetect (
      */
     for (i = 0; i < ACPI_NUM_FIXED_EVENTS; i++)
     {
+        if (i == ACPI_EVENT_PCIE_WAKE &&
+		!(AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+		continue;
+	}
+
         /* Both the status and enable bits must be on for this event */
 
         if ((FixedStatus & AcpiGbl_FixedEventInfo[i].StatusBitMask) &&

--- a/source/components/events/evxfevnt.c
+++ b/source/components/events/evxfevnt.c
@@ -320,13 +320,18 @@ AcpiEnableEvent (
         return_ACPI_STATUS (AE_BAD_PARAMETER);
     }
 
+    if (Event == ACPI_EVENT_PCIE_WAKE &&
+        !(AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+            return_ACPI_STATUS (AE_BAD_PARAMETER);
+    }
+
     /*
      * Enable the requested fixed event (by writing a one to the enable
      * register bit)
      */
     Status = AcpiWriteBitRegister (
         AcpiGbl_FixedEventInfo[Event].EnableRegisterId,
-        ACPI_ENABLE_EVENT);
+        Event == ACPI_EVENT_PCIE_WAKE ? ACPI_DISABLE_EVENT : ACPI_ENABLE_EVENT);
     if (ACPI_FAILURE (Status))
     {
         return_ACPI_STATUS (Status);
@@ -341,7 +346,7 @@ AcpiEnableEvent (
         return_ACPI_STATUS (Status);
     }
 
-    if (Value != 1)
+    if (Value != (Event == ACPI_EVENT_PCIE_WAKE ? 0 : 1))
     {
         ACPI_ERROR ((AE_INFO,
             "Could not enable %s event", AcpiUtGetEventName (Event)));
@@ -393,13 +398,17 @@ AcpiDisableEvent (
         return_ACPI_STATUS (AE_BAD_PARAMETER);
     }
 
+    if (Event == ACPI_EVENT_PCIE_WAKE &&
+        !(AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+            return_ACPI_STATUS (AE_BAD_PARAMETER);
+    }
     /*
      * Disable the requested fixed event (by writing a zero to the enable
      * register bit)
      */
     Status = AcpiWriteBitRegister (
         AcpiGbl_FixedEventInfo[Event].EnableRegisterId,
-        ACPI_DISABLE_EVENT);
+        Event == ACPI_EVENT_PCIE_WAKE ? ACPI_ENABLE_EVENT : ACPI_DISABLE_EVENT);
     if (ACPI_FAILURE (Status))
     {
         return_ACPI_STATUS (Status);
@@ -412,7 +421,7 @@ AcpiDisableEvent (
         return_ACPI_STATUS (Status);
     }
 
-    if (Value != 0)
+    if (Value != (Event == ACPI_EVENT_PCIE_WAKE ? 1 : 0))
     {
         ACPI_ERROR ((AE_INFO,
             "Could not disable %s events", AcpiUtGetEventName (Event)));
@@ -461,6 +470,10 @@ AcpiClearEvent (
         return_ACPI_STATUS (AE_BAD_PARAMETER);
     }
 
+    if (Event == ACPI_EVENT_PCIE_WAKE &&
+        !(AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+            return_ACPI_STATUS (AE_BAD_PARAMETER);
+    }
     /*
      * Clear the requested fixed event (By writing a one to the status
      * register bit)
@@ -514,6 +527,11 @@ AcpiGetEventStatus (
         return_ACPI_STATUS (AE_BAD_PARAMETER);
     }
 
+    if (Event == ACPI_EVENT_PCIE_WAKE &&
+        !(AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+            return_ACPI_STATUS (AE_BAD_PARAMETER);
+    }
+
     /* Fixed event currently can be dispatched? */
 
     if (AcpiGbl_FixedEventHandlers[Event].Handler)
@@ -530,7 +548,7 @@ AcpiGetEventStatus (
         return_ACPI_STATUS (Status);
     }
 
-    if (InByte)
+    if (Event == ACPI_EVENT_PCIE_WAKE ? !InByte : InByte)
     {
         LocalEventStatus |=
             (ACPI_EVENT_FLAG_ENABLED | ACPI_EVENT_FLAG_ENABLE_SET);

--- a/source/components/hardware/hwsleep.c
+++ b/source/components/hardware/hwsleep.c
@@ -220,6 +220,13 @@ AcpiHwLegacySleep (
         return_ACPI_STATUS (Status);
     }
 
+    /* Enable pcie wake event if support */
+    if ((AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
+        (void) AcpiWriteBitRegister (
+		AcpiGbl_FixedEventInfo[ACPI_EVENT_PCIE_WAKE].EnableRegisterId,
+		ACPI_DISABLE_EVENT);
+    }
+
     /* Get current value of PM1A control */
 
     Status = AcpiHwRegisterRead (ACPI_REGISTER_PM1_CONTROL,
@@ -475,11 +482,11 @@ AcpiHwLegacyWake (
             AcpiGbl_FixedEventInfo[ACPI_EVENT_SLEEP_BUTTON].StatusRegisterId,
             ACPI_CLEAR_STATUS);
 
-    /* Enable pcie wake event if support */
+    /* Clear and disable pcie wake event if support */
     if ((AcpiGbl_FADT.Flags & ACPI_FADT_PCI_EXPRESS_WAKE)) {
         (void) AcpiWriteBitRegister (
 		AcpiGbl_FixedEventInfo[ACPI_EVENT_PCIE_WAKE].EnableRegisterId,
-		ACPI_DISABLE_EVENT);
+		ACPI_ENABLE_EVENT);
         (void) AcpiWriteBitRegister (
 		AcpiGbl_FixedEventInfo[ACPI_EVENT_PCIE_WAKE].StatusRegisterId,
 		ACPI_CLEAR_STATUS);


### PR DESCRIPTION
Some platforms support the PCIEXP_WAKE_STS bit in the PM1 Status register and the PCIEXP_WAKE_EN bit in the PM1 Enable register. But ACPI_FADT_PCI_EXPRESS_WAKE is not set in fixed feature flag of FADT, skip handling it during processing fixed events if no ACPI_FADT_PCI_EXPRESS_WAKE set.

Second, fixed pcie wakeup event should be enabled before entering sleep state just as GPEs with wakeup ability, or the system will be not waked up by pcie devices due to its disabled state, and it should be cleared on waking up so that the event is disabled at runtime (it is not a runtime event).

Fixes: 32d875705c8e ("Events: Support fixed pcie wake event")