### PR TITLE
events/evxfgpe: correctly clear GPE_AUTO_ENABLED in AcpiSetupGpeForWake

### DIFF
--- a/source/components/events/evxfgpe.c
+++ b/source/components/events/evxfgpe.c
@@ -636,7 +636,7 @@ AcpiSetupGpeForWake (
          * permanently enabled and clear its ACPI_GPE_AUTO_ENABLED flag.
          */
         (void) AcpiEvRemoveGpeReference (GpeEventInfo);
-        GpeEventInfo->Flags &= ~~ACPI_GPE_AUTO_ENABLED;
+        GpeEventInfo->Flags &= ~ACPI_GPE_AUTO_ENABLED;
     }
 
     /*


### PR DESCRIPTION
Because of a typo we would inverse the mask twice, thus producing a bogus result.