### PR TITLE
Utilities: Fix spelling mistake "Incremement" -> "Increment"

### DIFF
--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -574,7 +574,7 @@ AcpiUtUpdateRefCount (
             "Obj %p Type %.2X [%s] Refs %.2X [Incremented]\n",
             Object, Object->Common.Type,
             AcpiUtGetObjectTypeName (Object), NewCount));
-        Message = "Incremement";
+        Message = "Increment";
         break;
 
     case REF_DECREMENT:


### PR DESCRIPTION
There is a spelling mistake in a literal string. Fix it.

Fixes: a171306ed1a1 ("Reference count: add additional debugging details)