### PR TITLE
Modify ACPI_OBJECT_COMMON_HEADER

### DIFF
--- a/source/include/acobject.h
+++ b/source/include/acobject.h
@@ -191,7 +191,7 @@
     UINT8                           DescriptorType;     /* To differentiate various internal objs */\
     UINT8                           Type;               /* ACPI_OBJECT_TYPE */\
     UINT16                          ReferenceCount;     /* For object deletion management */\
-    UINT8                           Flags;
+    UINT8                           Flags
     /*
      * Note: There are 3 bytes available here before the
      * next natural alignment boundary (for both 32/64 cases)
@@ -216,14 +216,14 @@
 
 typedef struct acpi_object_common
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
 
 } ACPI_OBJECT_COMMON;
 
 
 typedef struct acpi_object_integer
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     UINT8                           Fill[3];            /* Prevent warning on some compilers */
     UINT64                          Value;
 
@@ -238,23 +238,23 @@ typedef struct acpi_object_integer
  */
 #define ACPI_COMMON_BUFFER_INFO(_Type) \
     _Type                           *Pointer; \
-    UINT32                          Length;
+    UINT32                          Length
 
 
 /* Null terminated, ASCII characters only */
 
 typedef struct acpi_object_string
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_BUFFER_INFO         (char)              /* String in AML stream or allocated string */
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_BUFFER_INFO(char);              /* String in AML stream or allocated string */
 
 } ACPI_OBJECT_STRING;
 
 
 typedef struct acpi_object_buffer
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_BUFFER_INFO         (UINT8)             /* Buffer in AML stream or allocated buffer */
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_BUFFER_INFO(UINT8);      /* Buffer in AML stream or allocated buffer */
     UINT32                          AmlLength;
     UINT8                           *AmlStart;
     ACPI_NAMESPACE_NODE             *Node;              /* Link back to parent node */
@@ -264,7 +264,7 @@ typedef struct acpi_object_buffer
 
 typedef struct acpi_object_package
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     ACPI_NAMESPACE_NODE             *Node;              /* Link back to parent node */
     union acpi_operand_object       **Elements;         /* Array of pointers to AcpiObjects */
     UINT8                           *AmlStart;
@@ -282,7 +282,7 @@ typedef struct acpi_object_package
 
 typedef struct acpi_object_event
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     ACPI_SEMAPHORE                  OsSemaphore;        /* Actual OS synchronization object */
 
 } ACPI_OBJECT_EVENT;
@@ -290,7 +290,7 @@ typedef struct acpi_object_event
 
 typedef struct acpi_object_mutex
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     UINT8                           SyncLevel;          /* 0-15, specified in Mutex() call */
     UINT16                          AcquisitionDepth;   /* Allow multiple Acquires, same thread */
     ACPI_MUTEX                      OsMutex;            /* Actual OS synchronization object */
@@ -306,7 +306,7 @@ typedef struct acpi_object_mutex
 
 typedef struct acpi_object_region
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     UINT8                           SpaceId;
     ACPI_NAMESPACE_NODE             *Node;              /* Containing namespace node */
     union acpi_operand_object       *Handler;           /* Handler for region access */
@@ -320,7 +320,7 @@ typedef struct acpi_object_region
 
 typedef struct acpi_object_method
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     UINT8                           InfoFlags;
     UINT8                           ParamCount;
     UINT8                           SyncLevel;
@@ -360,22 +360,22 @@ typedef struct acpi_object_method
  */
 #define ACPI_COMMON_NOTIFY_INFO \
     union acpi_operand_object       *NotifyList[2];     /* Handlers for system/device notifies */\
-    union acpi_operand_object       *Handler;           /* Handler for Address space */
+    union acpi_operand_object       *Handler           /* Handler for Address space */
 
 /* COMMON NOTIFY for POWER, PROCESSOR, DEVICE, and THERMAL */
 
 typedef struct acpi_object_notify_common
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_NOTIFY_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_NOTIFY_INFO;
 
 } ACPI_OBJECT_NOTIFY_COMMON;
 
 
 typedef struct acpi_object_device
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_NOTIFY_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_NOTIFY_INFO;
     ACPI_GPE_BLOCK_INFO             *GpeBlock;
 
 } ACPI_OBJECT_DEVICE;
@@ -383,8 +383,8 @@ typedef struct acpi_object_device
 
 typedef struct acpi_object_power_resource
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_NOTIFY_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_NOTIFY_INFO;
     UINT32                          SystemLevel;
     UINT32                          ResourceOrder;
 
@@ -393,13 +393,13 @@ typedef struct acpi_object_power_resource
 
 typedef struct acpi_object_processor
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
 
     /* The next two fields take advantage of the 3-byte space before NOTIFY_INFO */
 
     UINT8                           ProcId;
     UINT8                           Length;
-    ACPI_COMMON_NOTIFY_INFO
+    ACPI_COMMON_NOTIFY_INFO;
     ACPI_IO_ADDRESS                 Address;
 
 } ACPI_OBJECT_PROCESSOR;
