### PR TITLE
acgcc: Fix C++ issue with ACPI_FLEX_ARRAY

### DIFF
--- a/source/include/platform/acgcc.h
+++ b/source/include/platform/acgcc.h
@@ -216,10 +216,12 @@ typedef __builtin_va_list       va_list;
  * C99, but this is not for any technical reason. Work around the
  * limitation.
  */
+#ifndef __cplusplus
 #define ACPI_FLEX_ARRAY(TYPE, NAME)             \
         struct {                                \
                 struct { } __Empty_ ## NAME;    \
                 TYPE NAME[];                    \
         }
+#endif
 
 #endif /* __ACGCC_H__ */


### PR DESCRIPTION
Fix access to array members wrapped into ACPI_FLEX_ARRAY when compiled in C++ (with gcc).
In C++, an empty struct has a size of 1, shifting the actual member by one byte. As this is a C99 workaround, disable it when compiling under C++.

As a reference: https://github.com/torvalds/linux/blob/master/include/uapi/linux/stddef.h#L32