### PR TITLE
Fix various spelling mistakes in text files and code comments

### DIFF
--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -772,7 +772,7 @@ typedef struct acpi_field_info
 typedef struct acpi_ged_handler_info
 {
     struct acpi_ged_handler_info    *Next;
-    UINT32                          IntId;      /* The interrupt ID that triggers the execution ofthe EvtMethod. */
+    UINT32                          IntId;      /* The interrupt ID that triggers the execution of the EvtMethod. */
     ACPI_NAMESPACE_NODE             *EvtMethod; /* The _EVT method to be executed when an interrupt with ID = IntID is received */
 
 } ACPI_GED_HANDLER_INFO;

--- a/source/os_specific/service_layers/oszephyr.c
+++ b/source/os_specific/service_layers/oszephyr.c
@@ -163,7 +163,7 @@ LOG_MODULE_DECLARE(acpica, LOG_LEVEL_ERR);
 
 typedef void (*zephyr_irq_t)(const void *);
 
-/* Global varibles use from acpica lib. */
+/* Global variables use from acpica lib. */
 BOOLEAN                     AslGbl_DoTemplates = FALSE;
 BOOLEAN                     AslGbl_VerboseTemplates = FALSE;
 

--- a/tests/aslts/adm/BugState/ALLBUGS
+++ b/tests/aslts/adm/BugState/ALLBUGS
@@ -8,7 +8,7 @@ ALLBUGS| Dont remove this line, it is used in the automatic processing of the ta
   1| C     | 419  |      |                  | 100 | The ASL Compiler doesn't allow non-constant TimeoutValue for Acquire
   2| I     |      |      |                  |     | The elseif operator works incorrectly
   3| C     | 420  |      |                  | 100 | The ASL Compiler should reject Switch operators with the identical Case operators in it
-  4| I     |      |      |                  |     | Concatenate being invoked in Method M000 changes the type of LocalX of calling Method passsed as operand to M000
+  4| I     |      |      |                  |     | Concatenate being invoked in Method M000 changes the type of LocalX of calling Method passed as operand to M000
   5| I     |      |      |                  |     | Switch operator doesn't provide Default branch
   6| I     |      |      |                  |     | ToInteger converts a decimal string the same way as a hexadecimal one
   7| I     |      |      |                  |     | ToString updates the LocalX value (if it is zero) passed as Length parameter
@@ -305,7 +305,7 @@ ALLBUGS| Dont remove this line, it is used in the automatic processing of the ta
 298| I     |      |      | FIXED INTEGRATED |     | AcpiExOpcode_XA_XT_XR routines assign addresses of released cache objects to WalkState->ResultObj causing further problems
 299| I     |      |      |                  | 100 | Many outstanding allocations on abnormal termination of AcpiDsCallControlMethod
 300| I     |      |      |                  | 100 | Recursive calls to methods with the internal declarations (and Switches) should be provided
-301| I     |      |      |                  | 100 | Recursive calls to methods with the internal declarations (and Swithces) causes AE_AML_INTERNAL and crash
+301| I     |      |      |                  | 100 | Recursive calls to methods with the internal declarations (and Switches) causes AE_AML_INTERNAL and crash
 302| I     |      |      |                  | 100 | Scope operation doesn't work for the root node Location
 303| I     |      |      |                  | 100 | Name operation performed from inside the If operation doesn't work for the full-path ObjectName
 304| I     |      |      |                  | 100 | No exception AE_AML_METHOD_LIMIT for the number of method invocations exceeding 255
@@ -373,7 +373,7 @@ ALLBUGS| Dont remove this line, it is used in the automatic processing of the ta
 | is fixing ACPI specification. It should be checked out manually
 | that the relevant part of specification is actually fixed/updated.
 | After that write manually INTEGRATED key in the STATE-MANUALLY
-| colomn of the relevant bug to confirm completion of bug. Some
+| column of the relevant bug to confirm completion of bug. Some
 | these bugs against specs may nevertheless have the relevant bdemo
 | tests which make use just of the relevant functionality touched
 | by the part of specification. But nevertheless PASS of these

