### PR TITLE
Add absent field_obj null check

### DIFF
--- a/source/components/events/evregion.c
+++ b/source/components/events/evregion.c
@@ -320,7 +320,7 @@ AcpiEvAddressSpaceDispatch (
             return_ACPI_STATUS (AE_NOT_EXIST);
         }
 
-        if (RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_COMM)
+        if (FieldObj && RegionObj->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_COMM)
         {
             ACPI_PCC_INFO *Ctx = HandlerDesc->AddressSpace.Context;
 


### PR DESCRIPTION
The AcpiEvAddressSpaceDispatch function designed 
in such a way that assigning  field_obj to NULL is valid case.
Cover the missed execution path with this check.

Fixes: 0acf24ad7e10 ("ACPICA: Add support for PCC Opregion special context data")