### PR TITLE
Namespace: Avoid walking the Namespace if StartNode is NULL

### DIFF
--- a/source/components/namespace/nswalk.c
+++ b/source/components/namespace/nswalk.c
@@ -322,10 +322,13 @@ AcpiNsWalkNamespace (
     if (StartNode == ACPI_ROOT_OBJECT)
     {
         StartNode = AcpiGbl_RootNode;
-        if (!StartNode)
-        {
-            return_ACPI_STATUS (AE_NO_NAMESPACE);
-        }
+    }
+
+    /* Avoid walking the namespace if the StartNode is NULL */
+
+    if (!StartNode)
+    {
+        return_ACPI_STATUS (AE_NO_NAMESPACE);
     }
 
     /* Null child means "get first node" */


### PR DESCRIPTION
Since commit b1c3656 ("Namespace: Avoid walking the Namespace if it is not there") fixed the situation that both StartNode and AcpiGbl_RootNode is NULL. The Linux kernel mainline now still crashed on Honor Magicbook 14 Pro[1]. Due to the access to the member of ParentNode in AcpiNsGetNextNode, the NULL pointer dereference will always happen, no matter whether the StartNode equals to the ACPI_ROOT_OBJECT or not. So we move the check of StartNode being NULL out of the if block.

Unfortunately, all the attempt to contact with Honor has failed, they refused to provide any technical support for Linux. The bad DSDT table's dump could be found on GitHub[2].

DMI: HONOR FMB-P/FMB-P-PCB, BIOS 1.13 05/08/2025

1. https://gist.github.com/Cryolitia/a860ffc97437dcd2cd988371d5b73ed7
2. https://github.com/denis-bb/honor-fmb-p-dsdt