### PR TITLE
fix for conflict macro definition on zephyr interface

### DIFF
--- a/source/include/platform/aczephyr.h
+++ b/source/include/platform/aczephyr.h
@@ -152,9 +152,6 @@
 #ifndef __ACZEPHYR_H__
 #define __ACZEPHYR_H__
 
-#define SEEK_SET FS_SEEK_SET
-#define SEEK_END FS_SEEK_END
-
 #define ACPI_MACHINE_WIDTH      64
 
 #define ACPI_NO_ERROR_MESSAGES


### PR DESCRIPTION
fix for conflict SEEK_SET/SEEK_END duplicate macro while run CI job.