### PR TITLE
Add safety checks in DtInsertCompilerIds to handle malformed headers

### DIFF
--- a/source/compiler/aslmessages.c
+++ b/source/compiler/aslmessages.c
@@ -412,7 +412,8 @@ const char                      *AslTableCompilerMsgs [] =
 /*    ASL_MSG_UNKNOWN_FORMAT */             "Unknown format value",
 /*    ASL_MSG_RESERVED_VALUE */             "Value for field is reserved or unknown",
 /*    ASL_MSG_TWO_ZERO_VALUES */            "32-bit DSDT Address and 64-bit X_DSDT Address cannot both be zero",
-/*    ASL_MSG_BAD_PARSE_TREE */             "Parse tree appears to be ill-defined"
+/*    ASL_MSG_BAD_PARSE_TREE */             "Parse tree appears to be ill-defined",
+/*    ASL_MSG_MALFORMED_HEADER */           "Malformed ACPI table header detected"
 };
 
 /* Preprocessor */

--- a/source/compiler/aslmessages.h
+++ b/source/compiler/aslmessages.h
@@ -414,6 +414,7 @@ typedef enum
     ASL_MSG_RESERVED_VALUE,
     ASL_MSG_TWO_ZERO_VALUES,
     ASL_MSG_BAD_PARSE_TREE,
+    ASL_MSG_MALFORMED_HEADER,
 
     /* These messages are used by the Preprocessor only */
 

--- a/source/compiler/dtcompile.c
+++ b/source/compiler/dtcompile.c
@@ -363,18 +363,42 @@ DtInsertCompilerIds (
         return;
     }
 
-    /* Walk to the Compiler fields at the end of the header */
+    /* Walk to the Compiler fields at the end of the header, with safety checks */
+
+    if (!FieldList)
+    {
+        DtError (ASL_WARNING, ASL_MSG_MALFORMED_HEADER, NULL, NULL);
+        return;
+    }
 
     Next = FieldList;
     for (i = 0; i < 7; i++)
     {
+        if (!Next || !Next->Next)
+        {
+            /* Malformed/short header: cannot insert compiler IDs */
+            DtError (ASL_WARNING, ASL_MSG_MALFORMED_HEADER, FieldList, NULL);
+            return;
+        }
         Next = Next->Next;
+    }
+
+    /* Ensure both Creator ID and Revision fields exist */
+    if (!Next || !Next->Next)
+    {
+        DtError (ASL_WARNING, ASL_MSG_MALFORMED_HEADER, FieldList, NULL);
+        return;
     }
 
     Next->Value = ASL_CREATOR_ID;
     Next->Flags = DT_FIELD_NOT_ALLOCATED;
 
     Next = Next->Next;
+    if (!Next)
+    {
+        DtError (ASL_WARNING, ASL_MSG_MALFORMED_HEADER, FieldList, NULL);
+        return;
+    }
     Next->Value = VersionString;
     Next->Flags = DT_FIELD_NOT_ALLOCATED;
 }


### PR DESCRIPTION
Fixes: #1072