### PR TITLE
Fix pointer offset into SLIC table

### DIFF
--- a/source/common/dmtbdump3.c
+++ b/source/common/dmtbdump3.c
@@ -178,7 +178,7 @@ AcpiDmDumpSlic (
 {
 
     (void) AcpiDmDumpTable (Table->Length, sizeof (ACPI_TABLE_HEADER),
-        (void *) (Table + sizeof (*Table)),
+        (void *) ((UINT8 *)Table + sizeof (*Table)),
         Table->Length - sizeof (*Table), AcpiDmTableInfoSlic);
 }
 


### PR DESCRIPTION
Currently the offset into the SLIC table is being computing by adding an offset onto the Table pointer but because Table is a ACPI_TABLE_HEADER pointer type the offset is actually in multiples of the size of the ACPI_TABLE_HEADER struct. Fix this by casting Table to a UINT8 * to make the pointer arithmetic work in terms of octects (bytes).

Detected when integrating ACPICA into the Firmware Test Suite and I noticed the SLIC table data was being fetched from a bogus location.

Fixes: 1672c9dc6446 ("Correct dumping of SLIC tables")