### PR TITLE
events/evxfregn: don't release the ContextMutex that was never acquired

### DIFF
--- a/source/components/events/evxfregn.c
+++ b/source/components/events/evxfregn.c
@@ -392,7 +392,6 @@ AcpiRemoveAddressSpaceHandler (
 
             /* Now we can delete the handler object */
 
-            AcpiOsReleaseMutex (HandlerObj->AddressSpace.ContextMutex);
             AcpiUtRemoveReference (HandlerObj);
             goto UnlockAndExit;
         }


### PR DESCRIPTION
This bug was first introduced in c9e011695, where the author of the patch probably meant to do DeleteMutex instead of ReleaseMutex. The mutex leak was noticed later on and fixed in bc43c878, but the bogus MutexRelease line was never removed, so do it now.

Fixes: c9e011695 ("Fix race in GenericSerialBus (I2C) and GPIO OpRegion parameter handling")