### PR TITLE
Fix asltests using the Fatal() opcode

### DIFF
--- a/source/components/executer/exoparg3.c
+++ b/source/components/executer/exoparg3.c
@@ -225,11 +225,18 @@ AcpiExOpcode_3A_0T_0R (
 
         AcpiOsSignal (ACPI_SIGNAL_FATAL, &Fatal);
 
+#ifndef ACPI_CONTINUE_ON_FATAL
         /*
          * Might return while OS is shutting down, so abort the AML execution
          * by returning an error.
          */
         return_ACPI_STATUS (AE_ERROR);
+#else
+	/*
+	 * The alstests require that the Fatal() opcode does not return an error.
+	 */
+	return_ACPI_STATUS (AE_OK);
+#endif
 
     case AML_EXTERNAL_OP:
         /*

--- a/tests/aslts.sh
+++ b/tests/aslts.sh
@@ -88,9 +88,10 @@ build_acpi_tools() {
 	if [ "x$REBUILD_TOOLS" = "xyes" ]; then
 		jobs=`nproc`
 		make clean
-		make iasl ASLTS=TRUE -j$jobs
-		make acpibin ASLTS=TRUE -j$jobs
-		make acpiexec ASLTS=TRUE -j$jobs
+		# We need to disable the Fatal() opcode in order to test it
+		make iasl ASLTS=TRUE OPT_CFLAGS="-DACPI_CONTINUE_ON_FATAL" -j$jobs
+		make acpibin ASLTS=TRUE OPT_CFLAGS="-DACPI_CONTINUE_ON_FATAL" -j$jobs
+		make acpiexec ASLTS=TRUE OPT_CFLAGS="-DACPI_CONTINUE_ON_FATAL" -j$jobs
 	fi
 
 	if [ -d "bin" ] && [ -f "bin/iasl" ]; then

--- a/tests/aslts/HOW_TO_INSTALL
+++ b/tests/aslts/HOW_TO_INSTALL
@@ -51,7 +51,7 @@ ENVIRONMENT
 
    For test execution, three additional variables are required:
 
-        acpiexec - path to acpiexec utility: (example)
+        acpiexec - path to acpiexec utility: (example, needs to be build with ACPI_CONTINUE_ON_FATAL)
 
             > export acpiexec="c:/acpica/libraries/acpiexec.exe"
 

--- a/tests/aslts/HOW_TO_USE
+++ b/tests/aslts/HOW_TO_USE
@@ -28,7 +28,7 @@ How to execute the run-time tests
 
             > export ASL="c:/acpica/libraries/iasl.exe"
 
-        acpiexec - path to acpiexec utility: (example)
+        acpiexec - path to acpiexec utility: (example, needs to be build with ACPI_CONTINUE_ON_FATAL)
 
             > export acpiexec="c:/acpica/libraries/acpiexec.exe"
 

--- a/tests/aslts/README
+++ b/tests/aslts/README
@@ -19,7 +19,9 @@ more common functionality.
    The testing is performed in "hardware-independent" mode without any
 access to ACPI subsystem hardware. In this purpose the AcpiExec utility
 is used which includes the entire ACPICA subsystem and allows to execute
-the AML code and thus verify functionality of ACPICA subsystem.
+the AML code and thus verify functionality of ACPICA subsystem. Please keep
+in mind that AcpiExec needs to be build with ACPI_CONTINUE_ON_FATAL being
+defined in order to run tests dealing with the Fatal() operator.
 
    The ASL source code is compiled to AML code and then passed to
 AcpiExec utility. In this relation one more type tests are provided,


### PR DESCRIPTION
Some asltests test the behavior of the Fatal() opcode and thus require that said opcode does not return an error when called.

Introduce a compile-time option called ACPI_CONTINUE_ON_FATAL to instruct the executor to continue the execution of AML bytecode when encountering a Fatal() opcode. Also update the asltest to use this new option.

This fixes the test regressions observed after #1058.