### PR TITLE
actypes: Distinguish between D3hot/cold, and default `ACPI_STATE_D3` to D3cold.

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -741,9 +741,11 @@ typedef UINT64                          ACPI_INTEGER;
 #define ACPI_STATE_D0                   (UINT8) 0
 #define ACPI_STATE_D1                   (UINT8) 1
 #define ACPI_STATE_D2                   (UINT8) 2
-#define ACPI_STATE_D3                   (UINT8) 3
-#define ACPI_D_STATES_MAX               ACPI_STATE_D3
-#define ACPI_D_STATE_COUNT              4
+#define ACPI_STATE_D3_HOT               (UINT8) 3
+#define ACPI_STATE_D3_COLD              (UINT8) 4
+#define ACPI_STATE_D3                   ACPI_STATE_D3_COLD
+#define ACPI_D_STATES_MAX               ACPI_STATE_D3_COLD
+#define ACPI_D_STATE_COUNT              5
 
 #define ACPI_STATE_C0                   (UINT8) 0
 #define ACPI_STATE_C1                   (UINT8) 1


### PR DESCRIPTION
Working on implementing D3cold support for FreeBSD ([D48294](https://reviews.freebsd.org/D48294)), I ran into the issue of ACPICA not having constants to distinguish between D3hot and D3cold states. I wasn't sure exactly what `ACPI_STATE_D3` should default to (it is unclear for me if D3 for a device which doesn't have a `_PR3` object is equivalent to D3hot or D3cold), so I decided to mirror what Linux does for this (in `include/acpi/actypes.h`):

```c
#define ACPI_STATE_D0                   (u8) 0
#define ACPI_STATE_D1                   (u8) 1
#define ACPI_STATE_D2                   (u8) 2
#define ACPI_STATE_D3_HOT               (u8) 3
#define ACPI_STATE_D3                   (u8) 4
#define ACPI_STATE_D3_COLD              ACPI_STATE_D3
#define ACPI_D_STATES_MAX               ACPI_STATE_D3
#define ACPI_D_STATE_COUNT              5
```

This PR is me trying to upstream those changes/open the discussion on what these constants should be named or if they should be distinguished at ACPICA's level at all. I think they should be at least distinguished as other objects evaluate to 4 to signify D3cold, e.g. _SxW.

I have checked that these constants aren't used anywhere else in ACPICA.