### PR TITLE
iASL: Fix EINJV2 disassembly

### DIFF
--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -299,6 +299,14 @@ static const char           *AcpiDmEinjActions[] =
     "Get Command Status",
     "Set Error Type With Address",
     "Get Execute Timings",
+    "Unassigned",
+    "Unassigned",
+    "Unassigned",
+    "Unassigned",
+    "Unassigned",
+    "Unassigned",
+    "EinjV2 Set Error Type(deprecated)",
+    "EinjV2 Get Error Type",
     "Unknown Action"
 };
 


### PR DESCRIPTION
ACPI specification added new "action" codes for EINJV2 (and then deprecated one of the new codes in ACPI v6.6).

The new ACPI_EINJV2_GET_ERROR_TYPE was added to enum AcpiEinjActions, but the corresponding AcpiDmEinjActions[] array of action names was not updated.

Result was that "iasl -d" indexed past the end of the action names array and printed spurious names for actions 0x10 and 0x11.

Fix by extending the array for the new action values (note that these are not contiguous with the existing ones, so add "Unassigned" strings for the values that were skipped).

Fixes: 6975cd07e20b ("actbl1: Add EINJv2 get error type action")