### PR TITLE
Fix heap-buffer-overflow in AcpiNsLookup

### DIFF
--- a/source/common/dmtbinfo2.c
+++ b/source/common/dmtbinfo2.c
@@ -1243,7 +1243,7 @@ ACPI_DMTABLE_INFO           AcpiDmTableInfoMadt30[] =
 {
     {ACPI_DMT_UINT16,   ACPI_MADT30_OFFSET (Reserved),              "Reserved", 0},
     {ACPI_DMT_UINT32,   ACPI_MADT30_OFFSET (LinkedTranslatorId),    "Linked Its Id", 0},
-    {ACPI_DMT_UINT32,   ACPI_MADT30_OFFSET (TranslateFrameId),      "Its Transalte Id", 0},
+    {ACPI_DMT_UINT32,   ACPI_MADT30_OFFSET (TranslateFrameId),      "Its Translate Id", 0},
     {ACPI_DMT_UINT32,   ACPI_MADT30_OFFSET (Reserved2),             "Reserved", 0},
     {ACPI_DMT_UINT64,   ACPI_MADT30_OFFSET (BaseAddress),           "Its Translate Frame Physical Base Address", 0},
    ACPI_DMT_TERMINATOR

--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -293,10 +293,19 @@ AcpiPsGetNextNamestring (
 
     /* Point past any namestring prefix characters (backslash or carat) */
 
-    while (ACPI_IS_ROOT_PREFIX (*End) ||
-           ACPI_IS_PARENT_PREFIX (*End))
+    while ((End < ParserState->AmlEnd) &&
+           (ACPI_IS_ROOT_PREFIX (*End) ||
+            ACPI_IS_PARENT_PREFIX (*End)))
     {
         End++;
+    }
+
+    /* Check for buffer overflow before dereferencing */
+
+    if (End >= ParserState->AmlEnd)
+    {
+        ParserState->Aml = ParserState->AmlEnd;
+        return_PTR (NULL);
     }
 
     /* Decode the path prefix character */
@@ -334,6 +343,14 @@ AcpiPsGetNextNamestring (
 
         End += ACPI_NAMESEG_SIZE;
         break;
+    }
+
+    /* Check for buffer overflow */
+
+    if (End > ParserState->AmlEnd)
+    {
+        ParserState->Aml = ParserState->AmlEnd;
+        return_PTR (NULL);
     }
 
     ParserState->Aml = End;
@@ -387,6 +404,17 @@ AcpiPsGetNextNamepath (
 
     if (!Path)
     {
+        /*
+         * If Aml did not advance, the NULL path indicates an error
+         * (buffer overflow), not a valid Null name
+         */
+        if (ParserState->Aml == Start)
+        {
+            /* Force AML pointer to end to prevent infinite loop */
+            ParserState->Aml = ParserState->AmlEnd;
+            return_ACPI_STATUS (AE_AML_BUFFER_LIMIT);
+        }
+
         Arg->Common.Value.Name = Path;
         return_ACPI_STATUS (AE_OK);
     }

--- a/source/components/parser/psparse.c
+++ b/source/components/parser/psparse.c
@@ -220,6 +220,13 @@ AcpiPsPeekOpcode (
     UINT16                  Opcode;
 
 
+    /* Check for AML pointer at or beyond end */
+
+    if (ParserState->Aml >= ParserState->AmlEnd)
+    {
+        return (0);
+    }
+
     Aml = ParserState->Aml;
     Opcode = (UINT16) ACPI_GET8 (Aml);
 
@@ -228,6 +235,11 @@ AcpiPsPeekOpcode (
         /* Extended opcode, get the second opcode byte */
 
         Aml++;
+        if (Aml >= ParserState->AmlEnd)
+        {
+            return (0);
+        }
+
         Opcode = (UINT16) ((Opcode << 8) | ACPI_GET8 (Aml));
     }
 


### PR DESCRIPTION
Add boundary checks in parser to prevent reading beyond AML buffer end.
- psargs.c: Add AmlEnd boundary checks in AcpiPsGetNextNamestring and AcpiPsGetNextNamepath when parsing namestrings and namepaths
- psparse.c: Add AmlEnd boundary checks in AcpiPsPeekOpcode before reading opcode bytes

Fixes: #1111