### PR TITLE
Shorten acpi_subtable_header structure name to match typedef ACPI_SUB…

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -262,7 +262,7 @@ typedef struct acpi_whea_header
 
 /* Larger subtable header (when Length can exceed 255) */
 
-typedef struct acpi_subtable_header_16
+typedef struct acpi_subtbl_hdr_16
 {
     UINT16                  Type;
     UINT16                  Length;


### PR DESCRIPTION
…TBL_HDR

This doesn't cause problems building ACPICA. But when converting source code format for Linux with the "acpisrc -l" command the mismatch results in structure definitions using "struct acpi_subtbl_hdr_16" without any definition of this name.