### PR TITLE
Fix nonsensical overflow check in vsnprintf

### DIFF
--- a/source/components/utilities/utprint.c
+++ b/source/components/utilities/utprint.c
@@ -561,12 +561,8 @@ vsnprintf (
 
     Pos = String;
 
-
-    if (Size != ACPI_UINT32_MAX) {
-        End = String + Size;
-    } else {
-        End = ACPI_CAST_PTR(char, ACPI_UINT32_MAX);
-    }
+    Size = ACPI_MIN(Size, ACPI_PTR_DIFF(ACPI_MAX_PTR, String));
+    End = String + Size;
 
     for (; *Format; ++Format)
     {


### PR DESCRIPTION
A single glance at the ‘fix’ introduced in #568 should make it clear that it cannot possibly work when `(String >> 32) != 0`.  First, nothing gets written to the destination because `End < String`.  Then, because `End < Pos`, it tries to write a zero byte at address 0xfffffffe.

The original problem should have been handled with an *actual* overflow check.

The only reason acpidump, which passes a stack pointer here, even *works* on 64-bit systems is because it uses the sprintf from libc.  Except the Linux [vendored version](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/power/acpi/tools/acpidump?id=612c29328466bdc1454ce76959fc03a1e2f7087a) which segfaults.