--- a/tests/aslts/adm/BugState/ALLBUGS_DUP
+++ b/tests/aslts/adm/BugState/ALLBUGS_DUP
@@ -8,7 +8,7 @@ ALLBUGS| Dont remove this line, it is used in the automatic processing of the ta
   1| C     | 419  |      |                  | 100 | The ASL Compiler doesn't allow non-constant TimeoutValue for Acquire
   2| I     |      |      |                  |     | The elseif operator works incorrectly
   3| C     | 420  |      |                  | 100 | The ASL Compiler should reject Switch operators with the identical Case operators in it
-  4| I     |      |      |                  |     | Concatenate being invoked in Method M000 changes the type of LocalX of calling Method passsed as operand to M000
+  4| I     |      |      |                  |     | Concatenate being invoked in Method M000 changes the type of LocalX of calling Method passed as operand to M000
   5| I     |      |      |                  |     | Switch operator doesn't provide Default branch
   6| I     |      |      |                  |     | ToInteger converts a decimal string the same way as a hexadecimal one
   7| I     |      |      |                  |     | ToString updates the LocalX value (if it is zero) passed as Length parameter
@@ -300,7 +300,7 @@ ALLBUGS| Dont remove this line, it is used in the automatic processing of the ta
 | is fixing ACPI specification. It should be checked out manually
 | that the relevant part of specification is actually fixed/updated.
 | After that write manually INTEGRATED key in the STATE-MANUALLY
-| colomn of the relevant bug to confirm completion of bug. Some
+| column of the relevant bug to confirm completion of bug. Some
 | these bugs against specs may nevertheless have the relevant bdemo
 | tests which make use just of the relevant functionality touched
 | by the part of specification. But nevertheless PASS of these

--- a/tests/aslts/src/runtime/collections/bdemo/ACPICA/0063/File1.asl
+++ b/tests/aslts/src/runtime/collections/bdemo/ACPICA/0063/File1.asl
@@ -1066,7 +1066,7 @@
      * 4. "0000000000000000000000001234"
      * (zeros before significant characters in image without '0x' are skipped).
      *
-     * Exampples: mf9b + 000000000
+     * Examples: mf9b + 000000000
      *
      * All the above examples but
      *

--- a/tests/aslts/src/runtime/collections/functional/reference/SPEC
+++ b/tests/aslts/src/runtime/collections/functional/reference/SPEC
@@ -24,7 +24,7 @@ The layout of test specification:
   Some purposes of the tests dont contain the
   specification of the expected normal behaviour of
   the feature under testing. This takes place when the
-  ACPI specification doesnt assert anything definitely
+  ACPI specification doesn't assert anything definitely
   on that or when an additional investigation involving
   the BlackBox are needed.
 
@@ -113,7 +113,7 @@ Improve implementation of tests:
     Extend them for Arg{1-6} and Local{1-7} too.
 
  4) improve FEATURE entries: the way of improving the test is
-    analysing the implemented sub-tests desribing them more exactly
+    analysing the implemented sub-tests describing them more exactly
     by FEATURE entries and then examining the summary coverage of
     sub-tests basing on the FEATURE entries of them propose the
     additional sub-tests.
@@ -183,7 +183,7 @@ Notation:
 
    M0                   - start Method of test
    M1,M2...             - Methods invoked from M0
-   M1-M2-M3             - the chain of invokations of Methods (started from M0)
+   M1-M2-M3             - the chain of invocations of Methods (started from M0)
 
 
 
@@ -535,7 +535,7 @@ to the writing operator).
 
 Pass the result of RefOf to another Method (M2) for
 the following calculations as in the original test TEST 00.
-Check that the data refered to by ArgX of (M1) are changed {type,size,value}.
+Check that the data referred to by ArgX of (M1) are changed {type,size,value}.
 Check that the original objects (M0) are not changed {type,size,value}.
 
 M0 {Object} --> M1 {RefOf(ArgX);write} --> M2 {write(ArgX)}
@@ -677,7 +677,7 @@ FEATURE: ArgX-ORef:write_into_ArgY:write
 
 INCORRECT: not quite correct, because there is no way to
            "transfer" ArgX-Reference from ArgX to ArgY.
