### PR TITLE
iasl: handle empty ConnectionNode

### DIFF
--- a/source/components/executer/exprep.c
+++ b/source/components/executer/exprep.c
@@ -611,6 +611,10 @@ AcpiExPrepFieldValue (
         if (Info->ConnectionNode)
         {
             SecondDesc = Info->ConnectionNode->Object;
+            if (SecondDesc == NULL)
+            {
+                break;
+            }
             if (!(SecondDesc->Common.Flags & AOPOBJ_DATA_VALID))
             {
                 Status = AcpiDsGetBufferArguments (SecondDesc);


### PR DESCRIPTION
Solves https://github.com/acpica/acpica/issues/963

Not sure whether this is most clean/correct way to exit. Attempt to return error status or delete object description results in further failures. With just `break` decompiling finally completes:

```
Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20240322
Copyright (c) 2000 - 2023 Intel Corporation

File appears to be binary: found 61249 non-ASCII characters, disassembling
Binary file appears to be a valid ACPI table, disassembling
Input file /mnt/c/Users/alexv/Desktop/iasl-win-20240321/DSDT.aml, Length 0x3E413 (254995) bytes
ACPI: DSDT 0x0000000000000000 03E413 (v02 QCOMM  SDM8380  00000003 MSFT 05000000)
Pass 1 parse of [DSDT]
Pass 2 parse of [DSDT]
Parsing Deferred Opcodes (Methods/Buffers/Packages/Regions)

Parsing completed
Disassembly completed
ASL Output:    /mnt/c/Users/alexv/Desktop/iasl-win-20240321/DSDT.dsl - 2251342 bytes
```