### PR TITLE
Fix largest possible resource descriptor index

### DIFF
--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -1464,7 +1464,7 @@ typedef struct acpi_port_info
 #define ACPI_RESOURCE_NAME_PIN_GROUP_FUNCTION   0x91
 #define ACPI_RESOURCE_NAME_PIN_GROUP_CONFIG     0x92
 #define ACPI_RESOURCE_NAME_CLOCK_INPUT          0x93
-#define ACPI_RESOURCE_NAME_LARGE_MAX            0x94
+#define ACPI_RESOURCE_NAME_LARGE_MAX            0x93
 
 
 /*****************************************************************************


### PR DESCRIPTION
ACPI_RESOURCE_NAME_LARGE_MAX should be equal to the last actually used resource descriptor index (ACPI_RESOURCE_NAME_CLOCK_INPUT). Otherwise 'resource_index' in 'acpi_ut_validate_resource()' may be clamped incorrectly and resulting value may issue an out-of-bounds access for 'acpi_gbl_resource_types' array. Compile tested only.

Found by Linux Verification Center (linuxtesting.org) with SVACE. 
Fixes: 661feab5ee01 ("ACPICA: add support for ClockInput resource (v6.5)") 
Link: https://marc.info/?l=linux-acpi&m=175449676131260&w=2