### PR TITLE
CDAT fixes

### DIFF
--- a/source/compiler/dttemplate.c
+++ b/source/compiler/dttemplate.c
@@ -421,8 +421,13 @@ DtCreateAllTemplates (
 
         if (TableData->Template)
         {
-            Status = DtCreateOneTemplate (TableData->Signature,
-                0, TableData);
+	    if (!strcmp (TableData->Signature, "CDAT"))
+		/* Special handling of CDAT */
+                Status = DtCreateOneTemplate (TableData->Signature,
+                    0, NULL);
+	    else
+                Status = DtCreateOneTemplate (TableData->Signature,
+                    0, TableData);
             if (ACPI_FAILURE (Status))
             {
                 return (Status);
@@ -563,7 +568,7 @@ DtCreateOneTemplate (
     }
     else
     {
-        /* Special ACPI tables - DSDT, SSDT, OSDT, FACS, RSDP */
+        /* Special ACPI tables - DSDT, SSDT, OSDT, FACS, RSDP, CDAT */
 
         AcpiOsPrintf (" (AML byte code table)\n");
         AcpiOsPrintf (" */\n");
@@ -620,6 +625,11 @@ DtCreateOneTemplate (
         {
             AcpiDmDumpDataTable (ACPI_CAST_PTR (ACPI_TABLE_HEADER,
                 TemplateRsdp));
+        }
+        else if (ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_CDAT))
+        {
+            AcpiDmDumpCdat (ACPI_CAST_PTR (ACPI_TABLE_HEADER,
+                TemplateCdat));
         }
         else
         {

--- a/source/components/tables/tbprint.c
+++ b/source/components/tables/tbprint.c
@@ -279,6 +279,14 @@ AcpiTbPrintTableHeader (
             ACPI_CAST_PTR (ACPI_TABLE_RSDP, Header)->Revision,
             LocalHeader.OemId));
     }
+    else if (AcpiGbl_CDAT && !AcpiUtValidNameseg (Header->Signature))
+    {
+	/* CDAT does not use the common ACPI table header */
+
+        ACPI_INFO (("%-4.4s 0x%8.8X%8.8X %06X",
+            ACPI_SIG_CDAT, ACPI_FORMAT_UINT64 (Address),
+            ACPI_CAST_PTR (ACPI_TABLE_CDAT, Header)->Length));
+    }
     else
     {
         /* Standard ACPI table with full common header */


### PR DESCRIPTION
This PR addresses the following issues:
- Failure to generate CDAT template when passing `-T ALL` via command line
- Failure to print CDAT header information correctly as the table does not use the common ACPI table header