### PR TITLE
Fix segfault when error-checking mixed table types

### DIFF
--- a/source/compiler/aslfiles.c
+++ b/source/compiler/aslfiles.c
@@ -346,7 +346,9 @@ FlGetFileHandle (
 
     while (Current)
     {
-        if (!strcmp (Current->Files[InFileId].Filename, Filename))
+        if (!((Current->FileType == ASL_INPUT_TYPE_ASCII_DATA) &&
+            (InFileId == ASL_FILE_SOURCE_OUTPUT)) &&
+            !strcmp (Current->Files[InFileId].Filename, Filename))
         {
             return (Current->Files[OutFileId].Handle);
         }


### PR DESCRIPTION
If a code table which contains errors is passed to iasl followed by a data table, AePrintErrorSourceLine will call FlGetFileHandle with an InFileId of ASL_FILE_SOURCE_OUTPUT and a non-NULL Filename.

When FlGetFileHandle searches AslGbl_FilesList, it first encounters the entry for the data table, which has no Files entry for this InFileId.

It then passes a NULL value to strcmp which can cause a segfault.

The bug was introduced in https://github.com/acpica/acpica/commit/997f6ca123771073a6f62738734a561d2dd056ac when FlGetFileHandle was added. Before, AePrintErrorSourceLine checked if AslGbl_Files[ASL_FILE_SOURCE_OUTPUT].Handle was NULL before proceeding.

Simple repro:
```
❯ ./iasl -T dsdt
Created ACPI table template for [DSDT], written to "dsdt.asl"
❯ ./iasl -T facp
Created ACPI table template for [FACP], written to "facp.asl"
❯ diff dsdt.asl dsdt-mod.asl
11a12
>         Return (ABCD)
❯ ./iasl dsdt-mod.asl facp.asl

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20230628
Copyright (c) 2000 - 2023 Intel Corporation

zsh: segmentation fault  ./iasl dsdt-mod.asl facp.asl
```

Works properly if arg order is reversed:
```
❯ ./iasl facp.asl dsdt-mod.asl

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20230628
Copyright (c) 2000 - 2023 Intel Corporation

dsdt-mod.asl     12:         Return (ABCD)
Error    6084 -  Object does not exist ^  (ABCD)

ASL Input:     dsdt-mod.asl -     337 bytes      2 keywords      0 source lines
Table Input:   facp.asl -    8217 bytes    149 fields      172 source lines
Binary Output: facp.aml -     276 bytes

Compilation failed. 1 Errors, 0 Warnings, 0 Remarks
No AML files were generated due to compiler error(s)
```