### PR TITLE
Drop ACPI_NONSTRING where incorrectly applied

### DIFF
--- a/source/include/acdebug.h
+++ b/source/include/acdebug.h
@@ -187,7 +187,7 @@ typedef struct acpi_db_execute_walk
 {
     UINT32                  Count;
     UINT32                  MaxCount;
-    char                    NameSeg[ACPI_NAMESEG_SIZE + 1] ACPI_NONSTRING;
+    char                    NameSeg[ACPI_NAMESEG_SIZE + 1];
 
 } ACPI_DB_EXECUTE_WALK;
 

--- a/source/tools/acpidump/apfiles.c
+++ b/source/tools/acpidump/apfiles.c
@@ -264,7 +264,7 @@ ApWriteToBinaryFile (
     ACPI_TABLE_HEADER       *Table,
     UINT32                  Instance)
 {
-    char                    Filename[ACPI_NAMESEG_SIZE + 16] ACPI_NONSTRING;
+    char                    Filename[ACPI_NAMESEG_SIZE + 16];
     char                    InstanceStr [16];
     ACPI_FILE               File;
     ACPI_SIZE               Actual;


### PR DESCRIPTION
Partially revert commit # 1035a3d453f7 ("Apply ACPI_NONSTRING") as I've 
yet again incorrectly applied the ACPI_NONSTRING attribute where it is not 
needed. A warning was initially reported by Collin Funk [1], and 
further review by Jiri Slaby [2] highlighted another issue related to 
the same commit.

Drop the ACPI_NONSTRING attribute where it was previously incorrectly applied to fix the issue.

Link: https://lore.kernel.org/all/87ecvpcypw.fsf@gmail.com [1]
Link: https://lore.kernel.org/all/5c210121-c9b8-4458-b1ad-0da24732ac72@kernel.org [2]
