### PR TITLE
ACPICA: acpidump: fix return values in ap_is_valid_checksum()

### DIFF
--- a/source/tools/acpidump/apdump.c
+++ b/source/tools/acpidump/apdump.c
@@ -243,9 +243,10 @@ ApIsValidChecksum (
     {
         fprintf (stderr, "%4.4s: Warning: wrong checksum in table\n",
             Table->Signature);
+        return (FALSE);
     }
 
-    return (AE_OK);
+    return (TRUE);
 }
 
 


### PR DESCRIPTION
The function ap_is_valid_checksum() has a boolean name suggesting it should return TRUE/FALSE, but incorrectly returns AE_OK on success and has no explicit return on failure, leading to undefined behavior.

Fix by returning proper values:
- FALSE when checksum validation fails
- TRUE when checksum validation succeeds