### PR TITLE
Anonymous ResourceTemplate dissassembly fix

### DIFF
--- a/source/components/disassembler/dmwalk.c
+++ b/source/components/disassembler/dmwalk.c
@@ -969,8 +969,6 @@ AcpiDmDescendingOp (
                      AcpiDmPredefinedDescription (Op->Asl.Parent);
                 }
 
-                AcpiDmPredefinedDescription (Op->Asl.Parent);
-
                 AcpiOsPrintf ("\n");
                 AcpiDmIndent (Info->Level);
                 AcpiOsPrintf ("{\n");


### PR DESCRIPTION
Previous fix at 09a9a0808ba4997173ecb5c6ec3bdb1f2d0d50b5 was intended to capture the AcpiDmPredefinedDescription call in the conditional but the original call was left in place. This code still results in ASAN reporting a heap overflow on the minimal test case unless the original call is removed.

Test ASL derived from commit example:
```asl
DefinitionBlock ("", "DSDT", 2, "Intel", "_DSDT_01", 0x00000001)
{
    Method (TEST)
    {
        Local0 = ResourceTemplate ()
            {
                QWordMemory (ResourceProducer, PosDecode, MinFixed, MaxFixed, Cacheable, ReadWrite,
                    0, // Granularity
                    0, // Range Minimum
                    6, // Range Maximum
                    0, // Translation Offset
                    7, // Length
                    ,, , AddressRangeMemory, TypeStatic)
            }
        Return (Local0)
    }
}
```

Failing run at latest upstream commit:
```
❯ ASAN_OPTIONS=detect_leaks=0 ./iasl dsdt.asl

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20240322
Copyright (c) 2000 - 2023 Intel Corporation

ASL Input:     dsdt.asl -     757 bytes      3 keywords      0 source lines
AML Output:    dsdt.aml -      99 bytes      2 opcodes       1 named objects

Compilation successful. 0 Errors, 0 Warnings, 0 Remarks, 0 Optimizations
❯ ASAN_OPTIONS=detect_leaks=0 ./iasl dsdt.aml

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20240322
Copyright (c) 2000 - 2023 Intel Corporation

File appears to be binary: found 59 non-ASCII characters, disassembling
Binary file appears to be a valid ACPI table, disassembling
Input file dsdt.aml, Length 0x63 (99) bytes
ACPI: DSDT 0x0000000000000000 000063 (v02 Intel  _DSDT_01 00000001 INTL 20240322)
Pass 1 parse of [DSDT]
Pass 2 parse of [DSDT]
Parsing Deferred Opcodes (Methods/Buffers/Packages/Regions)

Parsing completed
=================================================================
==3013453==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60d0000001b4 at pc 0x5580575d3cfd bp 0x7ffd0e208af0 sp 0x7ffd0e208ae8
READ of size 1 at 0x60d0000001b4 thread T0
    #0 0x5580575d3cfc in AcpiDmPredefinedDescription ../../../source/components/disassembler/dmopcode.c:373
    #1 0x5580575f4270 in AcpiDmDescendingOp ../../../source/components/disassembler/dmwalk.c:972
    #2 0x5580575f1e5f in AcpiDmWalkParseTree ../../../source/components/disassembler/dmwalk.c:287
    #3 0x5580575f20d8 in AcpiDmDisassemble ../../../source/components/disassembler/dmwalk.c:233
    #4 0x5580575dfc7b in AdDisplayTables ../../../source/common/dmtables.c:372
    #5 0x55805756d46b in AdDisassembleOneTable ../../../source/common/adisasm.c:581
    #6 0x55805756d46b in AdAmlDisassemble ../../../source/common/adisasm.c:391
    #7 0x5580575b4aaf in AslDoDisassembly ../../../source/compiler/aslstartup.c:368
    #8 0x5580575b4aaf in AslDoDisassembly ../../../source/compiler/aslstartup.c:351
    #9 0x55805752d59b in main ../../../source/compiler/aslmain.c:281
    #10 0x7fa6d8e456c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7fa6d8e45784 in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x55805752f840 in _start (/[...]/acpica/generate/unix/bin/iasl+0xe2840) (BuildId: 37671653bc46acfb8fdb2b42ebcfdfb951107450)

0x60d0000001b4 is located 20 bytes after 144-byte region [0x60d000000110,0x60d0000001a0)
allocated by thread T0 here:
    #0 0x7fa6d90d7f97 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x55805765ca98 in AcpiOsAcquireObject ../../../source/components/utilities/utcache.c:453

SUMMARY: AddressSanitizer: heap-buffer-overflow ../../../source/components/disassembler/dmopcode.c:373 in AcpiDmPredefinedDescription
[...]
==3013453==ABORTING
```

Working run with the fix applied:
```
❯ ASAN_OPTIONS=detect_leaks=0 ./iasl dsdt.asl

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20240322
Copyright (c) 2000 - 2023 Intel Corporation

ASL Input:     dsdt.asl -     757 bytes      3 keywords      0 source lines
AML Output:    dsdt.aml -      99 bytes      2 opcodes       1 named objects

Compilation successful. 0 Errors, 0 Warnings, 0 Remarks, 0 Optimizations
❯ ASAN_OPTIONS=detect_leaks=0 ./iasl dsdt.aml

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20240322
Copyright (c) 2000 - 2023 Intel Corporation

File appears to be binary: found 59 non-ASCII characters, disassembling
Binary file appears to be a valid ACPI table, disassembling
Input file dsdt.aml, Length 0x63 (99) bytes
ACPI: DSDT 0x0000000000000000 000063 (v02 Intel  _DSDT_01 00000001 INTL 20240322)
Pass 1 parse of [DSDT]
Pass 2 parse of [DSDT]
Parsing Deferred Opcodes (Methods/Buffers/Packages/Regions)

Parsing completed
Disassembly completed
ASL Output:    dsdt.dsl - 1215 bytes
```