### PR TITLE
fix coverity issue

### DIFF
--- a/source/components/dispatcher/dswstate.c
+++ b/source/components/dispatcher/dswstate.c
@@ -426,8 +426,8 @@ AcpiDsResultStackPop (
     WalkState->ResultSize -= ACPI_RESULTS_FRAME_OBJ_NUM;
 
     ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
-        "Result=%p RemainingResults=%X State=%p\n",
-        State, WalkState->ResultCount, WalkState));
+        "RemainingResults=%X State=%p\n",
+        WalkState->ResultCount, WalkState));
 
     return (AE_OK);
 }

--- a/source/components/namespace/nsalloc.c
+++ b/source/components/namespace/nsalloc.c
@@ -275,8 +275,8 @@ AcpiNsDeleteNode (
     (void) AcpiOsReleaseObject (AcpiGbl_NamespaceCache, Node);
 
     ACPI_MEM_TRACKING (AcpiGbl_NsNodeList->TotalFreed++);
-    ACPI_DEBUG_PRINT ((ACPI_DB_ALLOCATIONS, "Node %p, Remaining %X\n",
-        Node, AcpiGbl_CurrentNodeCount));
+    ACPI_DEBUG_PRINT ((ACPI_DB_ALLOCATIONS, "Remaining %X\n",
+        AcpiGbl_CurrentNodeCount));
 }
 
 

--- a/source/components/namespace/nsdump.c
+++ b/source/components/namespace/nsdump.c
@@ -635,10 +635,6 @@ AcpiNsDumpOneObject (
             break;
         }
         break;
-
-    default:
-        AcpiOsPrintf ("\n");
-        break;
     }
 
     /* If debug turned off, done */

--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -901,6 +901,7 @@ AcpiPsGetNextArg (
     ACPI_PARSE_OBJECT       *Field;
     UINT32                  Subop;
     ACPI_STATUS             Status = AE_OK;
+    ACPI_PARSE_OBJECT       *tmp = NULL;
 
 
     ACPI_FUNCTION_TRACE_PTR (PsGetNextArg, ParserState);
@@ -948,6 +949,12 @@ AcpiPsGetNextArg (
                 Field = AcpiPsGetNextField (ParserState);
                 if (!Field)
                 {
+                    while (Arg)
+                    {
+                        tmp = Arg->Common.Next;
+                        AcpiPsFreeOp (Arg);
+                        Arg = tmp;
+                    }
                     return_ACPI_STATUS (AE_NO_MEMORY);
                 }
 


### PR DESCRIPTION
dswstate.c
'State' is deleted before DEBUG_PRINT()

nsalloc.c
'Node' is delete before DEBUG_PRINT()

nsdump.c
the default block will not be excuted.

psargs.c
when hit the 'Field' is null, the 'Arg' will not be free which will lead memory leak.