### PR TITLE
Revert "Add definition for ACPI C4 C-state"

### DIFF
--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -751,9 +751,8 @@ typedef UINT64                          ACPI_INTEGER;
 #define ACPI_STATE_C1                   (UINT8) 1
 #define ACPI_STATE_C2                   (UINT8) 2
 #define ACPI_STATE_C3                   (UINT8) 3
-#define ACPI_STATE_C4                   (UINT8) 4
-#define ACPI_C_STATES_MAX               ACPI_STATE_C4
-#define ACPI_C_STATE_COUNT              5
+#define ACPI_C_STATES_MAX               ACPI_STATE_C3
+#define ACPI_C_STATE_COUNT              4
 
 /*
  * Sleep type invalid value


### PR DESCRIPTION
This reverts commit 6215f3c3397ef8b93bac41af20372828c7741fe5. The ACPI specification doesn't allow for anything but "Types" C1, C2, and C3.  We shouldn't be introducing a 4th type. This appears to be a BIOS bug.