### PR TITLE
Allow PCC Data Type in MCTP resource.

### DIFF
--- a/source/components/resources/rsaddr.c
+++ b/source/components/resources/rsaddr.c
@@ -441,7 +441,8 @@ AcpiRsGetAddressCommon (
     /* Validate the Resource Type */
 
     if ((Address.ResourceType > 2) &&
-        (Address.ResourceType < 0xC0))
+        (Address.ResourceType < 0xC0) &&
+        (Address.ResourceType != 0x0A))
     {
         return (FALSE);
     }


### PR DESCRIPTION
explicitly allow QWord address space description type to be 0xA to indicate it refers to a Platform
Communication channel
IAW  ACPI_ECR_PCC_DESCRIPTORS_CF_V2

https://bugzilla.tianocore.org/show_bug.cgi?id=4594

An entity in a DSDT or in SSDTs that requires
a platform communication channel table (PCCT) entry to communicate with a remote service will have a single value that is the index of the entry in the PCCT.
This data type with have a ResourceType value of 0xA.

This value indicates that the type shares the same footprint as a DWordSpace section.