### PR TITLE
Fix build indeterminism for asm compiler header.

### DIFF
--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -655,6 +655,8 @@ void
 AslCompilerFileHeader (
     UINT32                  FileId)
 {
+    char                    *NewTime;
+    time_t                  Aclock;
     char                    *Prefix = "";
 
 
@@ -695,11 +697,25 @@ AslCompilerFileHeader (
         break;
     }
 
-    /* Compilation header */
+    /* Compilation header (with timestamp) */
 
     FlPrintFile (FileId,
         "%sCompilation of \"%s\"",
         Prefix, AslGbl_Files[ASL_FILE_INPUT].Filename);
+
+    if (!AslGbl_Deterministic) 
+    {
+        Aclock = time (NULL);
+        NewTime = ctime (&Aclock);
+        if (NewTime)
+        {
+            FlPrintFile (FileId, " - %s%s\n", NewTime, Prefix);
+        }
+    }
+    else 
+    {
+        FlPrintFile (FileId, "\n");
+    }
 
     switch (FileId)
     {

--- a/source/compiler/aslcompile.c
+++ b/source/compiler/aslcompile.c
@@ -655,8 +655,6 @@ void
 AslCompilerFileHeader (
     UINT32                  FileId)
 {
-    char                    *NewTime;
-    time_t                  Aclock;
     char                    *Prefix = "";
 
 
@@ -697,19 +695,11 @@ AslCompilerFileHeader (
         break;
     }
 
-    /* Compilation header with timestamp */
-
-    Aclock = time (NULL);
-    NewTime = ctime (&Aclock);
+    /* Compilation header */
 
     FlPrintFile (FileId,
-        "%sCompilation of \"%s\" -",
+        "%sCompilation of \"%s\"",
         Prefix, AslGbl_Files[ASL_FILE_INPUT].Filename);
-
-    if (NewTime)
-    {
-        FlPrintFile (FileId, " %s%s\n", NewTime, Prefix);
-    }
 
     switch (FileId)
     {

--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -325,6 +325,7 @@ ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_ReferenceOptimizatio
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DisplayRemarks, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DisplayWarnings, TRUE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_DisplayOptimizations, FALSE);
+ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_Deterministic, FALSE);
 ASL_EXTERN UINT8                    ASL_INIT_GLOBAL (AslGbl_WarningLevel, ASL_WARNING);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_UseOriginalCompilerId, FALSE);
 ASL_EXTERN BOOLEAN                  ASL_INIT_GLOBAL (AslGbl_VerboseTemplates, FALSE);

--- a/source/compiler/asloptions.c
+++ b/source/compiler/asloptions.c
@@ -630,6 +630,13 @@ AslDoOptions (
             AcpiGbl_DmOpt_Listing = TRUE;
             break;
 
+        case 'd':
+
+            /* Produce deterministic output, suppressing timestamp */
+
+            AslGbl_Deterministic = TRUE;
+            break;
+
         case 'i':
 
             /* Produce preprocessor output file */


### PR DESCRIPTION
Existing code puts a timestamp in the .lst files, e.g.: 
Compilation of ".../src/fw/ssdt-misc.i" - Thu Oct 22 13:38:41 2023 
This makes the build non-deterministic.