### PR TITLE
Fix missing break in switch statment for case ACPI_MPAM_LOCATION_TYPE…

### DIFF
--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -603,6 +603,7 @@ DtCompileMpam (
                     break;
                 case ACPI_MPAM_LOCATION_TYPE_UNKNOWN:
                     InfoTable = AcpiDmTableInfoMpam1G;
+		    break;
                 default:
                     DtFatal (ASL_MSG_UNKNOWN_SUBTABLE, SubtableStart, "Resource Locator Type");
                     return (AE_ERROR);


### PR DESCRIPTION
Currently the ACPI_MPAM_LOCATION_TYPE_UNKNOWN case statement is missing a break statement, so it falls through to the default case where a fatal error message is reported. Fix this by adding the missing break statement.

Fixes: 005e24bcaa6e ("Add support for Arm's MPAM ACPI table version 2")