### PR TITLE
Decrease `AcpiExTracePoint` verbosity

### DIFF
--- a/source/components/executer/extrace.c
+++ b/source/components/executer/extrace.c
@@ -299,9 +299,9 @@ AcpiExTracePoint (
     if (Pathname)
     {
         ACPI_DEBUG_PRINT ((ACPI_DB_TRACE_POINT,
-            "%s %s [0x%p:%s] execution.\n",
+            "%s %s [%s] execution.\n",
             AcpiExGetTraceEventName (Type), Begin ? "Begin" : "End",
-            Aml, Pathname));
+            Pathname));
     }
     else
     {


### PR DESCRIPTION
Early in kernel boot pointers can't be used and so %p shows up incorrectly:

```
extrace-0138 ex_trace_point        : Method Begin [0x(____ptrval____):\M460] execution.
```

Later in the boot %p works, but it's not really actually useful when the pathname can resolve properly. Adjust the debug print so that if the Pathname resolves that the pointer isn't also printed:

```
extrace-0138 ex_trace_point        : Method Begin [\M460] execution.
```