### PR TITLE
Add null pointer check to UtLocalCacheCalloc

### DIFF
--- a/source/compiler/aslcache.c
+++ b/source/compiler/aslcache.c
@@ -210,7 +210,8 @@ UtLocalCacheCalloc (
         }
     }
 
-    if ((AslGbl_StringCacheNext + Length) >= AslGbl_StringCacheLast)
+    if ((!AslGbl_StringCacheNext) ||
+        ((AslGbl_StringCacheNext + Length) >= AslGbl_StringCacheLast))
     {
         /* Allocate a new buffer */
 


### PR DESCRIPTION
This was doing arithmetic math with a null pointer on first access which runs afoul of ubsan.

I was able to reproduce this with any input file at all as long as ubsan was enabled, including this simple DSDT:
```
DefinitionBlock ("", "DSDT", 2, "Intel", "_DSDT_01", 0x00000001)
{
    Method (DS01)
    {
    }
}
```

Yielding:
```
# ./iasl dsdt.dsl
acpica/source/compiler/aslcache.c:213:33: runtime error: applying non-zero offset 70 to null pointer

SUMMARY: UndefinedBehaviorSanitizer: nullptr-with-nonzero-offset acpica/source/compiler/aslcache.c:213:33
```

This pattern of null pointer access can be verified on code inspection, and is relieved by simply skipping the arithmetic check if the pointer is null and proceeding to the body of the if-statement where the pointer values are populated, rendering pointer arithmetic valid upon the next call to `UtLocalCacheCalloc`.