### PR TITLE
Add alias node support in namespace handling

### DIFF
--- a/source/compiler/aslload.c
+++ b/source/compiler/aslload.c
@@ -1406,6 +1406,8 @@ LdNamespace2Begin (
 
         /* Save the target node within the alias node as well as type information */
 
+        /* Mark as alias node and store target namespace node */
+        Node->Flags |= ANOBJ_IS_ALIAS;
         Node->Object = ACPI_CAST_PTR (ACPI_OPERAND_OBJECT, TargetNode);
         Node->Type = TargetNode->Type;
         if (Node->Type == ACPI_TYPE_METHOD)

--- a/source/components/namespace/nsobject.c
+++ b/source/components/namespace/nsobject.c
@@ -336,6 +336,13 @@ AcpiNsDetachObject (
 
     ObjDesc = Node->Object;
 
+    /* Alias nodes point directly to other namespace nodes; skip teardown */
+    if (Node->Flags & ANOBJ_IS_ALIAS)
+    {
+        Node->Object = NULL;
+        return_VOID;
+    }
+
     if (!ObjDesc ||
         (ObjDesc->Common.Type == ACPI_TYPE_LOCAL_DATA))
     {

--- a/source/include/aclocal.h
+++ b/source/include/aclocal.h
@@ -332,6 +332,7 @@ typedef struct acpi_namespace_node
 #define ANOBJ_IS_EXTERNAL               0x08    /* iASL only: This object created via External() */
 #define ANOBJ_METHOD_NO_RETVAL          0x10    /* iASL only: Method has no return value */
 #define ANOBJ_METHOD_SOME_NO_RETVAL     0x20    /* iASL only: Method has at least one return value */
+#define ANOBJ_IS_ALIAS                  0x40    /* iASL only: Node is an alias to another node */
 #define ANOBJ_IS_REFERENCED             0x80    /* iASL only: Object was referenced */
 
 


### PR DESCRIPTION
- Mark nodes as alias in LdNamespace2Begin function.
- Skip teardown for alias nodes in AcpiNsDetachObject function.
- Define ANOBJ_IS_ALIAS flag in aclocal.h.

Fixes: #1075