### PR TITLE
Add support for printing AML arguments when trace point enabled

### DIFF
--- a/source/components/dispatcher/dsmthdat.c
+++ b/source/components/dispatcher/dsmthdat.c
@@ -357,6 +357,7 @@ AcpiDsMethodDataInitArgs (
 
         Index++;
     }
+    AcpiExTraceArgs(Params, Index);
 
     ACPI_DEBUG_PRINT ((ACPI_DB_EXEC, "%u args passed to method\n", Index));
     return_ACPI_STATUS (AE_OK);

--- a/source/components/executer/extrace.c
+++ b/source/components/executer/extrace.c
@@ -269,6 +269,68 @@ AcpiExGetTraceEventName (
 
 #endif
 
+/*******************************************************************************
+ *
+ * FUNCTION:    AcpiExTraceArgs
+ *
+ * PARAMETERS:  Params            - AML method arguments
+ *              Count             - numer of method arguments
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Trace any arguments
+ *
+ ******************************************************************************/
+
+void
+AcpiExTraceArgs(ACPI_OPERAND_OBJECT **Params, UINT32 Count)
+{
+    UINT32 i;
+
+    ACPI_FUNCTION_NAME(ExTraceArgs);
+
+    for (i = 0; i < Count; i++)
+    {
+        ACPI_OPERAND_OBJECT *obj_desc = Params[i];
+
+        if (!i)
+        {
+            ACPI_DEBUG_PRINT((ACPI_DB_TRACE_POINT, " "));
+        }
+
+        switch (obj_desc->Common.Type)
+        {
+        case ACPI_TYPE_INTEGER:
+            ACPI_DEBUG_PRINT_RAW((ACPI_DB_TRACE_POINT, "%lx", obj_desc->Integer.Value));
+            break;
+
+        case ACPI_TYPE_STRING:
+            if (!obj_desc->String.Length)
+            {
+                ACPI_DEBUG_PRINT_RAW((ACPI_DB_TRACE_POINT, "NULL"));
+                break;
+            }
+            if (ACPI_IS_DEBUG_ENABLED(ACPI_LV_TRACE_POINT, _COMPONENT))
+            {
+                AcpiUtPrintString(obj_desc->String.Pointer, ACPI_UINT8_MAX);
+            }
+            break;
+
+        default:
+            ACPI_DEBUG_PRINT_RAW((ACPI_DB_TRACE_POINT, "Unknown"));
+            break;
+        }
+
+        if ((i + 1) == Count)
+        {
+            ACPI_DEBUG_PRINT_RAW((ACPI_DB_TRACE_POINT, "\n"));
+        }
+	else
+	{
+            ACPI_DEBUG_PRINT_RAW((ACPI_DB_TRACE_POINT, ", "));
+        }
+    }
+}
 
 /*******************************************************************************
  *

--- a/source/include/acinterp.h
+++ b/source/include/acinterp.h
@@ -280,6 +280,10 @@ AcpiExTracePoint (
     UINT8                   *Aml,
     char                    *Pathname);
 
+void
+AcpiExTraceArgs(
+    ACPI_OPERAND_OBJECT **Params,
+    UINT32 Count);
 
 /*
  * exfield - ACPI AML (p-code) execution - field manipulation


### PR DESCRIPTION
When debug level is set to `ACPI_LV_TRACE_POINT` method start and exit are emitted into the debug logs. This can be useful to understand call paths, however none of the arguments for the method calls are populated even when turning up other debug levels.

This can be useful for BIOSes that contain debug strings to see those strings. When `ACPI_LV_TRACE_POINT` is set also output all of the arguments for a given method call.

This enables this type of debugging:

```
extrace-0138 ex_trace_point        : Method Begin [0x0000000096b240c4:\M460] execution.
extrace-0173 ex_trace_args         :  "  POST CODE: %X  ACPI TIMER: %X  TIME: %d.%d ms\n", b0003f53, 1a26a8b2, 0, 15e, 0, 0
extrace-0138 ex_trace_point        : Method End [0x0000000096b240c4:\M460] execution.
```