### PR TITLE
Improve argument parsing in AcpiPsGetNextSimpleArg to handle remaining AML data safely

### DIFF
--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -545,6 +545,8 @@ AcpiPsGetNextSimpleArg (
     UINT32                  Length;
     UINT16                  Opcode;
     UINT8                   *Aml = ParserState->Aml;
+    UINT32                  Remaining = (UINT32) ACPI_PTR_DIFF (ParserState->AmlEnd, Aml);
+    UINT64                  PartialValue;
 
 
     ACPI_FUNCTION_TRACE_U32 (PsGetNextSimpleArg, ArgType);
@@ -557,8 +559,16 @@ AcpiPsGetNextSimpleArg (
         /* Get 1 byte from the AML stream */
 
         Opcode = AML_BYTE_OP;
-        Arg->Common.Value.Integer = (UINT64) *Aml;
-        Length = 1;
+        if (Remaining >= 1)
+        {
+            Arg->Common.Value.Integer = (UINT64) *Aml;
+            Length = 1;
+        }
+        else
+        {
+            Arg->Common.Value.Integer = 0;
+            Length = 0;
+        }
         break;
 
     case ARGP_WORDDATA:
@@ -566,8 +576,23 @@ AcpiPsGetNextSimpleArg (
         /* Get 2 bytes from the AML stream */
 
         Opcode = AML_WORD_OP;
-        ACPI_MOVE_16_TO_64 (&Arg->Common.Value.Integer, Aml);
-        Length = 2;
+        if (Remaining >= 2)
+        {
+            ACPI_MOVE_16_TO_64 (&Arg->Common.Value.Integer, Aml);
+            Length = 2;
+        }
+        else
+        {
+            Arg->Common.Value.Integer = 0;
+            Length = 0;
+            if (Remaining > 0)
+            {
+                PartialValue = 0;
+                memcpy (&PartialValue, Aml, Remaining);
+                Arg->Common.Value.Integer = PartialValue;
+                Length = Remaining;
+            }
+        }
         break;
 
     case ARGP_DWORDDATA:
@@ -575,8 +600,23 @@ AcpiPsGetNextSimpleArg (
         /* Get 4 bytes from the AML stream */
 
         Opcode = AML_DWORD_OP;
-        ACPI_MOVE_32_TO_64 (&Arg->Common.Value.Integer, Aml);
-        Length = 4;
+        if (Remaining >= 4)
+        {
+            ACPI_MOVE_32_TO_64 (&Arg->Common.Value.Integer, Aml);
+            Length = 4;
+        }
+        else
+        {
+            Arg->Common.Value.Integer = 0;
+            Length = 0;
+            if (Remaining > 0)
+            {
+                PartialValue = 0;
+                memcpy (&PartialValue, Aml, Remaining);
+                Arg->Common.Value.Integer = PartialValue;
+                Length = Remaining;
+            }
+        }
         break;
 
     case ARGP_QWORDDATA:
@@ -584,8 +624,23 @@ AcpiPsGetNextSimpleArg (
         /* Get 8 bytes from the AML stream */
 
         Opcode = AML_QWORD_OP;
-        ACPI_MOVE_64_TO_64 (&Arg->Common.Value.Integer, Aml);
-        Length = 8;
+        if (Remaining >= 8)
+        {
+            ACPI_MOVE_64_TO_64 (&Arg->Common.Value.Integer, Aml);
+            Length = 8;
+        }
+        else
+        {
+            Arg->Common.Value.Integer = 0;
+            Length = 0;
+            if (Remaining > 0)
+            {
+                PartialValue = 0;
+                memcpy (&PartialValue, Aml, Remaining);
+                Arg->Common.Value.Integer = PartialValue;
+                Length = Remaining;
+            }
+        }
         break;
 
     case ARGP_CHARLIST:
@@ -598,11 +653,32 @@ AcpiPsGetNextSimpleArg (
         /* Find the null terminator */
 
         Length = 0;
-        while (Aml[Length])
+        while ((Length < Remaining) && Aml[Length])
         {
             Length++;
         }
-        Length++;
+        if (Length < Remaining)
+        {
+            /* Account for the terminating null */
+            Length++;
+        }
+        else
+        {
+            /*
+             * No terminator found - add null at buffer boundary
+             * and report a warning
+             */
+            ACPI_WARNING ((AE_INFO,
+                "Invalid AML string: no null terminator, truncating at offset %u",
+                (UINT32) (Aml - ParserState->Aml)));
+
+            /* Add null terminator at the boundary */
+            if (Remaining > 0)
+            {
+                Aml[Remaining - 1] = 0;
+                Length = Remaining;
+            }
+        }
         break;
 
     case ARGP_NAME:


### PR DESCRIPTION
Fixes: #1073, #1131