### PR TITLE
PHAT: Various fixes

### DIFF
--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1927,13 +1927,13 @@ AcpiDmDumpPhat (
         case ACPI_PHAT_TYPE_FW_VERSION_DATA:
 
             InfoTable = AcpiDmTableInfoPhat0;
-            SubtableLength = Offset += sizeof (ACPI_PHAT_VERSION_DATA);
+            SubtableLength = sizeof (ACPI_PHAT_VERSION_DATA);
             break;
 
         case ACPI_PHAT_TYPE_FW_HEALTH_DATA:
 
             InfoTable = AcpiDmTableInfoPhat1;
-            SubtableLength = Offset += sizeof (ACPI_PHAT_HEALTH_DATA);
+            SubtableLength = sizeof (ACPI_PHAT_HEALTH_DATA);
             break;
 
         default:
@@ -1944,12 +1944,14 @@ AcpiDmDumpPhat (
             return;
         }
 
-        Status = AcpiDmDumpTable (Length, SubtableLength, Subtable,
+        Status = AcpiDmDumpTable (Length, Offset, Subtable,
             SubtableLength, InfoTable);
         if (ACPI_FAILURE (Status))
         {
             return;
         }
+
+        Offset += SubtableLength;
 
         OriginalOffset = Offset;
         switch (Subtable->Type)

--- a/source/common/dmtbdump2.c
+++ b/source/common/dmtbdump2.c
@@ -1933,7 +1933,7 @@ AcpiDmDumpPhat (
         case ACPI_PHAT_TYPE_FW_HEALTH_DATA:
 
             InfoTable = AcpiDmTableInfoPhat1;
-            SubtableLength = Offset += sizeof (ACPI_PHAT_TYPE_FW_HEALTH_DATA);
+            SubtableLength = Offset += sizeof (ACPI_PHAT_HEALTH_DATA);
             break;
 
         default:


### PR DESCRIPTION
This series contains various fixes for the PHAT table parser:

 - fixing a possible segfault when encountering invalid device paths
 - fixing displayed offsets
 - fix parsing of firmware health records

I tested the changes on a PHAT table from the Acer Predator Triton PT14-51, and everything seems to work.