### PR TITLE
Fix integer overflow in AcpiExOpcode_3A_1T_1R (MidOp)

### DIFF
--- a/source/components/executer/exoparg3.c
+++ b/source/components/executer/exoparg3.c
@@ -320,7 +320,8 @@ AcpiExOpcode_3A_1T_1R (
 
         /* Truncate request if larger than the actual String/Buffer */
 
-        else if ((Index + Length) > Operand[0]->String.Length)
+        else if ((Index + Length) > Operand[0]->String.Length ||
+                 (Index + Length) < Index) /* Check for overflow */
         {
             Length =
                 (ACPI_SIZE) Operand[0]->String.Length - (ACPI_SIZE) Index;


### PR DESCRIPTION
Add overflow check for Index + Length to prevent integer overflow when calculating the truncation length. This prevents negative size parameter being passed to memcpy.

Fixes: #1129