### PR TITLE
Add a define for size of acpi_srat_generic_affinity DeviceHandle

### DIFF
--- a/source/include/actbl3.h
+++ b/source/include/actbl3.h
@@ -454,13 +454,15 @@ typedef struct acpi_srat_gic_its_affinity
  * 6: ACPI_SRAT_TYPE_GENERIC_PORT_AFFINITY
  */
 
+#define ACPI_SRAT_DEVICE_HANDLE_SIZE	16
+
 typedef struct acpi_srat_generic_affinity
 {
     ACPI_SUBTABLE_HEADER    Header;
     UINT8                   Reserved;
     UINT8                   DeviceHandleType;
     UINT32                  ProximityDomain;
-    UINT8                   DeviceHandle[16];
+    UINT8                   DeviceHandle[ACPI_SRAT_DEVICE_HANDLE_SIZE];
     UINT32                  Flags;
     UINT32                  Reserved1;
 


### PR DESCRIPTION
Replace magic number with a define. Linux kernel code will utilize this define.