### PR TITLE
Follow-up on ACPI_NONSTRING and strncpy() deprecation

### DIFF
--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -458,7 +458,7 @@ AdDisassembleOneTable (
      */
     if (AcpiGbl_CaptureComments)
     {
-        strncpy (Table->Signature, AcpiGbl_TableSig, ACPI_NAMESEG_SIZE);
+        memcpy (Table->Signature, AcpiGbl_TableSig, ACPI_NAMESEG_SIZE);
     }
 #endif
 

--- a/source/compiler/aslprintf.c
+++ b/source/compiler/aslprintf.c
@@ -294,7 +294,7 @@ OpcParsePrintf (
         if (StringToProcess)
         {
             NewString = UtLocalCacheCalloc (StringLength + 1);
-            strncpy (NewString, StartPosition, StringLength);
+            memcpy (NewString, StartPosition, StringLength);
 
             NewOp = TrAllocateOp (PARSEOP_STRING_LITERAL);
             NewOp->Asl.Value.String = NewString;
@@ -383,7 +383,7 @@ OpcParsePrintf (
     if (StringToProcess)
     {
         NewString = UtLocalCacheCalloc (StringLength + 1);
-        strncpy (NewString, StartPosition, StringLength);
+        memcpy (NewString, StartPosition, StringLength);
 
         NewOp = TrAllocateOp (PARSEOP_STRING_LITERAL);
         NewOp->Asl.Value.String = NewString;

--- a/source/compiler/dtio.c
+++ b/source/compiler/dtio.c
@@ -285,7 +285,7 @@ DtTrim (
     ReturnString = UtLocalCacheCalloc (Length + 1);
     if (strlen (Start))
     {
-        strncpy (ReturnString, Start, Length);
+        memcpy (ReturnString, Start, Length);
     }
 
     ReturnString[Length] = 0;
@@ -377,7 +377,7 @@ DtParseLine (
     Length = ACPI_PTR_DIFF (End, Start);
 
     TmpName = UtLocalCalloc (Length + 1);
-    strncpy (TmpName, Start, Length);
+    memcpy (TmpName, Start, Length);
     Name = DtTrim (TmpName);
     ACPI_FREE (TmpName);
 
@@ -425,7 +425,7 @@ DtParseLine (
     Length = ACPI_PTR_DIFF (End, Start);
     TmpValue = UtLocalCalloc (Length + 1);
 
-    strncpy (TmpValue, Start, Length);
+    memcpy (TmpValue, Start, Length);
     Value = DtTrim (TmpValue);
     ACPI_FREE (TmpValue);
 

--- a/source/compiler/prutils.c
+++ b/source/compiler/prutils.c
@@ -474,7 +474,7 @@ ResetHere2:
          * at the correct offset value which is resetted every iteration
          */
 JumpHere2:
-        strncpy (AslGbl_MacroTokenReplaceBuffer, AslGbl_MacroTokenBuffer, Args->Offset[i]);
+        memcpy (AslGbl_MacroTokenReplaceBuffer, AslGbl_MacroTokenBuffer, Args->Offset[i]);
         strcat (AslGbl_MacroTokenReplaceBuffer, Token);
         strcat (AslGbl_MacroTokenReplaceBuffer, (AslGbl_MacroTokenBuffer +
             (Args->Offset[i] + strlen (Args->Name))));

--- a/source/components/executer/exconvrt.c
+++ b/source/components/executer/exconvrt.c
@@ -388,7 +388,7 @@ AcpiExConvertToBuffer (
         /* Copy the string to the buffer */
 
         NewBuf = ReturnDesc->Buffer.Pointer;
-        strncpy ((char *) NewBuf, (char *) ObjDesc->String.Pointer,
+        memcpy ((char *) NewBuf, (char *) ObjDesc->String.Pointer,
             ObjDesc->String.Length);
         break;
 

--- a/source/components/tables/tbfind.c
+++ b/source/components/tables/tbfind.c
@@ -208,8 +208,8 @@ AcpiTbFindTable (
 
     memset (&Header, 0, sizeof (ACPI_TABLE_HEADER));
     ACPI_COPY_NAMESEG (Header.Signature, Signature);
-    strncpy (Header.OemId, OemId, ACPI_OEM_ID_SIZE);
-    strncpy (Header.OemTableId, OemTableId, ACPI_OEM_TABLE_ID_SIZE);
+    memcpy (Header.OemId, OemId, ACPI_OEM_ID_SIZE);
+    memcpy (Header.OemTableId, OemTableId, ACPI_OEM_TABLE_ID_SIZE);
 
     /* Search for the table */
 

--- a/source/components/utilities/utnonansi.c
+++ b/source/components/utilities/utnonansi.c
@@ -353,7 +353,7 @@ AcpiUtSafeStrncpy (
 {
     /* Always terminate destination string */
 
-    strncpy (Dest, Source, DestSize);
+    memcpy (Dest, Source, DestSize);
     Dest[DestSize - 1] = 0;
 }
 

--- a/source/include/acdebug.h
+++ b/source/include/acdebug.h
@@ -187,7 +187,7 @@ typedef struct acpi_db_execute_walk
 {
     UINT32                  Count;
     UINT32                  MaxCount;
-    char                    NameSeg[ACPI_NAMESEG_SIZE + 1];
+    char                    NameSeg[ACPI_NAMESEG_SIZE + 1] ACPI_NONSTRING;
 
 } ACPI_DB_EXECUTE_WALK;
 

--- a/source/include/actbl.h
+++ b/source/include/actbl.h
@@ -213,12 +213,12 @@
 
 typedef struct acpi_table_header
 {
-    char                    Signature[ACPI_NAMESEG_SIZE];       /* ASCII table signature */
+    char                    Signature[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;       /* ASCII table signature */
     UINT32                  Length;                             /* Length of table in bytes, including this header */
     UINT8                   Revision;                           /* ACPI Specification minor version number */
     UINT8                   Checksum;                           /* To make sum of entire table == 0 */
-    char                    OemId[ACPI_OEM_ID_SIZE];            /* ASCII OEM identification */
-    char                    OemTableId[ACPI_OEM_TABLE_ID_SIZE]; /* ASCII OEM table identification */
+    char                    OemId[ACPI_OEM_ID_SIZE] ACPI_NONSTRING;            /* ASCII OEM identification */
+    char                    OemTableId[ACPI_OEM_TABLE_ID_SIZE] ACPI_NONSTRING; /* ASCII OEM table identification */
     UINT32                  OemRevision;                        /* OEM revision number */
     char                    AslCompilerId[ACPI_NAMESEG_SIZE];   /* ASCII ASL compiler vendor ID */
     UINT32                  AslCompilerRevision;                /* ASL compiler version */

--- a/source/include/actbl.h
+++ b/source/include/actbl.h
@@ -214,14 +214,14 @@
 typedef struct acpi_table_header
 {
     char                    Signature[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;       /* ASCII table signature */
-    UINT32                  Length;                             /* Length of table in bytes, including this header */
-    UINT8                   Revision;                           /* ACPI Specification minor version number */
-    UINT8                   Checksum;                           /* To make sum of entire table == 0 */
+    UINT32                  Length;                                            /* Length of table in bytes, including this header */
+    UINT8                   Revision;                                          /* ACPI Specification minor version number */
+    UINT8                   Checksum;                                          /* To make sum of entire table == 0 */
     char                    OemId[ACPI_OEM_ID_SIZE] ACPI_NONSTRING;            /* ASCII OEM identification */
     char                    OemTableId[ACPI_OEM_TABLE_ID_SIZE] ACPI_NONSTRING; /* ASCII OEM table identification */
-    UINT32                  OemRevision;                        /* OEM revision number */
-    char                    AslCompilerId[ACPI_NAMESEG_SIZE];   /* ASCII ASL compiler vendor ID */
-    UINT32                  AslCompilerRevision;                /* ASL compiler version */
+    UINT32                  OemRevision;                                       /* OEM revision number */
+    char                    AslCompilerId[ACPI_NAMESEG_SIZE];                  /* ASCII ASL compiler vendor ID */
+    UINT32                  AslCompilerRevision;                               /* ASL compiler version */
 
 } ACPI_TABLE_HEADER;
 

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -678,7 +678,7 @@ typedef UINT64                          ACPI_INTEGER;
 
 /* Support for the special RSDP signature (8 characters) */
 
-#define ACPI_VALIDATE_RSDP_SIG(a)       (!strncmp (ACPI_CAST_PTR (char, (a)), ACPI_SIG_RSDP, 8))
+#define ACPI_VALIDATE_RSDP_SIG(a)       (!strncmp (ACPI_CAST_PTR (char, (a)), ACPI_SIG_RSDP, (sizeof(a) < 8) ? ACPI_NAMESEG_SIZE : 8))
 #define ACPI_MAKE_RSDP_SIG(dest)        (memcpy (ACPI_CAST_PTR (char, (dest)), ACPI_SIG_RSDP, 8))
 
 /* Support for OEMx signature (x can be any character) */

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -673,7 +673,7 @@ typedef UINT64                          ACPI_INTEGER;
 #define ACPI_COPY_NAMESEG(dest,src)     (*ACPI_CAST_PTR (UINT32, (dest)) = *ACPI_CAST_PTR (UINT32, (src)))
 #else
 #define ACPI_COMPARE_NAMESEG(a,b)       (!strncmp (ACPI_CAST_PTR (char, (a)), ACPI_CAST_PTR (char, (b)), ACPI_NAMESEG_SIZE))
-#define ACPI_COPY_NAMESEG(dest,src)     (strncpy (ACPI_CAST_PTR (char, (dest)), ACPI_CAST_PTR (char, (src)), ACPI_NAMESEG_SIZE))
+#define ACPI_COPY_NAMESEG(dest,src)     (memcpy (ACPI_CAST_PTR (char, (dest)), ACPI_CAST_PTR (char, (src)), ACPI_NAMESEG_SIZE))
 #endif
 
 /* Support for the special RSDP signature (8 characters) */

--- a/source/os_specific/service_layers/oslinuxtbl.c
+++ b/source/os_specific/service_layers/oslinuxtbl.c
@@ -167,7 +167,7 @@ typedef struct osl_table_info
 {
     struct osl_table_info   *Next;
     UINT32                  Instance;
-    char                    Signature[ACPI_NAMESEG_SIZE];
+    char                    Signature[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
 
 } OSL_TABLE_INFO;
 

--- a/source/tools/acpidump/apfiles.c
+++ b/source/tools/acpidump/apfiles.c
@@ -264,7 +264,7 @@ ApWriteToBinaryFile (
     ACPI_TABLE_HEADER       *Table,
     UINT32                  Instance)
 {
-    char                    Filename[ACPI_NAMESEG_SIZE + 16];
+    char                    Filename[ACPI_NAMESEG_SIZE + 16] ACPI_NONSTRING;
     char                    InstanceStr [16];
     ACPI_FILE               File;
     ACPI_SIZE               Actual;

--- a/source/tools/acpixtract/acpixtract.c
+++ b/source/tools/acpixtract/acpixtract.c
@@ -205,7 +205,7 @@ AxExtractTables (
 
     if (Signature)
     {
-        strncpy (UpperSignature, Signature, ACPI_NAMESEG_SIZE);
+        memcpy (UpperSignature, Signature, ACPI_NAMESEG_SIZE);
         AcpiUtStrupr (UpperSignature);
 
         /* Are there enough instances of the table to continue? */

--- a/source/tools/acpixtract/axutils.c
+++ b/source/tools/acpixtract/axutils.c
@@ -680,7 +680,7 @@ AxDumpTableHeader (
 
     /* RSDP has an oddball signature and header */
 
-    if (!strncmp (TableHeader->Signature, "RSD PTR ", 8))
+    if (ACPI_VALIDATE_RSDP_SIG (TableHeader->Signature))
     {
         AxCheckAscii ((char *) &Header[9], 6);
 


### PR DESCRIPTION
- Apply ACPI_NONSTRING annotations where needed[1]
- Replace deprecated strncpy()[2] with memcpy()
- Avoid sequence overread in call to strncmp()

[1] #1006 
[2] https://github.com/KSPP/linux/issues/90