### PR TITLE
ACPICA: Allow to skip Global Lock initialization

### DIFF
--- a/source/components/events/evglock.c
+++ b/source/components/events/evglock.c
@@ -195,6 +195,11 @@ AcpiEvInitGlobalLockHandler (
         return_ACPI_STATUS (AE_OK);
     }
 
+    if (!AcpiGbl_UseGlobalLock)
+    {
+        return_ACPI_STATUS (AE_OK);
+    }
+
     /* Attempt installation of the global lock handler */
 
     Status = AcpiInstallFixedEventHandler (ACPI_EVENT_GLOBAL,

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -358,6 +358,12 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_OsiData, 0);
 ACPI_INIT_GLOBAL (BOOLEAN,          AcpiGbl_ReducedHardware, FALSE);
 
 /*
+ * ACPI Global Lock is mainly used for systems with SMM, so no-SMM systems
+ * (such as LoongArch) may not have and not use Global Lock.
+ */
+ACPI_INIT_GLOBAL (BOOLEAN,          AcpiGbl_UseGlobalLock, TRUE);
+
+/*
  * Maximum timeout for While() loop iterations before forced method abort.
  * This mechanism is intended to prevent infinite loops during interpreter
  * execution within a host kernel.


### PR DESCRIPTION
Introduce AcpiGbl_UseGlobalLock, which allows to skip the Global Lock initialization. This is useful for systems without Global Lock (such as LoongArch), so as to avoid error messages during boot phase:

 ACPI Error: Could not enable GlobalLock event (20240827/evxfevnt-182)
 ACPI Error: No response from Global Lock hardware, disabling lock (20240827/evglock-59)