### PR TITLE
ACPICA: replace ACPI_FREE with AcpiUtDeleteObjectDesc

### DIFF
--- a/source/components/namespace/nsxfname.c
+++ b/source/components/namespace/nsxfname.c
@@ -805,7 +805,7 @@ AcpiInstallMethod (
 ErrorExit:
 
     ACPI_FREE (AmlBuffer);
-    ACPI_FREE (MethodObj);
+    AcpiUtDeleteObjectDesc (MethodObj);
     return (Status);
 }
 

--- a/source/components/utilities/utobject.c
+++ b/source/components/utilities/utobject.c
@@ -305,7 +305,7 @@ AcpiUtCreatePackageObject (
         ((ACPI_SIZE) Count + 1) * sizeof (void *));
     if (!PackageElements)
     {
-        ACPI_FREE (PackageDesc);
+        AcpiUtDeleteObjectDesc (PackageDesc);
         return_PTR (NULL);
     }
 


### PR DESCRIPTION
AcpiUtCreateInternalObject may allocate memory from a slab cache via kmem_cache_zalloc, but the code currently frees it with ACPI_FREE, which calls kfree. This mismatch prevents the object from being released properly and may lead to memory leaks or other issues.

Fix this by replacing ACPI_FREE with AcpiUtDeleteObjectDesc, which matches the allocation method used for internal objects.