### PR TITLE
Get rid of a useless UseCount field in ACPI_MUTEX_INFO

### DIFF
--- a/source/components/debugger/dbstats.c
+++ b/source/components/debugger/dbstats.c
@@ -585,8 +585,9 @@ AcpiDbDisplayStatistics (
         AcpiOsPrintf ("\nMutex usage:\n\n");
         for (i = 0; i < ACPI_NUM_MUTEX; i++)
         {
-            AcpiOsPrintf ("%-28s:       %7u\n",
-                AcpiUtGetMutexName (i), AcpiGbl_MutexInfo[i].UseCount);
+            AcpiOsPrintf ("%-28s:       %d\n",
+                AcpiUtGetMutexName (i),
+                AcpiOsGetThreadId () == AcpiGbl_MutexInfo[i].ThreadId);
         }
         break;
 

--- a/source/components/utilities/utinit.c
+++ b/source/components/utilities/utinit.c
@@ -267,7 +267,6 @@ AcpiUtInitGlobals (
     {
         AcpiGbl_MutexInfo[i].Mutex          = NULL;
         AcpiGbl_MutexInfo[i].ThreadId       = ACPI_MUTEX_NOT_ACQUIRED;
-        AcpiGbl_MutexInfo[i].UseCount       = 0;
     }
 
     for (i = 0; i < ACPI_NUM_OWNERID_MASKS; i++)

--- a/source/components/utilities/utmutex.c
+++ b/source/components/utilities/utmutex.c
@@ -312,7 +312,6 @@ AcpiUtCreateMutex (
     {
         Status = AcpiOsCreateMutex (&AcpiGbl_MutexInfo[MutexId].Mutex);
         AcpiGbl_MutexInfo[MutexId].ThreadId = ACPI_MUTEX_NOT_ACQUIRED;
-        AcpiGbl_MutexInfo[MutexId].UseCount = 0;
     }
 
     return_ACPI_STATUS (Status);
@@ -426,7 +425,6 @@ AcpiUtAcquireMutex (
             "Thread %u acquired Mutex [%s]\n",
             (UINT32) ThisThreadId, AcpiUtGetMutexName (MutexId)));
 
-        AcpiGbl_MutexInfo[MutexId].UseCount++;
         AcpiGbl_MutexInfo[MutexId].ThreadId = ThisThreadId;
     }
     else

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -239,7 +239,6 @@ typedef struct acpi_rw_lock
 typedef struct acpi_mutex_info
 {
     ACPI_MUTEX                      Mutex;
-    UINT32                          UseCount;
     ACPI_THREAD_ID                  ThreadId;
 
 } ACPI_MUTEX_INFO;


### PR DESCRIPTION
This could only ever have a value of 1 or 0 since AcpiOSAcquireMutex is not recursive, so having this counter just wastes extra space.

See check above (triggered if ACPI_MUTEX_DEBUG is enabled):
```c
if (AcpiGbl_MutexInfo[i].ThreadId == ThisThreadId)
{
    if (i == MutexId)
    {
        ACPI_ERROR ((AE_INFO,
            "Mutex [%s] already acquired by this thread [%u]",
            AcpiUtGetMutexName (MutexId),
            (UINT32) ThisThreadId));

        return (AE_ALREADY_ACQUIRED);
    }
```
And also a call to non-recursive `AcpiOSAcquireMutex`, which will hang forever if UseCount is 1:
```c
    Status = AcpiOsAcquireMutex (
        AcpiGbl_MutexInfo[MutexId].Mutex, ACPI_WAIT_FOREVER);
```