### PR TITLE
source/compiler: made `PARSEOP_DEVICE` consistent with ACPI 6.3, Errata A

### DIFF
--- a/source/compiler/aslmethod.c
+++ b/source/compiler/aslmethod.c
@@ -546,9 +546,9 @@ MtMethodAnalysisWalkBegin (
         else if (HidExists && AdrExists)
         {
             /*
-             * According to the ACPI spec, "A device object must contain
-             * either an _HID object or an _ADR object, but should not contain
-             * both".
+             * "A device object must contain either an _HID object or
+             * an _ADR object, but must not contain both".
+             * (ACPI spec 6.3, Errata A Section 6.1, page 327)
              */
             AslError (ASL_WARNING, ASL_MSG_MULTIPLE_TYPES, Op,
                 "Device object requires either a _HID or _ADR, but not both");


### PR DESCRIPTION
In `MtMethodAnalysisWalkBegin`, for the case `PARSEOP_DEVICE`; the comment does not tell from which ACPI specs an object must not contain both `_HID` and `_ADR`.

[A discussion in Xen project]( https://lore.kernel.org/all/20241222161444.1558599-2-Ariel.Otilibili-Anieli@eurecom.fr/) showed the wording has changed:

From  [ACPI 2.0 (Jul. 27, 2000; Section 6.1, page 146)](https://uefi.org/sites/default/files/resources/ACPI_2.pdf):
> A device object must contain either an _HID object or an _ADR object, but can contain both.

To [ACPI 6.0 (April 2015; Section 6.1, page 278)](https://uefi.org/sites/default/files/resources/ACPI_6.0.pdf),
>A device object must contain either an _HID object or an _ADR object, but should not contain both.

And from [ACPI 6.3, Errata A (October 2020; Section 6.1, page 327)](https://uefi.org/sites/default/files/resources/ACPI_Spec_6_3_A_Oct_6_2020.pdf):
>A device object must contain either an _HID object or an _ADR object, but must not contain both.

Cc: @jbeulich