### PR TITLE
fix I2C LVR item count in the conversion table

### DIFF
--- a/source/components/resources/rsserial.c
+++ b/source/components/resources/rsserial.c
@@ -518,7 +518,7 @@ ACPI_RSCONVERT_INFO     AcpiRsConvertI2cSerialBus[18] =
     /* Read LVR from Type Specific Flags, bits[15:8] */
     {ACPI_RSC_MOVE8,    ACPI_RS_OFFSET (Data.I2cSerialBus.Lvr),
                         AML_OFFSET (I2cSerialBus.TypeSpecificFlags) + 1,
-                        0},
+                        1},
 
     {ACPI_RSC_MOVE32,   ACPI_RS_OFFSET (Data.I2cSerialBus.ConnectionSpeed),
                         AML_OFFSET (I2cSerialBus.ConnectionSpeed),


### PR DESCRIPTION
For ACPI_RSC_MOVE8, the 'Value' field in acpi_rsconvert_info is the item count and not a bit position like for the bitflags. Set 'Value' for the LVR field as '1' to fix this.

Conversion still works coincidentally with '0' because item_count is not reset between table entries, and the previous count value was taking effect.