### PR TITLE
Avoid warning for Dump Functions

### DIFF
--- a/source/components/resources/rsdump.c
+++ b/source/components/resources/rsdump.c
@@ -230,6 +230,7 @@ AcpiRsDumpDescriptor (
     ACPI_RSDUMP_INFO        *Table);
 
 
+#ifdef ACPI_DEBUGGER
 /*******************************************************************************
  *
  * FUNCTION:    AcpiRsDumpResourceList
@@ -359,7 +360,7 @@ AcpiRsDumpIrqList (
             PrtElement, PrtElement->Length);
     }
 }
-
+#endif
 
 /*******************************************************************************
  *


### PR DESCRIPTION
Only include the functions AcpiRsDumpResourceList and AcpiRsDumpIrqList if ACPI_DEBUGGER is defined, as specified in the header. This avoid the compiler warning by adding the ifdef for ACPI_DEBUGGER.

The header: https://github.com/acpica/acpica/blob/master/source/include/acresrc.h#L470