### PR TITLE
os_specific: zephyr: add generic platform support

### DIFF
--- a/source/include/platform/aczephyr.h
+++ b/source/include/platform/aczephyr.h
@@ -152,7 +152,17 @@
 #ifndef __ACZEPHYR_H__
 #define __ACZEPHYR_H__
 
-#define ACPI_MACHINE_WIDTH      64
+#if defined(__x86_64__)
+#define ACPI_MACHINE_WIDTH          64
+#else
+#define ACPI_32BIT_PHYSICAL_ADDRESS
+#define ACPI_MACHINE_WIDTH          32
+#define ACPI_USE_NATIVE_DIVIDE
+#define ACPI_USE_NATIVE_MATH64
+#endif
+
+#define COMPILER_DEPENDENT_INT64    long long
+#define COMPILER_DEPENDENT_UINT64   unsigned long long
 
 #define ACPI_NO_ERROR_MESSAGES
 #undef ACPI_DEBUG_OUTPUT

--- a/source/os_specific/service_layers/oszephyr.c
+++ b/source/os_specific/service_layers/oszephyr.c
@@ -153,7 +153,7 @@
 #include "accommon.h"
 #include "acapps.h"
 #include "aslcompiler.h"
-#include <zephyr/arch/x86/efi.h>
+#include <zephyr/arch/x86/x86_acpi_osal.h>
 #include <zephyr/drivers/pcie/pcie.h>
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/sys/__assert.h>
@@ -163,15 +163,13 @@ LOG_MODULE_DECLARE(acpica, LOG_LEVEL_ERR);
 
 typedef void (*zephyr_irq_t)(const void *);
 
-#define ASL_MSG_BUFFER_SIZE (1024 * 128)
-
 /* Global varibles use from acpica lib. */
 BOOLEAN                     AslGbl_DoTemplates = FALSE;
 BOOLEAN                     AslGbl_VerboseTemplates = FALSE;
 
 char                        AslGbl_MsgBuffer[ASL_MSG_BUFFER_SIZE];
 static BOOLEAN              EnDbgPrint;
-
+static ACPI_PHYSICAL_ADDRESS RsdpPhyAdd;
 
 /******************************************************************************
  *
@@ -384,12 +382,12 @@ AcpiOsReadMemory (
 
         *((UINT32 *) Value) = sys_read32 (Address);
         break;
-
+#if defined(__x86_64__)
     case 64:
 
         *((UINT64 *) Value) = sys_read64 (Address);
         break;
-
+#endif
     default:
 
         return (AE_BAD_PARAMETER);
@@ -435,12 +433,12 @@ AcpiOsWriteMemory (
 
         sys_write32 ((UINT32) Value, Address);
         break;
-
+#if defined(__x86_64__)
     case 64:
 
         sys_write64 ((UINT64) Value, Address);
         break;
-
+#endif
     default:
 
         return (AE_BAD_PARAMETER);
@@ -773,11 +771,17 @@ ACPI_PHYSICAL_ADDRESS
 AcpiOsGetRootPointer (
     void)
 {
+	 LOG_DBG ("");
 
-    LOG_DBG ("");
-    return ((ACPI_PHYSICAL_ADDRESS) efi_get_acpi_rsdp ());
+	if(RsdpPhyAdd)
+	{
+		return RsdpPhyAdd;
+	}
+
+	RsdpPhyAdd = (ACPI_PHYSICAL_ADDRESS)acpi_rsdp_get();
+
+	return RsdpPhyAdd;
 }
-
 
 #ifndef ACPI_USE_NATIVE_MEMORY_MAPPING
 /******************************************************************************


### PR DESCRIPTION
add support for uefi as well as non uefi platform for zephyr rtos.
Also add support for 32bit platforms.