### PR TITLE
Implement the DWordPCC Resource Descriptor Macro

### DIFF
--- a/source/compiler/aslcompiler.h
+++ b/source/compiler/aslcompiler.h
@@ -1582,9 +1582,12 @@ RsDoDwordMemoryDescriptor (
     ASL_RESOURCE_INFO       *Info);
 
 ASL_RESOURCE_NODE *
-RsDoDwordSpaceDescriptor (
+RsDoDwordPccDescriptor (
     ASL_RESOURCE_INFO       *Info);
 
+ASL_RESOURCE_NODE *
+RsDoDwordSpaceDescriptor (
+    ASL_RESOURCE_INFO       *Info);
 
 /*
  * aslrestype2e - Extended address descriptors

--- a/source/compiler/aslcompiler.l
+++ b/source/compiler/aslcompiler.l
@@ -438,6 +438,7 @@ NamePathTail                [.]{NameSeg}
 "DMA"                       { count (1); return (PARSEOP_DMA); }
 "DWordIO"                   { count (1); return (PARSEOP_DWORDIO); }
 "DWordMemory"               { count (1); return (PARSEOP_DWORDMEMORY); }
+"DWordPcc"                  { count (1); return (PARSEOP_DWORDPCC); }
 "DWordSpace"                { count (1); return (PARSEOP_DWORDSPACE); }
 "EndDependentFn"            { count (1); return (PARSEOP_ENDDEPENDENTFN); }
 "ExtendedIO"                { count (1); return (PARSEOP_EXTENDEDIO); }

--- a/source/compiler/aslmap.c
+++ b/source/compiler/aslmap.c
@@ -319,6 +319,7 @@ const ASL_MAPPING_ENTRY     AslKeywordMapping [] =
 /* DWORDCONST */                OP_TABLE_ENTRY (AML_RAW_DATA_DWORD,         0,                              0,                  ACPI_BTYPE_INTEGER),
 /* DWORDIO */                   OP_TABLE_ENTRY (AML_DEFAULT_ARG_OP,         0,                              0,                  0),
 /* DWORDMEMORY */               OP_TABLE_ENTRY (AML_DEFAULT_ARG_OP,         0,                              0,                  0),
+/* DWORDPCC */                  OP_TABLE_ENTRY (AML_DEFAULT_ARG_OP,         0,                              0,                  0),
 /* DWORDSPACE */                OP_TABLE_ENTRY (AML_BYTE_OP,                0,                              0,                  0),
 /* EISAID */                    OP_TABLE_ENTRY (AML_DWORD_OP,               0,                              0,                  ACPI_BTYPE_INTEGER),
 /* ELSE */                      OP_TABLE_ENTRY (AML_ELSE_OP,                0,                              OP_AML_PACKAGE,     0),

--- a/source/compiler/aslparser.y
+++ b/source/compiler/aslparser.y
@@ -208,7 +208,7 @@ AslLocalAllocate (
  * These shift/reduce conflicts are expected. There should be zero
  * reduce/reduce conflicts.
  */
-%expect 128
+%expect 130
 
 /*! [Begin] no source code translation */
 

--- a/source/compiler/aslresource.c
+++ b/source/compiler/aslresource.c
@@ -788,6 +788,11 @@ RsDoOneResourceDescriptor (
         Rnode = RsDoDwordMemoryDescriptor (Info);
         break;
 
+    case PARSEOP_DWORDPCC:
+
+        Rnode = RsDoDwordPccDescriptor (Info);
+        break;
+
     case PARSEOP_DWORDSPACE:
 
         Rnode = RsDoDwordSpaceDescriptor (Info);

--- a/source/compiler/aslresources.y
+++ b/source/compiler/aslresources.y
@@ -194,6 +194,7 @@ ResourceMacroTerm
     | DMATerm                       {}
     | DWordIOTerm                   {}
     | DWordMemoryTerm               {}
+    | DWordPccTerm                  {}
     | DWordSpaceTerm                {}
     | EndDependentFnTerm            {}
     | ExtendedIOTerm                {}
@@ -315,6 +316,20 @@ DWordMemoryTerm
     | PARSEOP_DWORDMEMORY
         PARSEOP_OPEN_PAREN
         error PARSEOP_CLOSE_PAREN   {$$ = AslDoError(); yyclearin;}
+    ;
+
+DWordPccTerm
+    : PARSEOP_DWORDPCC
+        PARSEOP_OPEN_PAREN           {$<n>$ = TrCreateLeafOp (PARSEOP_DWORDPCC);}
+        ByteConstExpr
+        OptionalByteConstExpr
+        OptionalStringData
+        OptionalNameString_Last
+        PARSEOP_CLOSE_PAREN                         {$$ = TrLinkOpChildren ($<n>3,4,
+                                                        $4,$5,$6,$7);}
+    | PARSEOP_DWORDPCC
+        PARSEOP_OPEN_PAREN
+        error PARSEOP_CLOSE_PAREN                   {$$ = AslDoError(); yyclearin;}
     ;
 
 DWordSpaceTerm

--- a/source/compiler/aslrestype2d.c
+++ b/source/compiler/aslrestype2d.c
@@ -158,10 +158,167 @@
 /*
  * This module contains the Dword (32-bit) address space descriptors:
  *
+ * DWordPcc
  * DwordIO
  * DwordMemory
  * DwordSpace
  */
+
+
+/*******************************************************************************
+ *
+ * FUNCTION:    RsDoDwordPccDescriptor
+ *
+ * PARAMETERS:  Info                - Parse Op and resource template offset
+ *
+ * RETURN:      Completed resource node
+ *
+ * DESCRIPTION: Construct a long "DWordPcc" descriptor
+ *
+ ******************************************************************************/
+
+ASL_RESOURCE_NODE *
+RsDoDwordPccDescriptor (
+    ASL_RESOURCE_INFO       *Info)
+{
+    AML_RESOURCE            *Descriptor;
+    ACPI_PARSE_OBJECT       *InitializerOp;
+    ACPI_PARSE_OBJECT       *MinOp = NULL;
+    ACPI_PARSE_OBJECT       *MaxOp = NULL;
+    ACPI_PARSE_OBJECT       *LengthOp = NULL;
+    ACPI_PARSE_OBJECT       *GranOp = NULL;
+    ASL_RESOURCE_NODE       *Rnode;
+    UINT16                  StringLength = 0;
+    UINT32                  OptionIndex = 0;
+    UINT8                   *OptionalFields;
+    UINT32                  i;
+    BOOLEAN                 ResSourceIndex = FALSE;
+
+
+    InitializerOp = Info->DescriptorTypeOp->Asl.Child;
+    StringLength = RsGetStringDataLength (InitializerOp);
+
+    Rnode = RsAllocateResourceNode (
+        sizeof (AML_RESOURCE_ADDRESS32) + 1 + StringLength);
+
+    Descriptor = Rnode->Buffer;
+    Descriptor->Address32.DescriptorType = ACPI_RESOURCE_NAME_ADDRESS32;
+    Descriptor->Address32.ResourceType  = ACPI_ADDRESS_TYPE_PCC_NUMBER;
+
+    /*
+     * Initial descriptor length -- may be enlarged if there are
+     * optional fields present
+     */
+    OptionalFields = ((UINT8 *) Descriptor) + sizeof (AML_RESOURCE_ADDRESS32);
+    Descriptor->Address32.ResourceLength = (UINT16)
+        (sizeof (AML_RESOURCE_ADDRESS32) -
+         sizeof (AML_RESOURCE_LARGE_HEADER));
+
+
+    /*
+    * Bit [3] Max Address Fixed, _MAF: 1 (max address is fixed)
+    * Bit [2] Min Address Fixed,_MIF: 1 (min address is fixed)
+    * Bit [1] Decode Type, _DEC: 0 (do not care)
+    * BIT [0] Ignored (must be zero)
+    */
+    Descriptor->Address32.Flags = 0b1100;
+
+    // No type specific flags. Set to 0.
+    Descriptor->Address32.SpecificFlags = 0;
+
+    // must be set to zero if _MAX == _MIN.
+    Descriptor->Address32.Granularity = 0x0;
+    /* Process all child initialization nodes */
+
+    // No translation offset.
+    Descriptor->Address32.TranslationOffset = 0;
+
+    // Pcc is unique address.
+    Descriptor->Address32.AddressLength = 1;
+
+    for (i = 0; InitializerOp; i++)
+    {
+        switch (i)
+        {
+
+        case 0: /* Address Min = Max */
+
+            Descriptor->Address32.Minimum =
+                (UINT32) InitializerOp->Asl.Value.Integer;
+            Descriptor->Address32.Maximum =
+                (UINT32) InitializerOp->Asl.Value.Integer;
+
+            break;
+
+        case 1: /* ResSourceIndex [Optional Field - BYTE] */
+
+            if (InitializerOp->Asl.ParseOpcode != PARSEOP_DEFAULT_ARG)
+            {
+                /* Found a valid ResourceSourceIndex */
+
+                OptionalFields[0] = (UINT8) InitializerOp->Asl.Value.Integer;
+                OptionIndex++;
+                Descriptor->Address32.ResourceLength++;
+                ResSourceIndex = TRUE;
+            }
+            break;
+
+        case 2: /* ResSource [Optional Field - STRING] */
+
+            if ((InitializerOp->Asl.ParseOpcode != PARSEOP_DEFAULT_ARG) &&
+                (InitializerOp->Asl.Value.String))
+            {
+                if (StringLength)
+                {
+                    /* Found a valid ResourceSource */
+
+                    Descriptor->Address32.ResourceLength = (UINT16)
+                        (Descriptor->Address32.ResourceLength + StringLength);
+
+                    strcpy ((char *)
+                        &OptionalFields[OptionIndex],
+                        InitializerOp->Asl.Value.String);
+
+                    /* ResourceSourceIndex must also be valid */
+
+                    if (!ResSourceIndex)
+                    {
+                        AslError (ASL_ERROR, ASL_MSG_RESOURCE_INDEX,
+                            InitializerOp, NULL);
+                    }
+                }
+            }
+
+            break;
+
+        case 3: // DescriptorName
+            UtAttachNamepathToOwner (Info->DescriptorTypeOp, InitializerOp);
+            break;
+
+        default:
+
+            AslError (ASL_ERROR, ASL_MSG_RESOURCE_LIST, InitializerOp, NULL);
+            break;
+        }
+
+        InitializerOp = RsCompleteNodeAndGetNext (InitializerOp);
+    }
+
+    /* Validate the Min/Max/Len/Gran values */
+
+    RsLargeAddressCheck (
+        (UINT64) Descriptor->Address32.Minimum,
+        (UINT64) Descriptor->Address32.Maximum,
+        (UINT64) Descriptor->Address32.AddressLength,
+        (UINT64) Descriptor->Address32.Granularity,
+        Descriptor->Address32.Flags,
+        MinOp, MaxOp, LengthOp, GranOp, Info->DescriptorTypeOp);
+
+    Rnode->BufferLength = sizeof (AML_RESOURCE_ADDRESS32) +
+        OptionIndex + StringLength;
+    return (Rnode);
+}
+
 
 /*******************************************************************************
  *

--- a/source/compiler/asltokens.y
+++ b/source/compiler/asltokens.y
@@ -256,6 +256,7 @@ NoEcho('
 %token <i> PARSEOP_DWORDCONST
 %token <i> PARSEOP_DWORDIO
 %token <i> PARSEOP_DWORDMEMORY
+%token <i> PARSEOP_DWORDPCC
 %token <i> PARSEOP_DWORDSPACE
 %token <i> PARSEOP_EISAID
 %token <i> PARSEOP_ELSE

--- a/source/compiler/asltypes.y
+++ b/source/compiler/asltypes.y
@@ -419,6 +419,7 @@ NoEcho('
 %type <n> DMATerm
 %type <n> DWordIOTerm
 %type <n> DWordMemoryTerm
+%type <n> DWordPccTerm
 %type <n> DWordSpaceTerm
 %type <n> EndDependentFnTerm
 %type <n> ExtendedIOTerm

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -1412,6 +1412,8 @@ typedef struct acpi_port_info
 #define ACPI_ADDRESS_TYPE_IO_RANGE              1
 #define ACPI_ADDRESS_TYPE_BUS_NUMBER_RANGE      2
 
+#define ACPI_ADDRESS_TYPE_PCC_NUMBER            0xA
+
 /* Resource descriptor types and masks */
 
 #define ACPI_RESOURCE_NAME_LARGE                0x80


### PR DESCRIPTION
The DWordPcc (alongside WordPcc and QWordPcc) were accepted to ACPI inclusion via a code-first process.

This patch implements support in iASL for DWordPcc.

ASWG ticket: https://mantis.uefi.org/mantis/view.php?id=2429
Bugzilla ticket: https://bugzilla.tianocore.org/show_bug.cgi?id=4594

Change-Id: I06d61644b428bed2802a76abff59ceb1c79930da