### PR TITLE
dmtbdump2: remove redundant failure check on Status

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -2025,10 +2025,6 @@ AcpiDmDumpPhat (
                 Offset += VendorLength;
             }
 
-            if (ACPI_FAILURE (Status))
-            {
-                return;
-            }
             break;
 
         default:


### PR DESCRIPTION
The failure check on Status is redundant as it is being checked in the previous if statement and before the if statement too. It is impossible for ACPI_FAILURE(Status) to be true because the previous checks have already returned out of the function at this point. Remove it.