### PR TITLE
Fix memory leak if AcpiPsGetNextField() fails

### DIFF
--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -989,10 +989,10 @@ AcpiPsGetNextArg (
                 Field = AcpiPsGetNextField (ParserState);
                 if (!Field)
                 {
-		    if (Arg)
-		    {
-		        AcpiPsFreeFieldList(Arg);
-		    }
+                    if (Arg)
+                    {
+                        AcpiPsFreeFieldList(Arg);
+                    }
 
                     return_ACPI_STATUS (AE_NO_MEMORY);
                 }

--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -170,6 +170,10 @@ static ACPI_PARSE_OBJECT *
 AcpiPsGetNextField (
     ACPI_PARSE_STATE        *ParserState);
 
+static void
+AcpiPsFreeFieldList (
+    ACPI_PARSE_OBJECT       *Start);
+
 
 /*******************************************************************************
  *
@@ -872,6 +876,43 @@ AcpiPsGetNextField (
     return_PTR (Field);
 }
 
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiPsFreeFieldList
+ *
+ * PARAMETERS:  Start               - First Op in field list
+ *
+ * RETURN:      None.
+ *
+ * DESCRIPTION: Free all Op objects inside a field list.
+ *
+ ******************************************************************************/
+
+static void
+AcpiPsFreeFieldList (
+    ACPI_PARSE_OBJECT	*Start)
+{
+    ACPI_PARSE_OBJECT *Current = Start;
+    ACPI_PARSE_OBJECT *Next;
+    ACPI_PARSE_OBJECT *Arg;
+
+    while (Current)
+    {
+        Next = Current->Common.Next;
+
+        /* AML_INT_CONNECTION_OP can have a single argument */
+
+        Arg = AcpiPsGetArg (Current, 0);
+        if (Arg)
+        {
+            AcpiPsFreeOp (Arg);
+        }
+
+        AcpiPsFreeOp(Current);
+        Current = Next;
+    }
+}
+
 
 /*******************************************************************************
  *
@@ -948,6 +989,11 @@ AcpiPsGetNextArg (
                 Field = AcpiPsGetNextField (ParserState);
                 if (!Field)
                 {
+		    if (Arg)
+		    {
+		        AcpiPsFreeFieldList(Arg);
+		    }
+
                     return_ACPI_STATUS (AE_NO_MEMORY);
                 }
 


### PR DESCRIPTION
If AcpiPsGetNextField() fails, the previously created field list needs to be properly disposed before returning the status code.