### PR TITLE
SWFT: Add basic support

### DIFF
--- a/source/common/ahtable.c
+++ b/source/common/ahtable.c
@@ -265,6 +265,7 @@ const AH_TABLE      AcpiGbl_SupportedTables[] =
     {ACPI_SIG_SSDT, "Secondary System Description Table (AML table)"},
     {ACPI_SIG_STAO, "Status Override Table"},
     {ACPI_SIG_SVKL, "Storage Volume Key Location Table"},
+    {ACPI_SIG_SWFT, "SoundWire File Table"},
     {ACPI_SIG_TCPA, "Trusted Computing Platform Alliance Table"},
     {ACPI_SIG_TDEL, "TD-Event Log Table"},
     {ACPI_SIG_TPM2, "Trusted Platform Module hardware interface Table"},

--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -721,6 +721,7 @@ const ACPI_DMTABLE_DATA     AcpiDmTableData[] =
     {ACPI_SIG_SRAT, NULL,                   AcpiDmDumpSrat, DtCompileSrat,  TemplateSrat},
     {ACPI_SIG_STAO, NULL,                   AcpiDmDumpStao, DtCompileStao,  TemplateStao},
     {ACPI_SIG_SVKL, AcpiDmTableInfoSvkl,    AcpiDmDumpSvkl, DtCompileSvkl,  TemplateSvkl},
+    {ACPI_SIG_SWFT, NULL,                   NULL,           NULL,           NULL},
     {ACPI_SIG_TCPA, NULL,                   AcpiDmDumpTcpa, DtCompileTcpa,  TemplateTcpa},
     {ACPI_SIG_TDEL, AcpiDmTableInfoTdel,    NULL,           NULL,           TemplateTdel},
     {ACPI_SIG_TPM2, AcpiDmTableInfoTpm2,    AcpiDmDumpTpm2, DtCompileTpm2,  TemplateTpm2},

--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -201,6 +201,7 @@
 #define ACPI_SIG_SDEI           "SDEI"      /* Software Delegated Exception Interface Table */
 #define ACPI_SIG_SDEV           "SDEV"      /* Secure Devices table */
 #define ACPI_SIG_SVKL           "SVKL"      /* Storage Volume Key Location Table */
+#define ACPI_SIG_SWFT           "SWFT"      /* SoundWire File Table */
 #define ACPI_SIG_TDEL           "TDEL"      /* TD Event Log Table */
 
 
@@ -4094,6 +4095,30 @@ enum acpi_svkl_format
     ACPI_SVKL_FORMAT_RESERVED   = 1 /* 1 and greater are reserved */
 };
 
+/*******************************************************************************
+ *
+ * SWFT - SoundWire File Table
+ *        as described in Discovery and Configuration (DisCo) Specification
+ *        for SoundWire®
+ *        Version 1
+ *
+ ******************************************************************************/
+
+typedef struct acpi_table_swft
+{
+    ACPI_TABLE_HEADER       Header; /* Common ACPI table header */
+
+} ACPI_TABLE_SWFT;
+
+typedef struct acpi_swft_file
+{
+    UINT16                  VendorID;
+    UINT32                  FileID;
+    UINT16                  FileVersion;
+    UINT16                  FileLength;
+    UINT8                   FileData[];
+
+} ACPI_SWFT_FILE;
 
 /*******************************************************************************
  *


### PR DESCRIPTION
SoundWire File Table (SWFT) is necessary for the File Download (FDL) process of SoundWire Class Audio (SDCA) driver, which provides code/data which may be required by an SDCA device. There is a single SWFT for the system, and SWFT can contain multiple files (information about the file as well as its binary contents). The SWFT has a standard ACPI Descriptor Table Header, followed by SoundWire File definitions as described in Discovery and Configuration (DisCo) Specification for SoundWire®.

In this pull request, the plan is to provide minimal, basic support for SWFT in order to not block development of SDCA driver in the linux kernel (for which the FDL support is going to be added soon) followed by full support for SWFT like compiler/disassembler and template in the near future. Please let me know if this approach is acceptable?