### PR TITLE
acpica: Revert "Do not cross page boundaries when mapping operation regions."

### DIFF
--- a/source/components/executer/exregion.c
+++ b/source/components/executer/exregion.c
@@ -191,7 +191,6 @@ AcpiExSystemMemorySpaceHandler (
     ACPI_MEM_MAPPING        *Mm = MemInfo->CurMm;
     UINT32                  Length;
     ACPI_SIZE               MapLength;
-    ACPI_SIZE               PageBoundaryMapLength;
 #ifdef ACPI_MISALIGNMENT_NOT_SUPPORTED
     UINT32                  Remainder;
 #endif
@@ -298,27 +297,9 @@ AcpiExSystemMemorySpaceHandler (
         MapLength = (ACPI_SIZE)
             ((MemInfo->Address + MemInfo->Length) - Address);
 
-        /*
-         * If mapping the entire remaining portion of the region will cross
-         * a page boundary, just map up to the page boundary, do not cross.
-         * On some systems, crossing a page boundary while mapping regions
-         * can cause warnings if the pages have different attributes
-         * due to resource management.
-         *
-         * This has the added benefit of constraining a single mapping to
-         * one page, which is similar to the original code that used a 4k
-         * maximum window.
-         */
-        PageBoundaryMapLength = (ACPI_SIZE)
-            (ACPI_ROUND_UP (Address, ACPI_DEFAULT_PAGE_SIZE) - Address);
-        if (PageBoundaryMapLength == 0)
+        if (MapLength > ACPI_DEFAULT_PAGE_SIZE)
         {
-            PageBoundaryMapLength = ACPI_DEFAULT_PAGE_SIZE;
-        }
-
-        if (MapLength > PageBoundaryMapLength)
-        {
-            MapLength = PageBoundaryMapLength;
+            MapLength = ACPI_DEFAULT_PAGE_SIZE;
         }
 
         /* Create a new mapping starting at the address given */


### PR DESCRIPTION

Revert changes made in commit 381f8561ee4e ("Do not cross page boundaries when mapping operation regions."). The original intention of that commit was to prevent memory mappings for operation regions from crossing page boundaries, as it can cause warnings in case of different page attributes.

However, it was discovered that when this condition occurs, mapping is done until the end of the boundary, but still attempts to read/write the entire length of the map, resulting in a NULL pointer deference. For instance, if there is a request to map four bytes but only one byte is mapped because it reaches the end of the current page boundary, there is still an attempt to read/write four bytes, causing a NULL pointer dereference.

Instead, map the complete length, as there is no restriction in the ACPI specification that requires it to be in the same page boundary. It is acceptable for it to be mapped in different regions.

Cc: Mario Limonciello <mario.limonciello@amd.com>
Link: https://bugzilla.kernel.org/show_bug.cgi?id=14445
Fixes: 381f8561ee4e ("Do not cross page boundaries when mapping operation regions.")
Co-developed-by: Sanath S <Sanath.S@amd.com>
Signed-off-by: Sanath S <Sanath.S@amd.com>
Signed-off-by: Raju Rangoju <Raju.Rangoju@amd.com>
