### PR TITLE
Fix NULL pointer dereference in AcpiNsCustomPackage

### DIFF
--- a/source/components/namespace/nsprepkg.c
+++ b/source/components/namespace/nsprepkg.c
@@ -779,6 +779,13 @@ AcpiNsCustomPackage (
 
     /* Get version number, must be Integer */
 
+    if (!(*Elements))
+    {
+        ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname, Info->NodeFlags,
+            "Return Package has a NULL version element"));
+        return_ACPI_STATUS (AE_AML_OPERAND_TYPE);
+    }
+
     if ((*Elements)->Common.Type != ACPI_TYPE_INTEGER)
     {
         ACPI_WARN_PREDEFINED ((AE_INFO, Info->FullPathname, Info->NodeFlags,


### PR DESCRIPTION
## Summary

`AcpiNsCustomPackage()` unconditionally dereferences the first element of the package to read the `_BIX` version number, without checking for NULL:

```c
if ((*Elements)->Common.Type != ACPI_TYPE_INTEGER)
```

When firmware returns a `_BIX` package whose first element is an unresolvable reference, ACPICA evaluates that entry to NULL. `AcpiNsRemoveNullElements()` does not strip NULL entries for `ACPI_PTYPE_CUSTOM` packages (fixed-position format would break if elements were shifted), so `AcpiNsCustomPackage()` sees the NULL and causes a crash.

### Linux kernel crash log

```
general protection fault, probably for non-canonical address 0xdffffc0000000001: 0000 [#1] SMP KASAN NOPTI
KASAN: null-ptr-deref in range [0x0000000000000008-0x000000000000000f]
RIP: acpi_ns_check_package (drivers/acpi/acpica/nsprepkg.c:634 drivers/acpi/acpica/nsprepkg.c:110)
Call Trace:
 <TASK>
 acpi_ns_check_return_value (nspredef.c:136)
 acpi_ns_evaluate (nseval.c:266)
 acpi_evaluate_object (nsxfeval.c:360)
 acpi_battery_get_info (battery.c:537)
 acpi_battery_update (battery.c:1007)
 acpi_battery_add (battery.c:1237)
 acpi_device_probe (bus.c:1076)
 really_probe (dd.c:659)
 </TASK>
Kernel panic - not syncing: Fatal exception
```

## Fix

Add a NULL check for the first element (version field) before dereferencing it. The caller then receives `AE_AML_OPERAND_TYPE` instead of crashing.

## Reproduction

A QEMU environment with a malicious ACPI SSDT table whose `_BIX` method returns `Package(One){UNKN}` (an unresolvable reference) triggers the crash 100% of the time during battery probe at boot. With the fix applied, the battery probe fails gracefully with error -14 and the kernel continues normally.

Reported-by: Xiang Mei <xmei5@asu.edu>
Reported-by: Weiming Shi <bestswngs@gmail.com>