### PR TITLE
exserial.c: replace ternary operator with ACPI_MIN()

### DIFF
--- a/source/components/executer/exserial.c
+++ b/source/components/executer/exserial.c
@@ -505,8 +505,7 @@ AcpiExWriteSerialBus (
     /* Copy the input buffer data to the transfer buffer */
 
     Buffer = BufferDesc->Buffer.Pointer;
-    DataLength = (BufferLength < SourceDesc->Buffer.Length ?
-        BufferLength : SourceDesc->Buffer.Length);
+    DataLength = ACPI_MIN (BufferLength, SourceDesc->Buffer.Length);
     memcpy (Buffer, SourceDesc->Buffer.Pointer, DataLength);
 
     /* Lock entire transaction if requested */


### PR DESCRIPTION
Make the code simpler and more readable.