### PR TITLE
Adjust the position of code lines.

### DIFF
--- a/source/components/utilities/utcache.c
+++ b/source/components/utilities/utcache.c
@@ -433,9 +433,9 @@ AcpiOsAcquireObject (
     {
         /* The cache is empty, create a new object */
 
-        ACPI_MEM_TRACKING (Cache->TotalAllocated++);
-
 #ifdef ACPI_DBG_TRACK_ALLOCATIONS
+	ACPI_MEM_TRACKING (Cache->TotalAllocated++);
+
         if ((Cache->TotalAllocated - Cache->TotalFreed) > Cache->MaxOccupied)
         {
             Cache->MaxOccupied = Cache->TotalAllocated - Cache->TotalFreed;


### PR DESCRIPTION
In the acpica/utcache.c file, adjust the position of the "ACPI_MEM_TRACKING(cache->total_allocated++);" code line to ensure that the increment operation on total_allocated is included within the ACPI_DBG_TRACK_ALLOCATIONS configuration.