### PR TITLE
exserial: don't forget to handle FFixedHW opregions for reading

### DIFF
--- a/source/components/executer/exserial.c
+++ b/source/components/executer/exserial.c
@@ -359,6 +359,12 @@ AcpiExReadSerialBus (
         Function = ACPI_READ;
         break;
 
+    case ACPI_ADR_SPACE_FIXED_HARDWARE:
+
+        BufferLength = ACPI_FFH_INPUT_BUFFER_SIZE;
+        Function = ACPI_READ;
+        break;
+
     default:
         return_ACPI_STATUS (AE_AML_INVALID_SPACE_ID);
     }


### PR DESCRIPTION
The initial commit that introduced support for FFixedHW operation regions did add a special case in the AcpiExReadSerialBus If, but forgot to actually handle it inside the switch, so add the missing case to prevent reads from failing with AE_AML_INVALID_SPACE_ID.

Fixes: fad527b6e76 ("Add support for FFH Opregion special context data")