### PR TITLE
[RFC] nssearch: Improve performance of AcpiNsSearchOneScope

### DIFF
--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -208,6 +208,14 @@ AcpiNsRootInitialize (
         goto UnlockAndExit;
     }
 
+#ifdef ACPI_USE_NS_SEARCH_ACCELERATION
+    Status = AcpiNsSearchAccelerationInit ();
+    if (ACPI_FAILURE (Status))
+    {
+        return_ACPI_STATUS (Status);
+    }
+#endif
+
     /*
      * Tell the rest of the subsystem that the root is initialized
      * (This is OK because the namespace is locked)
@@ -272,6 +280,10 @@ AcpiNsRootInitialize (
 
         NewNode->Parent = &AcpiGbl_RootNodeStruct;
         PrevNode = NewNode;
+
+#ifdef ACPI_USE_NS_SEARCH_ACCELERATION
+        AcpiNsSearchAccelerationAddNode (NewNode);
+#endif
 
         /*
          * Name entered successfully. If entry in PreDefinedNames[] specifies

--- a/source/components/namespace/nsalloc.c
+++ b/source/components/namespace/nsalloc.c
@@ -237,6 +237,10 @@ AcpiNsDeleteNode (
         return_VOID;
     }
 
+#ifdef ACPI_USE_ACCELERATED_NS_SEARCH
+    AcpiNsSearchAccelerationDeleteNode(Node);
+#endif
+
     /* Detach an object if there is one */
 
     AcpiNsDetachObject (Node);
@@ -421,6 +425,10 @@ AcpiNsInstallNode (
 
     Node->OwnerId = OwnerId;
     Node->Type = (UINT8) Type;
+
+#ifdef ACPI_USE_NS_SEARCH_ACCELERATION
+    AcpiNsSearchAccelerationAddNode (Node);
+#endif
 
     ACPI_DEBUG_PRINT ((ACPI_DB_NAMES,
         "%4.4s (%s) [Node %p Owner %3.3X] added to %4.4s (%s) [Node %p]\n",

--- a/source/components/namespace/nsutils.c
+++ b/source/components/namespace/nsutils.c
@@ -806,6 +806,9 @@ AcpiNsTerminate (
 
     ACPI_FUNCTION_TRACE (NsTerminate);
 
+#ifdef ACPI_USE_NS_SEARCH_ACCELERATION
+    AcpiNsSearchAccelerationTerminate ();
+#endif
 
     /*
      * Free the entire namespace -- all nodes and all objects

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -301,6 +301,9 @@ typedef struct acpi_namespace_node
     struct acpi_namespace_node      *Child;         /* First child */
     struct acpi_namespace_node      *Peer;          /* First peer */
     ACPI_OWNER_ID                   OwnerId;        /* Node creator */
+#ifdef ACPI_USE_NS_SEARCH_ACCELERATION
+    ACPI_NS_SEARCH_LIST_NODE_TYPE   SearchListNode; /* Link together nodes that hash to the same bucket */
+#endif
 
     /*
      * The following fields are used by the ASL compiler and disassembler only

--- a/source/include/acnamesp.h
+++ b/source/include/acnamesp.h
@@ -645,6 +645,24 @@ AcpiNsInstallNode (
     ACPI_NAMESPACE_NODE     *Node,
     ACPI_OBJECT_TYPE        Type);
 
+#ifdef ACPI_USE_NS_SEARCH_ACCELERATION
+ACPI_STATUS
+AcpiNsSearchAccelerationInit(
+    void);
+
+void
+AcpiNsSearchAccelerationTerminate(
+    void);
+
+void
+AcpiNsSearchAccelerationAddNode(
+    ACPI_NAMESPACE_NODE     *Node);
+
+void
+AcpiNsSearchAccelerationDeleteNode(
+    ACPI_NAMESPACE_NODE     *Node);
+#endif
+
 
 /*
  * nsutils - Utility functions

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -188,6 +188,7 @@
 #define ACPI_MUTEX_DEBUG
 #endif
 
+#include <linux/hashtable.h>
 #include <linux/string.h>
 #include <linux/kernel.h>
 #include <linux/ctype.h>
@@ -304,6 +305,15 @@
  * Linux wants to use designated initializers for function pointer structs.
  */
 #define ACPI_STRUCT_INIT(field, value)  .field = value
+
+#define ACPI_USE_NS_SEARCH_ACCELERATION
+#define ACPI_NS_SEARCH_LIST_NODE_TYPE struct hlist_node
+#define ACPI_NS_SEARCH_LIST_HEAD_TYPE struct hlist_head
+#define ACPI_HASH_UINT32(val, bits) hash_32(val, bits)
+#define ACPI_HASH_PTR(ptr, bits) hash_ptr(ptr, bits)
+#define ACPI_NS_SEARCH_LIST_ADD_HEAD(node, head) hlist_add_head(node, head)
+#define ACPI_HASH_DEL(node) hash_del(node)
+#define ACPI_LIST_FOR_EACH_ENTRY(pos, head, member) hlist_for_each_entry(pos, head, member)
 
 #else /* !__KERNEL__ */
 


### PR DESCRIPTION
As documented, the linear search performed by AcpiNsSearchOneScope is
good enough for small namespace trees and is generally dominated by
other overheads anyway.

However, there are environments where improved performance during boot
is highly desirable.

This pull request is a proposed path forward towards improving performance by
using a hash table to look up nodes. The hash table is keyed by a
combination of node name and parent node pointer.

Instead of a fixed number of hash table buckets, it might be preferable
to pick the size dynamically: for example, allocation can be shifted
until after the total size of ACPI tables is known, and that can be used
for a heuristic to pick the size and avoid extraneous memory overhead.
The specifics around the best approach here are up for discussion.

Another point for discussion is whether the rather Linux-inspired set of macros
that platforms need to define to make use of the acceleration is appropriate, or
whether more of the core logic to compute hashes and handle simple hashtables
should reside in ACPICA itself.

Signed-off-by: Peter Szuecs <pszucs@amazon.de>
Co-authored-by: Stanislav Spassov <stanspas@amazon.de>