### PR TITLE
iASL/Templates: Use correct fd for printing info messages

### DIFF
--- a/source/common/adisasm.c
+++ b/source/common/adisasm.c
@@ -481,12 +481,12 @@ AdDisassembleOneTable (
             "FieldName : FieldValue (in hex)\n */\n\n");
 
         AcpiDmDumpDataTable (Table);
-        fprintf (stderr, "Acpi Data Table [%4.4s] decoded\n",
+        fprintf (stdout, "Acpi Data Table [%4.4s] decoded\n",
             AcpiGbl_CDAT ? (char *) AcpiGbl_CDAT : Table->Signature);
 
         if (File)
         {
-            fprintf (stderr, "Formatted output:  %s - %u bytes\n",
+            fprintf (stdout, "Formatted output:  %s - %u bytes\n",
                 DisasmFilename, CmGetFileSize (File));
         }
 
@@ -584,16 +584,16 @@ AdDisassembleOneTable (
 
         AcpiDmDumpDataTable (Table);
 
-        fprintf (stderr, "Disassembly completed\n");
+        fprintf (stdout, "Disassembly completed\n");
         if (File)
         {
-            fprintf (stderr, "ASL Output:    %s - %u bytes\n",
+            fprintf (stdout, "ASL Output:    %s - %u bytes\n",
                 DisasmFilename, CmGetFileSize (File));
         }
 
         if (AslGbl_MapfileFlag)
         {
-            fprintf (stderr, "%14s %s - %u bytes\n",
+            fprintf (stdout, "%14s %s - %u bytes\n",
                 AslGbl_FileDescs[ASL_FILE_MAP_OUTPUT].ShortDescription,
                 AslGbl_Files[ASL_FILE_MAP_OUTPUT].Filename,
                 FlGetFileSize (ASL_FILE_MAP_OUTPUT));
@@ -630,7 +630,7 @@ AdReparseOneTable (
     ACPI_COMMENT_ADDR_NODE  *AddrListHead;
 
 
-    fprintf (stderr,
+    fprintf (stdout,
         "\nFound %u external control methods, "
         "reparsing with new information\n",
         AcpiDmGetUnresolvedExternalMethodCount ());

--- a/source/compiler/dttemplate.c
+++ b/source/compiler/dttemplate.c
@@ -255,7 +255,7 @@ DtCreateTemplates (
 
     if (AcpiGbl_Optind < 3)
     {
-        fprintf (stderr, "Creating default template: [DSDT]\n");
+        fprintf (stdout, "Creating default template: [DSDT]\n");
         Status = DtCreateOneTemplateFile (ACPI_SIG_DSDT, 0);
         goto Exit;
     }
@@ -411,7 +411,7 @@ DtCreateAllTemplates (
     ACPI_STATUS             Status;
 
 
-    fprintf (stderr, "Creating all supported Template files\n");
+    fprintf (stdout, "Creating all supported Template files\n");
 
     /* Walk entire ACPI table data structure */
 
@@ -632,14 +632,14 @@ DtCreateOneTemplate (
 
     if (TableCount == 0)
     {
-        fprintf (stderr,
+        fprintf (stdout,
             "Created ACPI table template for [%4.4s], "
             "written to \"%s\"\n",
             Signature, DisasmFilename);
     }
     else
     {
-        fprintf (stderr,
+        fprintf (stdout,
             "Created ACPI table templates for [%4.4s] "
             "and %u [SSDT] in same file, written to \"%s\"\n",
             Signature, TableCount, DisasmFilename);


### PR DESCRIPTION
Print informational messages to stdout as opposed to stderr.