### PR TITLE
CEDT: Rename CXL Window coherency restrictions

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -826,8 +826,8 @@ typedef struct acpi_cedt_cfmws_target_element
 
 /* Values for Restrictions field above */
 
-#define ACPI_CEDT_CFMWS_RESTRICT_TYPE2      (1)
-#define ACPI_CEDT_CFMWS_RESTRICT_TYPE3      (1<<1)
+#define ACPI_CEDT_CFMWS_RESTRICT_DEVMEM     (1)
+#define ACPI_CEDT_CFMWS_RESTRICT_HOSTONLY   (1<<1)
 #define ACPI_CEDT_CFMWS_RESTRICT_VOLATILE   (1<<2)
 #define ACPI_CEDT_CFMWS_RESTRICT_PMEM       (1<<3)
 #define ACPI_CEDT_CFMWS_RESTRICT_FIXED      (1<<4)


### PR DESCRIPTION
This has been renamed in more recent CXL specs (3.0+), as type3 (memory expanders) can also use HDM-DB for device coherent memory.