### PR TITLE
Fix memory leak if AcpiPsGetNextNamepath() fails

### DIFF
--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -1016,6 +1016,11 @@ AcpiPsGetNextArg (
 
             Status = AcpiPsGetNextNamepath (WalkState, ParserState,
                 Arg, ACPI_NOT_METHOD_CALL);
+            if (ACPI_FAILURE(Status))
+            {
+                AcpiPsFreeOp (Arg);
+                return_ACPI_STATUS (Status);
+            }
         }
         else
         {
@@ -1048,6 +1053,11 @@ AcpiPsGetNextArg (
 
             Status = AcpiPsGetNextNamepath (WalkState, ParserState,
                 Arg, ACPI_POSSIBLE_METHOD_CALL);
+            if (ACPI_FAILURE(Status))
+            {
+                AcpiPsFreeOp (Arg);
+                return_ACPI_STATUS (Status);
+            }
 
             if (Arg->Common.AmlOpcode == AML_INT_METHODCALL_OP)
             {


### PR DESCRIPTION
If AcpiPsGetNextNamepath() fails, the previously allocated ACPI_PARSE_OBJECT needs to be freed before returning the status code.

The issue was first being reported on the Linux ACPI mailing list:

https://lore.kernel.org/linux-acpi/56f94776-484f-48c0-8855-dba8e6a7793b@yandex.ru/T/