-           In fact, the object assosiated with ArgX-Reference
+           In fact, the object associated with ArgX-Reference
            is copied into ArgY or into the Object associated with
            ArgY in ArgY-Reference case for any ASL-operation.
 
@@ -717,7 +717,7 @@ Do the same actions as in the TEST 00.
 
 5. After completion of the Method call, returning
    from it, check the original object {type,size,value}
-   coresponding to Arg0.
+   corresponding to Arg0.
    Use BlackBox for to clarify ACPI specification.
 
 
@@ -760,8 +760,8 @@ FEATURE: ArgX-ORef:write_into_LocalX:write
 
 INCORRECT: not quite correct, because there is no way to
            "transfer" ArgX-Reference from ArgX to LocalX.
-           In fact, the object assosiated with ArgX-Reference
-           is copied into LocalX (independantly on the value
+           In fact, the object associated with ArgX-Reference
+           is copied into LocalX (independently on the value
            of LocalX).
 
 So, the test is transformed into another one (see below).
@@ -838,7 +838,7 @@ The same as the TEST 20, but at first obtain the ORef
 to some global object and put it into ArgX and do all the read/write
 actions with that ArgX.
 
-Check the original object {type,size,value} coresponding to ArgX.
+Check the original object {type,size,value} corresponding to ArgX.
 Use BlackBox for to clarify ACPI specification.
 
 Example:
@@ -861,7 +861,7 @@ The same as the TEST 25 but use not global but local source objects:
    c) LocalX {0-7}
    d) Named: types {1-16}
 
-Check the original object {type,size,value} coresponding to ArgX.
+Check the original object {type,size,value} corresponding to ArgX.
 Use BlackBox for to clarify ACPI specification.
 
 Example:
@@ -1149,7 +1149,7 @@ WRITE_OPERATOR(XXXX, Index(LocalX, 0))
 WRITE_OPERATOR(XXXX, Index(NamedX, 0))
 
 Do this for all the ASL Operators which write results.
-FEATURE: write(Bufer:Index:IRef)
+FEATURE: write(Buffer:Index:IRef)
 
 
 ==========
@@ -1407,8 +1407,8 @@ FEATURE: Store(Index(arg0, x), Local0)
 ==========
 
 
-When this satart work the user will feel himself free
-in the way coding its toughts.
+When this start work the user will feel himself free
+in the way coding its thoughts.
 
 Store(ImageX    , RefOf())
 Store(ArgX      , RefOf())
@@ -1471,8 +1471,8 @@ as far as fixing the bugs.
 ==========
 
 
-When this satart work the user will feel himself free
-in the way coding its toughts.
+When this start work the user will feel himself free
+in the way coding its thoughts.
 
 Copy(ImageX    , RefOf())
 Copy(ArgX      , RefOf())
@@ -1544,7 +1544,7 @@ Do it after the current bugs fixing.
 ==========
 
 When this starts work the user will feel himself free
-in the way coding its toughts.
+in the way coding its thoughts.
 
 Do this comprehensive test after all the particular
 bugs will be fixed. Now, due to the bugs, it looks
@@ -1848,7 +1848,7 @@ and the contents of that object are returned.
 ==========
 
 
-Check the asertion above.
+Check the assertion above.
 
 
 SPEC:
@@ -1864,7 +1864,7 @@ then a fatal error is generated.
 ==========
 
 
-Check the asertion above.
+Check the assertion above.
 
 
 SPEC:
@@ -1882,7 +1882,7 @@ base object is returned.
 ==========
 
 
-The asertion above has been verified for Index and RefOf
+The assertion above has been verified for Index and RefOf
 cases by all the tests above by the (TEST_00.2) entry.
 
 Check it for the Alias case in this test.
@@ -1979,11 +1979,11 @@ Store(0, Derefof(Refof(Local0)))
 ==========
 
 
-Check presense/absence of Result conversion while writing
+Check presence/absence of Result conversion while writing
 to ORef.
 
 Do that without details.
-Details are to be exercised in onother separate test.
+Details are to be exercised in another separate test.
 
 
 ==========


### PR DESCRIPTION
There are a handful of spelling mistakes in various files as found using codespell. Fix these. No code changes.