### PR TITLE
Add check for empty value characters in DtParseLine function

### DIFF
--- a/source/compiler/dtio.c
+++ b/source/compiler/dtio.c
@@ -422,6 +422,12 @@ DtParseLine (
         End++;
     }
 
+    /* No value characters present */
+    if (End <= Start)
+    {
+        return (AE_OK);
+    }
+
     Length = ACPI_PTR_DIFF (End, Start);
     TmpValue = UtLocalCalloc (Length + 1);
 


### PR DESCRIPTION
Fixes: #1091