### PR TITLE
dmtbdump: remove duplicated code for both paths of an if statement

### DIFF
--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -266,14 +266,7 @@ AcpiDmDumpBuffer (
         /* Done with that line. */
         /* Close the comment and insert a backslash - line continuation character */
 
-        if (Length > 16)
-        {
-            AcpiOsPrintf (" */\\");
-        }
-        else
-        {
-            AcpiOsPrintf (" */\\");
-        }
+        AcpiOsPrintf (" */\\");
 
         i += 16; /* Point to next line */
     }

--- a/tests/aslts/doc/docs/TestOfOperands
+++ b/tests/aslts/doc/docs/TestOfOperands
@@ -331,7 +331,7 @@ references to the Uninitialized objects which prevents automated
 processing as well.
 
    One more inconvenience for testing arises from the type conversion
-functionality. Due to that some type objects could not be representes
+functionality. Due to that some type objects could not be represented
 not only as elements of Package, but also be passed to Method as parameters
 (Buffer Field, Field Unit, etc..), since they are converted to either Integer
 or Buffer types in the latter case. As a result, these conditions should

--- a/tests/aslts/src/runtime/collections/functional/module/object.asl
+++ b/tests/aslts/src/runtime/collections/functional/module/object.asl
@@ -48,7 +48,7 @@
  *
  * It appears the AML interpreter shouldn't support TermList for these
  * objects as both the ASL grammar and AML grammar doesn't allow it. But
- * the real world apears not.
+ * the real world appears not.
  */
 
 Name(z181, 181)


### PR DESCRIPTION
There is an if statement where both paths print the same output, hence the if is redundant and can be replace with just the print.