### PR TITLE
ACPICA: Modify ACPI_STATE_COMMON

### DIFF
--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -786,13 +786,13 @@ typedef struct acpi_field_info
     UINT8                           DescriptorType; /* To differentiate various internal objs */\
     UINT8                           Flags; \
     UINT16                          Value; \
-    UINT16                          State;
+    UINT16                          State
 
     /* There are 2 bytes available here until the next natural alignment boundary */
 
 typedef struct acpi_common_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
 } ACPI_COMMON_STATE;
 
 
@@ -801,7 +801,7 @@ typedef struct acpi_common_state
  */
 typedef struct acpi_update_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     union acpi_operand_object       *Object;
 
 } ACPI_UPDATE_STATE;
@@ -812,7 +812,7 @@ typedef struct acpi_update_state
  */
 typedef struct acpi_pkg_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT32                          Index;
     union acpi_operand_object       *SourceObject;
     union acpi_operand_object       *DestObject;
@@ -829,7 +829,7 @@ typedef struct acpi_pkg_state
  */
 typedef struct acpi_control_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT16                          Opcode;
     union acpi_parse_object         *PredicateOp;
     UINT8                           *AmlPredicateStart;     /* Start of if/while predicate */
@@ -844,7 +844,7 @@ typedef struct acpi_control_state
  */
 typedef struct acpi_scope_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     ACPI_NAMESPACE_NODE             *Node;
 
 } ACPI_SCOPE_STATE;
@@ -852,7 +852,7 @@ typedef struct acpi_scope_state
 
 typedef struct acpi_pscope_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT32                          ArgCount;               /* Number of fixed arguments */
     union acpi_parse_object         *Op;                    /* Current op being parsed */
     UINT8                           *ArgEnd;                /* Current argument end */
@@ -868,7 +868,7 @@ typedef struct acpi_pscope_state
  */
 typedef struct acpi_thread_state
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT8                           CurrentSyncLevel;       /* Mutex Sync (nested acquire) level */
     struct acpi_walk_state          *WalkStateList;         /* Head of list of WalkStates for this thread */
     union acpi_operand_object       *AcquiredMutexList;     /* List of all currently acquired mutexes */
@@ -883,7 +883,7 @@ typedef struct acpi_thread_state
  */
 typedef struct acpi_result_values
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     union acpi_operand_object       *ObjDesc [ACPI_RESULTS_FRAME_OBJ_NUM];
 
 } ACPI_RESULT_VALUES;
@@ -914,7 +914,7 @@ typedef struct acpi_global_notify_handler
  */
 typedef struct acpi_notify_info
 {
-    ACPI_STATE_COMMON
+    ACPI_STATE_COMMON;
     UINT8                           HandlerListId;
     ACPI_NAMESPACE_NODE             *Node;
     union acpi_operand_object       *HandlerListHead;


### PR DESCRIPTION
Avoid trailing semicolons in macro, and it's not readable to put macro ACPI_STATE_COMMON and other variables in the same line.
So modify the macro and just put it in a single line.