### PR TITLE
Remove extraneous spaces before \n character

### DIFF
--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -1086,7 +1086,7 @@ AcpiDmDumpTable (
         {
             AcpiOsPrintf (
                 "/**** ACPI table terminates "
-                "in the middle of a data structure! (dump table) \n"
+                "in the middle of a data structure! (dump table)\n"
                 "CurrentOffset: %X, TableLength: %X ***/", CurrentOffset, TableLength);
             return (AE_BAD_DATA);
         }

--- a/source/compiler/aslparseop.c
+++ b/source/compiler/aslparseop.c
@@ -790,7 +790,7 @@ TrCreateConstantLeafOp (
 
     DbgPrint (ASL_PARSE_OUTPUT,
         "\nCreateConstantLeafOp  Ln/Col %u/%u NewOp %p  "
-        "Op %s  Value %8.8X%8.8X  \n",
+        "Op %s  Value %8.8X%8.8X\n",
         Op->Asl.LineNumber, Op->Asl.Column, Op, UtGetOpName (ParseOpcode),
         ACPI_FORMAT_UINT64 (Op->Asl.Value.Integer));
 

--- a/source/compiler/prmacros.c
+++ b/source/compiler/prmacros.c
@@ -455,7 +455,7 @@ PrAddMacro (
         }
 
         DbgPrint (ASL_DEBUG_OUTPUT, PR_PREFIX_ID
-            "Macro param: %s \n",
+            "Macro param: %s\n",
             AslGbl_CurrentLineNumber, Token);
 
         Args[i].Name = UtLocalCalloc (strlen (Token) + 1);
@@ -497,7 +497,7 @@ PrAddMacro (
 
 
                 DbgPrint (ASL_DEBUG_OUTPUT, PR_PREFIX_ID
-                    "Macro Arg #%u: %s UseCount %u Offset %u \n",
+                    "Macro Arg #%u: %s UseCount %u Offset %u\n",
                     AslGbl_CurrentLineNumber, i, Token,
                     UseCount+1, Args[i].Offset[UseCount]);
 
@@ -544,7 +544,7 @@ AddMacroToList:
     }
 
     DbgPrint (ASL_DEBUG_OUTPUT, PR_PREFIX_ID
-        "Macro body: %s \n",
+        "Macro body: %s\n",
         AslGbl_CurrentLineNumber, BodyInSource);
 
     /* Add macro to the #define list */
@@ -668,7 +668,7 @@ PrDoMacroInvocation (
             PrReplaceResizeSubstring (Args, Diff1, Diff2, i, Token);
 
             DbgPrint (ASL_DEBUG_OUTPUT, PR_PREFIX_ID
-                "ExpandArg: %s \n",
+                "ExpandArg: %s\n",
                 AslGbl_CurrentLineNumber, AslGbl_MacroTokenBuffer);
         }
 
@@ -696,7 +696,7 @@ BadInvocation:
         THIS_TOKEN_OFFSET (MacroStart));
 
     DbgPrint (ASL_DEBUG_OUTPUT, PR_PREFIX_ID
-        "Bad macro invocation: %s \n",
+        "Bad macro invocation: %s\n",
         AslGbl_CurrentLineNumber, AslGbl_MacroTokenBuffer);
     return;
 }


### PR DESCRIPTION
There are a handful of output strings that have a trailing space before a \n character. The spaces seem to be extraneous and can be removed.