### PR TITLE
events/evgpeinit: don't forget to increment registered GPE count

### DIFF
--- a/source/components/events/evgpeinit.c
+++ b/source/components/events/evgpeinit.c
@@ -564,6 +564,7 @@ AcpiEvMatchGpeMethod (
     GpeEventInfo->Flags &= ~(ACPI_GPE_DISPATCH_MASK);
     GpeEventInfo->Flags |= (UINT8) (Type | ACPI_GPE_DISPATCH_METHOD);
     GpeEventInfo->Dispatch.MethodNode = MethodNode;
+    WalkInfo->Count++;
 
     ACPI_DEBUG_PRINT ((ACPI_DB_LOAD,
         "Registered GPE method %s as GPE number 0x%.2X\n",


### PR DESCRIPTION
This was used to log the number of newly discovered GPEs post table load in AcpiEvUpdateGpes, but we never incremented the number inside AcpiEvMatchGpeMethod so that was never logged.