@@ -407,8 +407,8 @@ typedef struct acpi_object_processor
 
 typedef struct acpi_object_thermal_zone
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_NOTIFY_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_NOTIFY_INFO;
 
 } ACPI_OBJECT_THERMAL_ZONE;
 
@@ -433,14 +433,14 @@ typedef struct acpi_object_thermal_zone
     UINT32                          BaseByteOffset;     /* Byte offset within containing object */\
     UINT32                          Value;              /* Value to store into the Bank or Index register */\
     UINT8                           StartFieldBitOffset;/* Bit offset within first field datum (0-63) */\
-    UINT8                           AccessLength;       /* For serial regions/fields */
+    UINT8                           AccessLength       /* For serial regions/fields */
 
 /* COMMON FIELD (for BUFFER, REGION, BANK, and INDEX fields) */
 
 typedef struct acpi_object_field_common
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_FIELD_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_FIELD_INFO;
     union acpi_operand_object       *RegionObj;         /* Parent Operation Region object (REGION/BANK fields only) */
 
 } ACPI_OBJECT_FIELD_COMMON;
@@ -448,8 +448,8 @@ typedef struct acpi_object_field_common
 
 typedef struct acpi_object_region_field
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_FIELD_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_FIELD_INFO;
     UINT16                          ResourceLength;
     union acpi_operand_object       *RegionObj;         /* Containing OpRegion object */
     UINT8                           *ResourceBuffer;    /* ResourceTemplate for serial regions/fields */
@@ -461,8 +461,8 @@ typedef struct acpi_object_region_field
 
 typedef struct acpi_object_bank_field
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_FIELD_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_FIELD_INFO;
     union acpi_operand_object       *RegionObj;         /* Containing OpRegion object */
     union acpi_operand_object       *BankObj;           /* BankSelect Register object */
 
@@ -471,8 +471,8 @@ typedef struct acpi_object_bank_field
 
 typedef struct acpi_object_index_field
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_FIELD_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_FIELD_INFO;
 
     /*
      * No "RegionObj" pointer needed since the Index and Data registers
@@ -488,8 +488,8 @@ typedef struct acpi_object_index_field
 
 typedef struct acpi_object_buffer_field
 {
-    ACPI_OBJECT_COMMON_HEADER
-    ACPI_COMMON_FIELD_INFO
+    ACPI_OBJECT_COMMON_HEADER;
+    ACPI_COMMON_FIELD_INFO;
     BOOLEAN                         IsCreateField;      /* Special case for objects created by CreateField() */
     union acpi_operand_object       *BufferObj;         /* Containing Buffer object */
 
@@ -504,7 +504,7 @@ typedef struct acpi_object_buffer_field
 
 typedef struct acpi_object_notify_handler
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     ACPI_NAMESPACE_NODE             *Node;              /* Parent device */
     UINT32                          HandlerType;        /* Type: Device/System/Both */
     ACPI_NOTIFY_HANDLER             Handler;            /* Handler address */
@@ -516,7 +516,7 @@ typedef struct acpi_object_notify_handler
 
 typedef struct acpi_object_addr_handler
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     UINT8                           SpaceId;
     UINT8                           HandlerFlags;
     ACPI_ADR_SPACE_HANDLER          Handler;
@@ -547,7 +547,7 @@ typedef struct acpi_object_addr_handler
  */
 typedef struct acpi_object_reference
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     UINT8                           Class;              /* Reference Class */
     UINT8                           TargetType;         /* Used for Index Op */
     UINT8                           Resolved;           /* Reference has been resolved to a value */
@@ -585,7 +585,7 @@ typedef enum
  */
 typedef struct acpi_object_extra
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     ACPI_NAMESPACE_NODE             *Method_REG;        /* _REG method for this region (if any) */
     ACPI_NAMESPACE_NODE             *ScopeNode;
     void                            *RegionContext;     /* Region-specific data */
@@ -599,7 +599,7 @@ typedef struct acpi_object_extra
 
 typedef struct acpi_object_data
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     ACPI_OBJECT_HANDLER             Handler;
     void                            *Pointer;
 
@@ -610,7 +610,7 @@ typedef struct acpi_object_data
 
 typedef struct acpi_object_cache_list
 {
-    ACPI_OBJECT_COMMON_HEADER
+    ACPI_OBJECT_COMMON_HEADER;
     union acpi_operand_object       *Next;              /* Link for object cache and internal lists*/
 
 } ACPI_OBJECT_CACHE_LIST;


### PR DESCRIPTION
modify 4 macros:
ACPI_OBJECT_COMMON_HEADER,
ACPI_COMMON_BUFFER_INFO,
ACPI_COMMON_NOTIFY_INFO,
ACPI_COMMON_FIELD_INFO
they  cause  poor readability.so del the last ";"
and when use them in a single line with the ";"in the end.