### PR TITLE
Fix use-after-free issue in AcpiDsTerminateControlMethod by clearing …

### DIFF
--- a/source/components/dispatcher/dsmethod.c
+++ b/source/components/dispatcher/dsmethod.c
@@ -901,6 +901,8 @@ AcpiDsTerminateControlMethod (
     ACPI_OPERAND_OBJECT     *MethodDesc,
     ACPI_WALK_STATE         *WalkState)
 {
+    UINT32                  i;
+    ACPI_NAMESPACE_NODE     *RefNode;
 
     ACPI_FUNCTION_TRACE_PTR (DsTerminateControlMethod, WalkState);
 
@@ -914,6 +916,45 @@ AcpiDsTerminateControlMethod (
 
     if (WalkState)
     {
+        /*
+         * Check if the return value is a RefOf reference to a method local
+         * or argument. If so, clear the reference to avoid use-after-free
+         * when the walk state is deleted.
+         */
+        if (WalkState->ReturnDesc &&
+            (WalkState->ReturnDesc->Common.Type == ACPI_TYPE_LOCAL_REFERENCE) &&
+            (WalkState->ReturnDesc->Reference.Class == ACPI_REFCLASS_REFOF))
+        {
+            RefNode = WalkState->ReturnDesc->Reference.Object;
+            if (RefNode)
+            {
+                /* Check against method locals */
+                for (i = 0; i < ACPI_METHOD_NUM_LOCALS; i++)
+                {
+                    if (RefNode == &WalkState->LocalVariables[i])
+                    {
+                        AcpiUtRemoveReference (WalkState->ReturnDesc);
+                        WalkState->ReturnDesc = NULL;
+                        break;
+                    }
+                }
+
+                /* Check against method arguments if not already cleared */
+                if (WalkState->ReturnDesc)
+                {
+                    for (i = 0; i < ACPI_METHOD_NUM_ARGS; i++)
+                    {
+                        if (RefNode == &WalkState->Arguments[i])
+                        {
+                            AcpiUtRemoveReference (WalkState->ReturnDesc);
+                            WalkState->ReturnDesc = NULL;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         /* Delete all arguments and locals */
 
         AcpiDsMethodDataDeleteAll (WalkState);


### PR DESCRIPTION
…references to method locals and arguments

Fixes: #1119