### PR TITLE
Implement ACPI_WARNING_ONCE and ACPI_ERROR_ONCE

### DIFF
--- a/source/components/executer/exsystem.c
+++ b/source/components/executer/exsystem.c
@@ -296,7 +296,7 @@ AcpiExSystemDoStall (
          * (ACPI specifies 100 usec as max, but this gives some slack in
          * order to support existing BIOSs)
          */
-        ACPI_ERROR ((AE_INFO,
+        ACPI_ERROR_ONCE ((AE_INFO,
             "Time parameter is too large (%u)", HowLongUs));
         Status = AE_AML_OPERAND_VALUE;
     }
@@ -304,7 +304,7 @@ AcpiExSystemDoStall (
     {
         if (HowLongUs > 100)
         {
-            ACPI_WARNING ((AE_INFO,
+            ACPI_WARNING_ONCE ((AE_INFO,
                 "Time parameter %u us > 100 us violating ACPI spec, please fix the firmware.", HowLongUs));
         }
         AcpiOsStall (HowLongUs);

--- a/source/include/acoutput.h
+++ b/source/include/acoutput.h
@@ -336,6 +336,7 @@
  */
 #ifndef ACPI_NO_ERROR_MESSAGES
 #define AE_INFO                         _AcpiModuleName, __LINE__
+#define ACPI_ONCE(_fn, _plist)                  { static char _done; if (!_done) { _done = 1; _fn _plist; } }
 
 /*
  * Error reporting. Callers module and line number are inserted by AE_INFO,
@@ -344,8 +345,10 @@
  */
 #define ACPI_INFO(plist)                AcpiInfo plist
 #define ACPI_WARNING(plist)             AcpiWarning plist
+#define ACPI_WARNING_ONCE(plist)        ACPI_ONCE(AcpiWarning, plist)
 #define ACPI_EXCEPTION(plist)           AcpiException plist
 #define ACPI_ERROR(plist)               AcpiError plist
+#define ACPI_ERROR_ONCE(plist)          ACPI_ONCE(AcpiError, plist)
 #define ACPI_BIOS_WARNING(plist)        AcpiBiosWarning plist
 #define ACPI_BIOS_EXCEPTION(plist)      AcpiBiosException plist
 #define ACPI_BIOS_ERROR(plist)          AcpiBiosError plist
@@ -357,8 +360,10 @@
 
 #define ACPI_INFO(plist)
 #define ACPI_WARNING(plist)
+#define ACPI_WARNING_ONCE(plist)
 #define ACPI_EXCEPTION(plist)
 #define ACPI_ERROR(plist)
+#define ACPI_ERROR_ONCE(plist)
 #define ACPI_BIOS_WARNING(plist)
 #define ACPI_BIOS_EXCEPTION(plist)
 #define ACPI_BIOS_ERROR(plist)


### PR DESCRIPTION
Implement ACPI_WARNING_ONCE and ACPI_ERROR_ONCE and use them to stop nagging the user about every Stall() call that violates the spec