### PR TITLE
Add option to make output deterministic

### DIFF
--- a/source/common/dmtables.c
+++ b/source/common/dmtables.c
@@ -190,7 +190,7 @@ extern ACPI_PARSE_OBJECT    *AcpiGbl_ParseOpRoot;
  * RETURN:      None
  *
  * DESCRIPTION: Create the disassembler header, including ACPICA signon with
- *              current time and date.
+ *              optional current time and date.
  *
  *****************************************************************************/
 
@@ -201,8 +201,6 @@ AdDisassemblerHeader (
 {
     time_t                  Timer;
 
-
-    time (&Timer);
 
     /* Header and input table info */
 
@@ -225,7 +223,15 @@ AdDisassemblerHeader (
         }
     }
 
-    AcpiOsPrintf (" * Disassembly of %s, %s", Filename, ctime (&Timer));
+    if (AslGbl_Deterministic)
+    {
+        AcpiOsPrintf (" * Disassembly of %s\n", Filename);
+    }
+    else
+    {
+        time (&Timer);
+        AcpiOsPrintf (" * Disassembly of %s, %s", Filename, ctime (&Timer));
+    }
     AcpiOsPrintf (" *\n");
 }
 

--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -697,18 +697,24 @@ AslCompilerFileHeader (
         break;
     }
 
-    /* Compilation header with timestamp */
-
-    Aclock = time (NULL);
-    NewTime = ctime (&Aclock);
+    /* Compilation header (with timestamp) */
 
     FlPrintFile (FileId,
-        "%sCompilation of \"%s\" -",
+        "%sCompilation of \"%s\"",
         Prefix, AslGbl_Files[ASL_FILE_INPUT].Filename);
 
-    if (NewTime)
+    if (!AslGbl_Deterministic) 
     {
-        FlPrintFile (FileId, " %s%s\n", NewTime, Prefix);
+        Aclock = time (NULL);
+        NewTime = ctime (&Aclock);
+        if (NewTime)
+        {
+            FlPrintFile (FileId, " - %s%s\n", NewTime, Prefix);
+        }
+    }
+    else 
+    {
+        FlPrintFile (FileId, "\n");
     }
 
     switch (FileId)

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -325,6 +325,7 @@ ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_ReferenceOptimizatio
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DisplayRemarks, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DisplayWarnings, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DisplayOptimizations, FALSE);
+ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_Deterministic, TRUE);
 ASL_EXTERN UINT8                    ASL_INIT_GLOBAL (AslGbl_WarningLevel, ASL_WARNING);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_UseOriginalCompilerId, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_VerboseTemplates, FALSE);

--- a/source/compiler/aslhelp.c
+++ b/source/compiler/aslhelp.c
@@ -185,6 +185,7 @@ Usage (
     ACPI_OPTION ("-vd",             "Display compiler build date and time");
     ACPI_OPTION ("-vo",             "Enable optimization comments");
     ACPI_OPTION ("-vs",             "Disable signon");
+    ACPI_OPTION ("-ld",             "Disable deterministic output");
 
     printf ("\nHelp:\n");
     ACPI_OPTION ("-h",              "This message");

--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -630,6 +630,13 @@ AslDoOptions (
             AcpiGbl_DmOpt_Listing = TRUE;
             break;
 
+        case 'd':
+
+            /* Disable deterministic output, enabling timestamp */
+
+            AslGbl_Deterministic = FALSE;
+            break;
+
         case 'i':
 
             /* Produce preprocessor output file */


### PR DESCRIPTION
The output from iasl -d included a timestamp. This meant that each execution returned different output. To provide a means of making the output deterministic, use the value of the SOURCE_DATE_EPOCH environment variable in preference to the current time.

See https://reproducible-builds.org/specs/source-date-epoch/ for background on the environment variable.