### PR TITLE
iASL: Fix _CRS CSI2 resource compilation and disassembly

### DIFF
--- a/source/compiler/aslrestype2s.c
+++ b/source/compiler/aslrestype2s.c
@@ -1469,7 +1469,7 @@ RsDoCsi2SerialBusDescriptor (
 
         case 2: /* Local Port Instance [Integer] (_PRT) */
 
-            RsSetFlagBits16 ((UINT16 *) &Descriptor->Csi2SerialBus.TypeSpecificFlags, InitializerOp, 0, 0);
+            RsSetFlagBits16 ((UINT16 *) &Descriptor->Csi2SerialBus.TypeSpecificFlags, InitializerOp, 2, 0);
             RsCreateMultiBitField (InitializerOp, ACPI_RESTAG_LOCALPORT,
                 CurrentByteOffset + ASL_RESDESC_OFFSET (Csi2SerialBus.TypeSpecificFlags), 2, 6);
             break;

--- a/source/components/disassembler/dmresrcl2.c
+++ b/source/components/disassembler/dmresrcl2.c
@@ -776,7 +776,7 @@ AcpiDmCsi2SerialBusDescriptor (
 
     AcpiOsPrintf (" 0x%2.2X, 0x%2.2X,\n",
         Resource->Csi2SerialBus.TypeSpecificFlags & 0x03,
-        Resource->Csi2SerialBus.TypeSpecificFlags & 0xFC);
+        (Resource->Csi2SerialBus.TypeSpecificFlags & 0xFC) >> 2);
 
     /* ResourceSource is a required field */
 


### PR DESCRIPTION
The iasl generates invalid AML _CRS CSI2 resource at byte 7, where the _PRT (bits 7--2) and _PHY bits (bits 1--0) are coalesced into lowest six bits of the byte 7, in what effectively is a bitwise or operation. This results in loss of information whenever the _PRT value is non-zero. A corresponding bug is also found in the disassembler, where the lowest 6 and 2 bits, respectively, are used to form the _PRT and _PHY values.

Fix both of these issues.

_CRS CSI2 descriptors, where the _PRT value is non-zero, generated before this patch are invalid.
