### PR TITLE
Add checks for malformed trees in XfNamespaceLocateBegin function

### DIFF
--- a/source/compiler/aslxref.c
+++ b/source/compiler/aslxref.c
@@ -558,10 +558,22 @@ XfNamespaceLocateBegin (
 
         Node = NextOp->Asl.Node;
 
+        /* Malformed tree: parent method has no namespace node */
+        if (!Node)
+        {
+            return_ACPI_STATUS (AE_OK);
+        }
+
         /* Get Arg # */
 
         RegisterNumber = Op->Asl.AmlOpcode - AML_ARG0; /* 0x68 through 0x6F */
         MethodArgs = Node->MethodArgs;
+
+        /* Gracefully handle malformed trees where method args were not set up */
+        if (!MethodArgs)
+        {
+            return_ACPI_STATUS (AE_OK);
+        }
 
         /* Mark this Arg as referenced */
 


### PR DESCRIPTION
Fixes: #1076