### PR TITLE
fix the phat getting wrong string length and offset

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -149,7 +149,6 @@
  *
  *****************************************************************************/
 
-#include <wchar.h>
 #include "acpi.h"
 #include "accommon.h"
 #include "acdisasm.h"
@@ -2283,7 +2282,8 @@ AcpiDmDumpPhat (
     UINT32                  PathLength;
     UINT32                  VendorLength;
     UINT16                  RecordType;
-    const wchar_t           *WideString;
+    const UINT16            *WideString;
+    UINT32                  i;
 
 
     Subtable = ACPI_ADD_PTR (ACPI_PHAT_HEADER, Table, sizeof (ACPI_TABLE_PHAT));
@@ -2391,10 +2391,13 @@ AcpiDmDumpPhat (
              * Get the length of the Device Path (UEFI wide string).
              * Include the wide null terminator (+2),
              */
-            WideString = ACPI_ADD_PTR (wchar_t, Subtable,
+            WideString = ACPI_ADD_PTR (UINT16, Subtable,
                 sizeof (ACPI_PHAT_HEALTH_DATA));
 
-            PathLength = (wcslen (WideString) * 2) + 2;
+	   for (i = 0; *WideString; i++, WideString++)
+		;
+
+            PathLength = i * 2 + 2;
             DbgPrint (ASL_DEBUG_OUTPUT, "/* %u, PathLength %X, Offset %X, Table->Length %X */\n",
                 __LINE__, PathLength, Offset, Length);
 

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -2314,7 +2314,7 @@ AcpiDmDumpPhat (
         case ACPI_PHAT_TYPE_FW_HEALTH_DATA:
 
             InfoTable = AcpiDmTableInfoPhat1;
-            SubtableLength = Offset += sizeof (ACPI_PHAT_TYPE_FW_HEALTH_DATA);
+            SubtableLength = Offset += sizeof (ACPI_PHAT_HEALTH_DATA);
             break;
 
         default:


### PR DESCRIPTION
Unlike Windows UTF-16 2-byte wide characters, wchar_t on Linux is 4 bytes UTF-32. So it will get unexpected string length.
  ```  
    /* 2196, Subtable->Type 1 */
    /* 2291, PathLength 20, Offset 50, Table->Length A2 */
    2307, Subtable->Length 2E, VendorLength FFFFFFF2, Offset 70 PathLength: 20
    
    [0002]                      Subtable Type : 0001 [Firmware Health Data]
    [0002]                             Length : 002E
    [0001]                           Revision : 00
    [0002]                           Reserved : 0000
    [0001]                             Health : 00
    [0016]                        Device GUID : 91AF0530-5D86-470E-A6B0-0A2DB9408249
    [0004]             Device-Specific Offset : 0000002A
    [0032]                        Device Path : 41 00 42 00 43 00 44 00 45 00 46 00 00 00 01 02 /* A.B.C.D.E.F..... */\
    /* 010h 0016  16 */                            03 04 00 00 28 00 00 00 00 00 01 00 00 00 30 05 /* ....(.........0. */\
```

And use the correct ACPI_PHAT_HEALTH_DATA struct to calculate offset.