### PR TITLE
Fix GCC 12 dangling-pointer warning

### DIFF
--- a/source/components/utilities/utdebug.c
+++ b/source/components/utilities/utdebug.c
@@ -185,7 +185,12 @@ AcpiUtInitStackPtrTrace (
     ACPI_SIZE               CurrentSp;
 
 
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wdangling-pointer="
+#endif
     AcpiGbl_EntryStackPointer = &CurrentSp;
+#pragma GCC diagnostic pop
 }
 
 

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -312,6 +312,7 @@
 #ifdef ACPI_USE_STANDARD_HEADERS
 #include <stddef.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #define ACPI_OFFSET(d, f)   offsetof(d, f)
 #endif


### PR DESCRIPTION
We're storing a persistent pointer to an ephemeral local variable which technically is a dangling pointer and the compiler is correct. However, since we never indirect the pointer, this is a safe operation and we can suppress the warning.

Also, some C run-times (like MUSL) aren't including <stdint.h> indirectly so we must include it explicitly or we won't have the type definition for uintptr_t.

Fixes issue #867.