### PR TITLE
Switch back to using strncpy in acpi_ut_safe_strncpy

### DIFF
--- a/source/components/utilities/utnonansi.c
+++ b/source/components/utilities/utnonansi.c
@@ -353,7 +353,7 @@ AcpiUtSafeStrncpy (
 {
     /* Always terminate destination string */
 
-    memcpy (Dest, Source, DestSize);
+    strncpy (Dest, Source, DestSize);
     Dest[DestSize - 1] = 0;
 }
 


### PR DESCRIPTION
I mistakenly replaced strncpy with memcpy in commit # 83019b4, not realizing the entire context behind *why* strncpy was used. In this safer implementation of strncpy, it does not make sense to use memcpy only to null-terminate strings passed to acpi_ut_safe_strncpy one byte early. The consequences of doing so are understandably *bad*, as was evident by the kernel test bot reporting problems[1]

This PR relates to #1009 

Link: https://lore.kernel.org/all/202505081033.50e45ff4-lkp@intel.com [1]
Reported-by: kernel test robot <oliver.sang@intel.com>
Closes: https://lore.kernel.org/oe-lkp/202505081033.50e45ff4-lkp@intel.com