### PR TITLE
dispatcher: Use AcpiDsClearOperands() in AcpiDsCallControlMethod()

### DIFF
--- a/source/components/dispatcher/dsmethod.c
+++ b/source/components/dispatcher/dsmethod.c
@@ -726,15 +726,7 @@ AcpiDsCallControlMethod (
      * Delete the operands on the previous walkstate operand stack
      * (they were copied to new objects)
      */
-    for (i = 0; i < ObjDesc->Method.ParamCount; i++)
-    {
-        AcpiUtRemoveReference (ThisWalkState->Operands [i]);
-        ThisWalkState->Operands [i] = NULL;
-    }
-
-    /* Clear the operand stack */
-
-    ThisWalkState->NumOperands = 0;
+    AcpiDsClearOperands (ThisWalkState);
 
     ACPI_DEBUG_PRINT ((ACPI_DB_DISPATCH,
         "**** Begin nested execution of [%4.4s] **** WalkState=%p\n",

--- a/source/components/dispatcher/dsmethod.c
+++ b/source/components/dispatcher/dsmethod.c
@@ -646,8 +646,6 @@ AcpiDsCallControlMethod (
     ACPI_WALK_STATE         *NextWalkState = NULL;
     ACPI_OPERAND_OBJECT     *ObjDesc;
     ACPI_EVALUATE_INFO      *Info;
-    UINT32                  i;
-
 
     ACPI_FUNCTION_TRACE_PTR (DsCallControlMethod, ThisWalkState);
 


### PR DESCRIPTION
When deleting the previous walkstate operand stack AcpiDsCallControlMethod() was deleting ObjDesc->Method.ParamCount operands. But Method.ParamCount does not necessarily match ThisWalkState->NumOperands, it may be either less or more.

After correcting the for loop to check `i < ThisWalkState->NumOperands` the code is identical to AcpiDsClearOperands(), so just outright replace the code with AcpiDsClearOperands() to fix this.