### PR TITLE
ACPICA: debugger: check status of AcpiEvaluateObject in AcpiDbWalkForFields

### DIFF
--- a/source/components/debugger/dbnames.c
+++ b/source/components/debugger/dbnames.c
@@ -774,7 +774,12 @@ AcpiDbWalkForFields (
     ACPI_FREE (Buffer.Pointer);
 
     Buffer.Length = ACPI_ALLOCATE_LOCAL_BUFFER;
-    AcpiEvaluateObject (ObjHandle, NULL, NULL, &Buffer);
+    Status = AcpiEvaluateObject (ObjHandle, NULL, NULL, &Buffer);
+    if (ACPI_FAILURE (Status))
+    {
+        AcpiOsPrintf ("Could Not evaluate object %p\n", ObjHandle);
+        return (AE_OK);
+    }
 
     /*
      * Since this is a field unit, surround the output in braces


### PR DESCRIPTION
Errors in AcpiEvaluateObject can lead to incorrect state of Buffer. This can lead to access to data in previously ACPI_FREEd Buffer and secondary ACPI_FREE to the same Buffer later.

Handle errors in AcpiEvaluateObject the same way it is done earlier with AcpiNsHandleToPathname.