### PR TITLE
tools/acpixtract: handle AX_OPTIONAL_TABLES correctly

### DIFF
--- a/source/tools/acpixtract/acpixtract.c
+++ b/source/tools/acpixtract/acpixtract.c
@@ -213,7 +213,8 @@ AxExtractTables (
         AxNormalizeSignature (UpperSignature);
         Instances = AxCountTableInstances (InputPathname, UpperSignature);
 
-        if (Instances < MinimumInstances || MinimumInstances == AX_OPTIONAL_TABLES)
+        if (Instances < MinimumInstances ||
+            (Instances == 0 && MinimumInstances == AX_OPTIONAL_TABLES))
         {
             printf ("Table [%s] was not found in %s\n",
                 UpperSignature, InputPathname);


### PR DESCRIPTION
Fix a regression found by @paulmenzel 