### PR TITLE
check null return of ACPI_ALLOCATE_ZEROED in AcpiDbConvertToPackage

### DIFF
--- a/source/components/debugger/dbconvert.c
+++ b/source/components/debugger/dbconvert.c
@@ -354,6 +354,8 @@ AcpiDbConvertToPackage (
 
     Elements = ACPI_ALLOCATE_ZEROED (
         DB_DEFAULT_PKG_ELEMENTS * sizeof (ACPI_OBJECT));
+    if (!Elements)
+        return (AE_NO_MEMORY);
 
     This = String;
     for (i = 0; i < (DB_DEFAULT_PKG_ELEMENTS - 1); i++)


### PR DESCRIPTION
ACPI_ALLOCATE_ZEROED may fails, Elements might be null and will cause null pointer dereference later.