### PR TITLE
Add new hardware IDs and _DSM UUIDs

### DIFF
--- a/source/common/ahids.c
+++ b/source/common/ahids.c
@@ -300,6 +300,7 @@ const AH_DEVICE_ID  AslDeviceIds[] =
     {"PNP0C12",     "Device Bay Controller"},
     {"PNP0C14",     "Windows Management Instrumentation Device"},
     {"PNP0C15",     "Docking Station"},
+    {"PNP0C32",     "Direct App Launch Button"},
     {"PNP0C33",     "Error Device"},
     {"PNP0C40",     "Standard Button Controller"},
     {"PNP0C50",     "HID Protocol Device (I2C bus)"},

--- a/source/common/ahuuids.c
+++ b/source/common/ahuuids.c
@@ -180,6 +180,11 @@ const AH_UUID  Gbl_AcpiUuids[] =
     {"Device Labeling Interface",   UUID_DEVICE_LABELING},
     {"Physical Presence Interface", UUID_PHYSICAL_PRESENCE},
 
+    {"[Trusted Platform Module]",   NULL},
+    {"TPM Hardware Information",    UUID_HARDWARE_INFORMATION},
+    {"TPM Start Method",            UUID_START_METHOD},
+    {"TPM Memory Clear",            UUID_MEMORY_CLEAR},
+
     {"[Non-volatile DIMM and NFIT table]",       NULL},
     {"NVDIMM Device",               UUID_NFIT_DIMM},
     {"Volatile Memory Region",      UUID_VOLATILE_MEMORY},

--- a/source/common/ahuuids.c
+++ b/source/common/ahuuids.c
@@ -211,6 +211,7 @@ const AH_UUID  Gbl_AcpiUuids[] =
     {"USB4 Capabilities",           UUID_USB4_CAPABILITIES},
     {"First Function ID for _DSM",  UUID_1ST_FUNCTION_ID},
     {"Second Function ID for _DSM", UUID_2ND_FUNCTION_ID},
+    {"Fan Trip Points",             UUID_FAN_TRIP_POINTS},
 
     {NULL, NULL}
 };

--- a/source/include/acuuid.h
+++ b/source/include/acuuid.h
@@ -179,6 +179,11 @@
 #define UUID_DEVICE_LABELING            "e5c937d0-3553-4d7a-9117-ea4d19c3434d"
 #define UUID_PHYSICAL_PRESENCE          "3dddfaa6-361b-4eb4-a424-8d10089d1653"
 
+/* TPM */
+#define UUID_HARDWARE_INFORMATION       "cf8e16a5-c1e8-4e25-b712-4f54a96702c8"
+#define UUID_START_METHOD               "6bbf6cab-5463-4714-b7cd-f0203c0368d4"
+#define UUID_MEMORY_CLEAR               "376054ed-cc13-4675-901c-4756d7f2d45d"
+
 /* NVDIMM - NFIT table */
 
 #define UUID_NFIT_DIMM                  "4309ac30-0d11-11e4-9191-0800200c9a66"

--- a/source/include/acuuid.h
+++ b/source/include/acuuid.h
@@ -213,4 +213,5 @@
 #define UUID_USB4_CAPABILITIES          "23a0d13a-26ab-486c-9c5f-0ffa525a575a"
 #define UUID_1ST_FUNCTION_ID            "893f00a6-660c-494e-bcfd-3043f4fb67c0"
 #define UUID_2ND_FUNCTION_ID            "107ededd-d381-4fd7-8da9-08e9a6c79644"
+#define UUID_FAN_TRIP_POINTS            "a7611840-99fe-41ae-a488-35c75926c8eb"
 #endif /* __ACUUID_H__ */


### PR DESCRIPTION
This patch series adds a couple of previously unknown _DSM UUIDs i encountered while compiling/decompiling ACPI tables.

Additionally this patch series adds the "PNP0C32" hardware ID to the list of known hardware IDs so that the AML disassembler can properly detect PNP0C32 devices.