### PR TITLE
Fix potential issue in runtime functional control ImplicitReturn tests.

### DIFF
--- a/tests/aslts/src/runtime/collections/functional/control/ImplicitReturn/store.asl
+++ b/tests/aslts/src/runtime/collections/functional/control/ImplicitReturn/store.asl
@@ -1052,11 +1052,7 @@ Method(mf6e,, Serialized)
 	Store(m005(1), i003)
 	if (SLCK) {
 		CH03("", z138, 0x059, __LINE__, 0)
-		if (y901) {
-			Store(0, Local0)
-		} else {
-			Store(Ones, Local0)
-		}
+		Store(0, Local0)
 		if (LNotEqual(i003, Local0)) {
 			err("", z138, __LINE__, 0, 0, i003, Local0)
 		}


### PR DESCRIPTION
While working on making an AML interpreter and using the ACPICA runtime tests for validation I stumbled across this potential issue. Its possible I've missed something and/or misunderstood, but here are my findings. My tests were run using `SLCK == 1` ("Slack mode" enabled) and `SETN == 6`.

Starting at line 1050 in `tests/aslts/src/runtime/collections/functional/control/ImplicitReturn/store.asl`, there appears to be a mistake when setting the expected implicitly returned value of the m005(1) method. 
```
Store(0xdddd0000, i003)
CH03("", z138, 0x058, __LINE__, 0)
Store(m005(1), i003)
if (SLCK) {
  CH03("", z138, 0x059, __LINE__, 0)
  if (y901) {
    Store(0, Local0)
  } else {
    Store(Ones, Local0)
  }
  if (LNotEqual(i003, Local0)) {
    err("", z138, __LINE__, 0, 0, i003, Local0)
  }
} else {
  CH04("", 0, 0xff, z138, __LINE__, 0, 0)
}
```

The expected value, `Local0`, changes depending on the value of the `y901` flag, which specifies if "Predicate generates Implicit Return" and is set to `0` when `SETN == 6`. However, checking the definition of the `m005` method, we see that `r001 == 0` when `arg0 == 1` which it in this case does, meaning that the last big while loop is not executed and that the last section of the method that sets ends up setting the implicit result is the following.
```
Store(0xdddd0000, i000)
CH03("", z138, 0x070, __LINE__, 0)
Store(m004(), i000)
if (SLCK) {
  CH03("", z138, 0x071, __LINE__, 0)
  Store(0xaaaa001c, Local0)
  if (LNotEqual(i000, Local0)) {
    err("", z138, __LINE__, 0, 0, i000, Local0)
  }
} else {
  CH04("", 0, 0xff, z138, __LINE__, 0, 0)
}
if (r001) {
// While loop starts down here but there is nothing after the end of this if statement.
```

From my understanding of the expected implicit result behavior, the last evaluated expression should be returned by the method. In this case the last expression is `LNotEqual(i000, Local0)`. I considered the possibility that the `y901` flag being set means that all expressions used to determine a predicate are also not to be considered for implicit return, however in that case the last expression would be `Store(0xaaaa001c, Local0)` which does not align with either `0` or `Ones` as the expected result. So my understanding is that not using predicates for implicit results does not disqualify expressions used to determine the predicate.

Checking the definition of `m004()`, whose result is stored in `i000`.
```
Method(m004)
{
  if (fl00) {
    Return (0)
  }
  switch (Multiply(0xaaaa001a, 1)) {
    case (0) {
      Store(0xaaaa001b, i001)
    }
    case (0xaaaa001a) {
      Store(0xaaaa001c, i001)
    }
    default {
      Store(0xaaaa001d, i001)
    }
  }
}
```
We see that its implicit result is `0xaaaa001c`, since `fl00` is always `0`. This means that the last expression in `m005(1)`, `LNotEqual(i000, Local0)`, evaluates to false or `0` since they are in fact equal. Thus, the expected implicit return value from `m005(1)` is `0` and does not, as far as I can tell, change depending on if the `y901` flag is or is not set.

The fix would seem to be that in the test on line 1050, we should always expect the implicit return value `0` independent of the `y901` flag. As mentioned, I am more than welcome to being wrong on this, the implicit result behavior does seem quite finicky.

Also note that I have not checked that ACPICA actually passes this new version of the test, which would obviously be important to check if this is indeed an incorrect test.