### PR TITLE
Fix CXL 3.0 structure (RDPAS) field in the CEDT table

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -834,8 +834,6 @@ struct acpi_cedt_cxims {
 
 struct acpi_cedt_rdpas {
     ACPI_CEDT_HEADER        Header;
-    UINT8                   Reserved1;
-    UINT16                  Length;
     UINT16                  Segment;
     UINT16                  Bdf;
     UINT8                   Protocol;


### PR DESCRIPTION
Fix CXL 3.0 structure (RDPAS) in the CEDT table

struct acpi_cedt_rdpas does not match with CXL r3.0 9.17.1.5 Table 9-24. 
reserved1 and length fields are already added by struct acpi_cedt_header.

