### PR TITLE
Modify Integer handling in ToHexString()

### DIFF
--- a/source/components/executer/exconvrt.c
+++ b/source/components/executer/exconvrt.c
@@ -437,6 +437,7 @@ AcpiExConvertToAscii (
     UINT32                  DecimalLength;
     UINT32                  Remainder;
     BOOLEAN                 SupressZeros = !LeadingZeros;
+    UINT8                   HexChar;
 
 
     ACPI_FUNCTION_ENTRY ();
@@ -503,8 +504,18 @@ AcpiExConvertToAscii (
         {
             /* Get one hex digit, most significant digits first */
 
-            String[k] = (UINT8)
+            HexChar = (UINT8)
                 AcpiUtHexToAsciiChar (Integer, ACPI_MUL_4 (j));
+
+            /* Supress leading zeros until the first non-zero character */
+
+            if (HexChar == ACPI_ASCII_ZERO && SupressZeros)
+            {
+                continue;
+            }
+
+            SupressZeros = FALSE;
+            String[k] = HexChar;
             k++;
         }
         break;

--- a/source/components/executer/exconvrt.c
+++ b/source/components/executer/exconvrt.c
@@ -165,7 +165,8 @@ AcpiExConvertToAscii (
     UINT64                  Integer,
     UINT16                  Base,
     UINT8                   *String,
-    UINT8                   MaxLength);
+    UINT8                   MaxLength,
+    BOOLEAN                 LeadingZeros);
 
 
 /*******************************************************************************
@@ -412,6 +413,7 @@ AcpiExConvertToBuffer (
  *              Base            - ACPI_STRING_DECIMAL or ACPI_STRING_HEX
  *              String          - Where the string is returned
  *              DataWidth       - Size of data item to be converted, in bytes
+ *              LeadingZeros    - Allow leading zeros
  *
  * RETURN:      Actual string length
  *
@@ -424,7 +426,8 @@ AcpiExConvertToAscii (
     UINT64                  Integer,
     UINT16                  Base,
     UINT8                   *String,
-    UINT8                   DataWidth)
+    UINT8                   DataWidth,
+    BOOLEAN                 LeadingZeros)
 {
     UINT64                  Digit;
     UINT32                  i;
@@ -433,7 +436,7 @@ AcpiExConvertToAscii (
     UINT32                  HexLength;
     UINT32                  DecimalLength;
     UINT32                  Remainder;
-    BOOLEAN                 SupressZeros;
+    BOOLEAN                 SupressZeros = !LeadingZeros;
 
 
     ACPI_FUNCTION_ENTRY ();
@@ -464,7 +467,6 @@ AcpiExConvertToAscii (
             break;
         }
 
-        SupressZeros = TRUE;     /* No leading zeros */
         Remainder = 0;
 
         for (i = DecimalLength; i > 0; i--)
@@ -556,6 +558,7 @@ AcpiExConvertToString (
     UINT32                  StringLength = 0;
     UINT16                  Base = 16;
     UINT8                   Separator = ',';
+    BOOLEAN                 LeadingZeros;
 
 
     ACPI_FUNCTION_TRACE_PTR (ExConvertToString, ObjDesc);
@@ -581,6 +584,7 @@ AcpiExConvertToString (
              * Make room for the maximum decimal number size
              */
             StringLength = ACPI_MAX_DECIMAL_DIGITS;
+            LeadingZeros = FALSE;
             Base = 10;
             break;
 
@@ -589,6 +593,7 @@ AcpiExConvertToString (
             /* Two hex string characters for each integer byte */
 
             StringLength = ACPI_MUL_2 (AcpiGbl_IntegerByteWidth);
+            LeadingZeros = TRUE;
             break;
         }
 
@@ -607,7 +612,7 @@ AcpiExConvertToString (
         /* Convert integer to string */
 
         StringLength = AcpiExConvertToAscii (
-            ObjDesc->Integer.Value, Base, NewBuf, AcpiGbl_IntegerByteWidth);
+            ObjDesc->Integer.Value, Base, NewBuf, AcpiGbl_IntegerByteWidth, LeadingZeros);
 
         /* Null terminate at the correct place */
 
@@ -628,6 +633,7 @@ AcpiExConvertToString (
              * From ACPI: "If the input is a buffer, it is converted to a
              * a string of decimal values separated by commas."
              */
+            LeadingZeros = FALSE;
             Base = 10;
 
             /*
@@ -661,6 +667,7 @@ AcpiExConvertToString (
              *
              * Each hex number is prefixed with 0x (11/2018)
              */
+            LeadingZeros = TRUE;
             Separator = ' ';
             StringLength = (ObjDesc->Buffer.Length * 5);
             break;
@@ -674,6 +681,7 @@ AcpiExConvertToString (
              *
              * Each hex number is prefixed with 0x (11/2018)
              */
+            LeadingZeros = TRUE;
             Separator = ',';
             StringLength = (ObjDesc->Buffer.Length * 5);
             break;
@@ -715,7 +723,7 @@ AcpiExConvertToString (
             }
 
             NewBuf += AcpiExConvertToAscii (
-                (UINT64) ObjDesc->Buffer.Pointer[i], Base, NewBuf, 1);
+                (UINT64) ObjDesc->Buffer.Pointer[i], Base, NewBuf, 1, LeadingZeros);
 
             /* Each digit is separated by either a comma or space */
 

--- a/source/components/executer/exconvrt.c
+++ b/source/components/executer/exconvrt.c
@@ -599,6 +599,15 @@ AcpiExConvertToString (
             Base = 10;
             break;
 
+        case ACPI_EXPLICIT_CONVERT_HEX:
+            /*
+             * From ToHexString.
+             *
+             * Supress leading zeros and append "0x"
+             */
+            StringLength = ACPI_MUL_2 (AcpiGbl_IntegerByteWidth) + 2;
+            LeadingZeros = FALSE;
+            break;
         default:
 
             /* Two hex string characters for each integer byte */
@@ -619,6 +628,13 @@ AcpiExConvertToString (
         }
 
         NewBuf = ReturnDesc->Buffer.Pointer;
+        if (Type == ACPI_EXPLICIT_CONVERT_HEX)
+        {
+            /* Append "0x" prefix for explicit hex conversion */
+
+            *NewBuf++ = '0';
+            *NewBuf++ = 'x';
+        }
 
         /* Convert integer to string */
 
@@ -628,6 +644,13 @@ AcpiExConvertToString (
         /* Null terminate at the correct place */
 
         ReturnDesc->String.Length = StringLength;
+        if (Type == ACPI_EXPLICIT_CONVERT_HEX)
+        {
+            /* Take "0x" prefix into account */
+
+            ReturnDesc->String.Length += 2;
+        }
+
         NewBuf [StringLength] = 0;
         break;
 


### PR DESCRIPTION
This series changes the handling of integers in ToHexString(), see Issue #827 for details.
The following ASL code was used to test the behavior of ToHexString() with integer arguments under both Windows and ACPICA: [ssdt.txt](https://github.com/acpica/acpica/files/13194389/ssdt.txt).

The output of \_SB.TE08, \_SB.TE16, \_SB.TE32 and \_SB.TE64 was verified to be the same under Windows and ACPICA
except when encountering 64 bit constants in 32 bit tables. In such a case, Windows would not truncate the output of \_SB.TE64,
but ACPICA did.

Since using 64 bit integers in a 32 bit table is unsupported anyway and the chance of encountering this in the wild are
rather low, i decided to ignore this special case.

As a side note, something similar was already done in commit f9efaa885dc3 ("ToHexString: Add "0x" prefix to the converted string
"), which was later reverted for different reasons.