### PR TITLE
Add definition for ACPI C4 C-state

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -751,8 +751,9 @@ typedef UINT64                          ACPI_INTEGER;
 #define ACPI_STATE_C1                   (UINT8) 1
 #define ACPI_STATE_C2                   (UINT8) 2
 #define ACPI_STATE_C3                   (UINT8) 3
-#define ACPI_C_STATES_MAX               ACPI_STATE_C3
-#define ACPI_C_STATE_COUNT              4
+#define ACPI_STATE_C4                   (UINT8) 4
+#define ACPI_C_STATES_MAX               ACPI_STATE_C4
+#define ACPI_C_STATE_COUNT              5
 
 /*
  * Sleep type invalid value


### PR DESCRIPTION
Some AMD systems have support for a C4 C-state.  This isn't directly used in acpica, but the definitions are used in Linux and should be updated in acpica as well.