### PR TITLE
Modify variable position

### DIFF
--- a/source/components/parser/psopinfo.c
+++ b/source/components/parser/psopinfo.c
@@ -181,7 +181,7 @@ AcpiPsGetOpcodeInfo (
     UINT16                  Opcode)
 {
 #ifdef ACPI_DEBUG_OUTPUT
-    const char              *OpcodeName = "Unknown AML opcode";
+    
 #endif
 
     ACPI_FUNCTION_NAME (PsGetOpcodeInfo);
@@ -207,7 +207,9 @@ AcpiPsGetOpcodeInfo (
 
 #if defined ACPI_ASL_COMPILER && defined ACPI_DEBUG_OUTPUT
 #include "asldefine.h"
-
+    
+    const char *OpcodeName = "Unknown AML opcode";
+    
     switch (Opcode)
     {
     case AML_RAW_DATA_BYTE:
@@ -249,12 +251,12 @@ AcpiPsGetOpcodeInfo (
     default:
         break;
     }
-#endif
 
     /* Unknown AML opcode */
 
     ACPI_DEBUG_PRINT ((ACPI_DB_EXEC,
         "%s [%4.4X]\n", OpcodeName, Opcode));
+#endif
 
     return (&AcpiGbl_AmlOpInfo [_UNK]);
 }

--- a/source/components/parser/psopinfo.c
+++ b/source/components/parser/psopinfo.c
@@ -181,7 +181,7 @@ AcpiPsGetOpcodeInfo (
     UINT16                  Opcode)
 {
 #if defined ACPI_ASL_COMPILER && defined ACPI_DEBUG_OUTPUT
-    const char *OpcodeName = "Unknown AML opcode";
+    const char 		    *OpcodeName = "Unknown AML opcode";
 #endif
 
     ACPI_FUNCTION_NAME (PsGetOpcodeInfo);

--- a/source/components/parser/psopinfo.c
+++ b/source/components/parser/psopinfo.c
@@ -180,6 +180,9 @@ const ACPI_OPCODE_INFO *
 AcpiPsGetOpcodeInfo (
     UINT16                  Opcode)
 {
+#if defined ACPI_ASL_COMPILER && defined ACPI_DEBUG_OUTPUT
+    const char *OpcodeName = "Unknown AML opcode";
+#endif
 
     ACPI_FUNCTION_NAME (PsGetOpcodeInfo);
 
@@ -204,8 +207,6 @@ AcpiPsGetOpcodeInfo (
 
 #if defined ACPI_ASL_COMPILER && defined ACPI_DEBUG_OUTPUT
 #include "asldefine.h"
-    
-    const char *OpcodeName = "Unknown AML opcode";
     
     switch (Opcode)
     {

--- a/source/components/parser/psopinfo.c
+++ b/source/components/parser/psopinfo.c
@@ -180,9 +180,6 @@ const ACPI_OPCODE_INFO *
 AcpiPsGetOpcodeInfo (
     UINT16                  Opcode)
 {
-#ifdef ACPI_DEBUG_OUTPUT
-    
-#endif
 
     ACPI_FUNCTION_NAME (PsGetOpcodeInfo);
 


### PR DESCRIPTION
Modify variable definition position to prevent potential undefined risks.