### PR TITLE
Add TPM2 start methods from TPM ACPI Spec 1.40

### DIFF
--- a/source/common/dmtable.c
+++ b/source/common/dmtable.c
@@ -568,6 +568,10 @@ static const char           *AcpiDmTpm2Subnames[] =
     "Reserved",
     "Reserved",
     "Command Response Buffer with ARM SMC",
+    "FIFO over I2C",
+    "Command Response Buffer with AMD Mailbox",
+    "Reserved",
+    "Command Response Buffer with ARM Framework-A",
     "Unknown Subtable Type"         /* Reserved */
 };
 


### PR DESCRIPTION
See: https://trustedcomputinggroup.org/wp-content/uploads/TCG-ACPI-Specification-Version-1.4-Revision-15_pub.pdf