### PR TITLE
Fix buffer overflow risk in CgWriteTableHeader by using strncpy for OEM ID and Table ID

### DIFF
--- a/source/compiler/aslcodegen.c
+++ b/source/compiler/aslcodegen.c
@@ -586,14 +586,16 @@ CgWriteTableHeader (
     /* OEMID */
 
     Child = Child->Asl.Next;
-    memcpy (AslGbl_TableHeader.OemId, Child->Asl.Value.String,
-        strlen (Child->Asl.Value.String));
+    /* Bound copy to header field size to avoid overflow on malformed input */
+    strncpy (AslGbl_TableHeader.OemId, Child->Asl.Value.String,
+        ACPI_OEM_ID_SIZE);
 
     /* OEM TableID */
 
     Child = Child->Asl.Next;
-    memcpy (AslGbl_TableHeader.OemTableId, Child->Asl.Value.String,
-        strlen (Child->Asl.Value.String));
+    /* Bound copy to header field size to avoid overflow on malformed input */
+    strncpy (AslGbl_TableHeader.OemTableId, Child->Asl.Value.String,
+        ACPI_OEM_TABLE_ID_SIZE);
 
     /* OEM Revision */
 


### PR DESCRIPTION
Fixes: #1077