### PR TITLE
Detect FACS even for reduced hardware platforms

### DIFF
--- a/source/components/tables/tbfadt.c
+++ b/source/components/tables/tbfadt.c
@@ -489,24 +489,19 @@ AcpiTbParseFadt (
         ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL, NULL, FALSE, TRUE,
         &AcpiGbl_DsdtIndex);
 
-    /* If Hardware Reduced flag is set, there is no FACS */
-
-    if (!AcpiGbl_ReducedHardware)
+    if (AcpiGbl_FADT.Facs)
     {
-        if (AcpiGbl_FADT.Facs)
-        {
-            AcpiTbInstallStandardTable (
-                (ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.Facs,
-                ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL, NULL, FALSE, TRUE,
-                &AcpiGbl_FacsIndex);
-        }
-        if (AcpiGbl_FADT.XFacs)
-        {
-            AcpiTbInstallStandardTable (
-                (ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.XFacs,
-                ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL, NULL, FALSE, TRUE,
-                &AcpiGbl_XFacsIndex);
-        }
+        AcpiTbInstallStandardTable (
+            (ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.Facs,
+            ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL, NULL, FALSE, TRUE,
+            &AcpiGbl_FacsIndex);
+    }
+    if (AcpiGbl_FADT.XFacs)
+    {
+        AcpiTbInstallStandardTable (
+            (ACPI_PHYSICAL_ADDRESS) AcpiGbl_FADT.XFacs,
+            ACPI_TABLE_ORIGIN_INTERNAL_PHYSICAL, NULL, FALSE, TRUE,
+            &AcpiGbl_XFacsIndex);
     }
 }
 

--- a/source/components/tables/tbutils.c
+++ b/source/components/tables/tbutils.c
@@ -185,15 +185,7 @@ AcpiTbInitializeFacs (
 {
     ACPI_TABLE_FACS         *Facs;
 
-
-    /* If Hardware Reduced flag is set, there is no FACS */
-
-    if (AcpiGbl_ReducedHardware)
-    {
-        AcpiGbl_FACS = NULL;
-        return (AE_OK);
-    }
-    else if (AcpiGbl_FADT.XFacs &&
+    if (AcpiGbl_FADT.XFacs &&
          (!AcpiGbl_FADT.Facs || !AcpiGbl_Use32BitFacsAddresses))
     {
         (void) AcpiGetTableByIndex (AcpiGbl_XFacsIndex,


### PR DESCRIPTION
The FACS is optional even on hardware reduced platforms, and may exist for the purpose of communicating the hardware_signature field to provke a clean reboot instead of a resume from hibernation.