### PR TITLE
Do not strip debug info when debugging is enabled

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -80,7 +80,14 @@ INSTALL  =   cp
 INSTALLFLAGS ?= -f
 else
 INSTALL =    install
+
+# Do not strip debug info when in debug mode
+ifeq ($(DEBUG),TRUE)
+INSTALLFLAGS ?= -m 555
+else
 INSTALLFLAGS ?= -m 555 -s
+endif
+
 endif
 
 INSTALLPROG = \


### PR DESCRIPTION
Then DEBUG is set to TRUE, the resulting binaries contain debugging information. Since those binaries are however always stripped during installation, this debug information is effectively unusable.

Fix this by not stripping the resulting binaries during installation in such a case.

Fixes: a7a2de9b80be ("Makefile: add debug flag")