### PR TITLE
CDAT/DSMAS: Add shareable and read only flag bit definitions

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -636,6 +636,8 @@ typedef struct acpi_cdat_dsmas
 /* Flags for subtable above */
 
 #define ACPI_CDAT_DSMAS_NON_VOLATILE        (1 << 2)
+#define ACPI_CDAT_DSMAS_SHAREABLE           (1 << 3)
+#define ACPI_CDAT_DSMAS_READ_ONLY           (1 << 6)
 
 
 /* Subtable 1: Device scoped Latency and Bandwidth Information Structure (DSLBIS) */


### PR DESCRIPTION
Add shareable and read only flag bit definitions to decode DSMAS flags field.