### PR TITLE
Provide #defines for EINJV2 error types

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -1778,6 +1778,13 @@ enum AcpiEinjCommandStatus
 #define ACPI_EINJ_VENDOR_DEFINED            (1<<31)
 
 
+/* EINJV2 error types from EINJV2_GET_ERROR_TYPE (ACPI 6.6) */
+
+#define ACPI_EINJV2_PROCESSOR               (1)
+#define ACPI_EINJV2_MEMORY                  (1<<1)
+#define ACPI_EINJV2_PCIE                    (1<<2)
+
+
 /*******************************************************************************
  *
  * ERST - Error Record Serialization Table (ACPI 4.0)


### PR DESCRIPTION
EINJV2 defined new error types by moving the severity (correctable, uncorrectable non-fatal, uncorrectable fatal) out of the "type".

ACPI 6.5 introduced EINJV2 and defined a vendor defined error type using bit 31. This was dropped in ACPI 6.6.