### PR TITLE
Fix FADT 32/64X length mismatch warning

### DIFF
--- a/source/components/tables/tbfadt.c
+++ b/source/components/tables/tbfadt.c
@@ -736,8 +736,11 @@ AcpiTbConvertFadt (
                  * Note: If the legacy length field is > 0xFF bits, ignore
                  * this check. (GPE registers can be larger than the
                  * 64-bit GAS structure can accommodate, 0xFF bits).
+                 * Also skip if BitWidth is 0, indicating the 64-bit field
+                 * was not populated - legacy length will be used instead.
                  */
                 if ((ACPI_MUL_8 (Length) <= ACPI_UINT8_MAX) &&
+                    (Address64->BitWidth != 0) &&
                     (Address64->BitWidth != ACPI_MUL_8 (Length)))
                 {
                     ACPI_BIOS_WARNING ((AE_INFO,


### PR DESCRIPTION
When the 64-bit address is set but BitWidth is 0, the spec says the legacy length should be used. That is valid firmware.

Skip the warning if BitWidth is 0.

This avoids false warnings like:
  `32/64X length mismatch in FADT/Gpe0Block: 128/0`

Tested on FreeBSD 16.0-CURRENT.