### PR TITLE
Apply ACPI_NONSTRING

### DIFF
--- a/source/compiler/aslanalyze.c
+++ b/source/compiler/aslanalyze.c
@@ -575,7 +575,19 @@ ApCheckForGpeNameConflict (
     char                    Target[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
 
 
-    /* Need a null-terminated string version of NameSeg */
+    /**
+     * Need a null-terminated string version of NameSeg
+     *
+     * NOTE: during a review on Name[ACPI_NAMESEG_SIZE + 1] having an extra
+     *       byte[1], compiler testing exhibited a difference in behavior between
+     *       GCC and Clang[2] (at least; MSVC may also exhibit the same) in
+     *       how optimization is done. The extra byte is needed to ensure
+     *       the signature does not get mangled, subsequently avoiding
+     *       GpeNumber being a completely different return value from strtoul.
+     *
+     *       [1] https://github.com/acpica/acpica/pull/1019#discussion_r2058687704
+     *       [2] https://github.com/acpica/acpica/pull/1019#discussion_r2061953039
+     */
 
     ACPI_MOVE_32_TO_32 (Name, Op->Asl.NameSeg);
     Name[ACPI_NAMESEG_SIZE] = 0;

--- a/source/compiler/aslanalyze.c
+++ b/source/compiler/aslanalyze.c
@@ -571,7 +571,7 @@ ApCheckForGpeNameConflict (
 {
     ACPI_PARSE_OBJECT       *NextOp;
     UINT32                  GpeNumber;
-    char                    Name[ACPI_NAMESEG_SIZE + 1] ACPI_NONSTRING;
+    char                    Name[ACPI_NAMESEG_SIZE + 1];
     char                    Target[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
 
 

--- a/source/compiler/aslanalyze.c
+++ b/source/compiler/aslanalyze.c
@@ -571,8 +571,8 @@ ApCheckForGpeNameConflict (
 {
     ACPI_PARSE_OBJECT       *NextOp;
     UINT32                  GpeNumber;
-    char                    Name[ACPI_NAMESEG_SIZE + 1];
-    char                    Target[ACPI_NAMESEG_SIZE];
+    char                    Name[ACPI_NAMESEG_SIZE + 1] ACPI_NONSTRING;
+    char                    Target[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
 
 
     /* Need a null-terminated string version of NameSeg */

--- a/source/include/actbl.h
+++ b/source/include/actbl.h
@@ -220,7 +220,7 @@ typedef struct acpi_table_header
     char                    OemId[ACPI_OEM_ID_SIZE] ACPI_NONSTRING;            /* ASCII OEM identification */
     char                    OemTableId[ACPI_OEM_TABLE_ID_SIZE] ACPI_NONSTRING; /* ASCII OEM table identification */
     UINT32                  OemRevision;                                       /* OEM revision number */
-    char                    AslCompilerId[ACPI_NAMESEG_SIZE];                  /* ASCII ASL compiler vendor ID */
+    char                    AslCompilerId[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;   /* ASCII ASL compiler vendor ID */
     UINT32                  AslCompilerRevision;                               /* ASL compiler version */
 
 } ACPI_TABLE_HEADER;

--- a/source/os_specific/efi/osefitbl.c
+++ b/source/os_specific/efi/osefitbl.c
@@ -167,7 +167,7 @@ typedef struct osl_table_info
 {
     struct osl_table_info   *Next;
     UINT32                  Instance;
-    char                    Signature[ACPI_NAMESEG_SIZE];
+    char                    Signature[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
 
 } OSL_TABLE_INFO;
 

--- a/source/os_specific/service_layers/oslinuxtbl.c
+++ b/source/os_specific/service_layers/oslinuxtbl.c
@@ -1276,7 +1276,7 @@ OslListCustomizedTables (
 {
     void                    *TableDir;
     UINT32                  Instance;
-    char                    TempName[ACPI_NAMESEG_SIZE];
+    char                    TempName[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
     char                    *Filename;
     ACPI_STATUS             Status = AE_OK;
 
@@ -1628,7 +1628,7 @@ OslGetCustomizedTable (
 {
     void                    *TableDir;
     UINT32                  CurrentInstance = 0;
-    char                    TempName[ACPI_NAMESEG_SIZE];
+    char                    TempName[ACPI_NAMESEG_SIZE] ACPI_NONSTRING;
     char                    TableFilename[PATH_MAX];
     char                    *Filename;
     ACPI_STATUS             Status;


### PR DESCRIPTION
Add ACPI_NONSTRING for destination char arrays without a terminating NUL character. This is a follow-up to 1035a3d453f7 where a few more destination arrays were missed

Closes: #1018