### PR TITLE
Slightly simplify an error message in AcpiDsResultPush()

### DIFF
--- a/source/components/dispatcher/dswstate.c
+++ b/source/components/dispatcher/dswstate.c
@@ -310,8 +310,8 @@ AcpiDsResultPush (
     if (!Object)
     {
         ACPI_ERROR ((AE_INFO,
-            "Null Object! Obj=%p State=%p Num=%u",
-            Object, WalkState, WalkState->ResultCount));
+            "Null Object! State=%p Num=%u",
+            WalkState, WalkState->ResultCount));
         return (AE_BAD_PARAMETER);
     }
 


### PR DESCRIPTION
'object' is known to be NULL at this point. There is little value to log it twice in the error message.