### PR TITLE
Fixes 20240322

### DIFF
--- a/source/common/dmtbdump1.c
+++ b/source/common/dmtbdump1.c
@@ -1371,8 +1371,8 @@ AcpiDmDumpDbg2 (
 
         if (Subtable->OemDataOffset)
         {
-            Status = AcpiDmDumpTable (Length, Offset + Subtable->OemDataOffset,
-                Table, Subtable->OemDataLength,
+            Status = AcpiDmDumpTable (Length, Subtable->OemDataOffset,
+                Subtable, Subtable->OemDataLength,
                 AcpiDmTableInfoDbg2OemData);
             if (ACPI_FAILURE (Status))
             {

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -2028,8 +2028,10 @@ AcpiDmDumpPhat (
 
             /* Get Device-Specific Data - length of which is the remaining subtable length. */
 
-            VendorLength =
-                Subtable->Length - sizeof (ACPI_PHAT_HEALTH_DATA) - PathLength;
+	    VendorLength = 0;
+	    if (Subtable->Length > sizeof (ACPI_PHAT_HEALTH_DATA) + PathLength)
+		VendorLength =
+			Subtable->Length - sizeof (ACPI_PHAT_HEALTH_DATA) - PathLength;
             DbgPrint (ASL_DEBUG_OUTPUT, "%u, Subtable->Length %X, VendorLength %X, Offset %X PathLength: %X\n",
                 __LINE__, Subtable->Length, VendorLength, Offset, PathLength);
 

--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -177,7 +177,8 @@ AcpiDmDumpSlic (
     ACPI_TABLE_HEADER       *Table)
 {
 
-    (void) AcpiDmDumpTable (Table->Length, sizeof (ACPI_TABLE_HEADER), Table,
+    (void) AcpiDmDumpTable (Table->Length, sizeof (ACPI_TABLE_HEADER),
+        (void *) (Table + sizeof (*Table)),
         Table->Length - sizeof (*Table), AcpiDmTableInfoSlic);
 }
 


### PR DESCRIPTION
Some fixes that were in my tree that touch on table dumping.  In particular for DBG2, SLIC and PHAT tables, subtable offsets were either not always calculated properly or used problematic arithmetic with unsigned variables.

Test cases for these can sometimes be very simple; for PHAT, for example, all you have to do is run "iasl -T phat" to get a segfault.
