### PR TITLE
Fix a compiler regression

### DIFF
--- a/source/compiler/aslglobal.h
+++ b/source/compiler/aslglobal.h
@@ -252,7 +252,6 @@ extern FILE                         *AslCompilerin;
 extern int                          DtParserdebug;
 extern int                          PrParserdebug;
 extern const ASL_MAPPING_ENTRY      AslKeywordMapping[];
-extern const UINT32                 AslKeywordMappingCount;
 extern char                         *AslCompilertext;
 extern char                         *DtCompilerParsertext;
 

--- a/source/compiler/aslmap.c
+++ b/source/compiler/aslmap.c
@@ -611,5 +611,3 @@ const ASL_MAPPING_ENTRY     AslKeywordMapping [] =
 /*! [End] no source code translation !*/
 
 };
-
-const UINT32     AslKeywordMappingCount = ACPI_ARRAY_LENGTH (AslKeywordMapping);

--- a/source/compiler/aslopcodes.c
+++ b/source/compiler/aslopcodes.c
@@ -863,14 +863,6 @@ OpcGenerateAmlOpcode (
 
     Index = (UINT16) (Op->Asl.ParseOpcode - ASL_PARSE_OPCODE_BASE);
 
-    if ((Op->Asl.ParseOpcode < ASL_PARSE_OPCODE_BASE) ||
-        (Index >= AslKeywordMappingCount))
-    {
-        AslError (ASL_ERROR, ASL_MSG_COMPILER_INTERNAL, Op,
-            "Invalid parse opcode in OpcGenerateAmlOpcode");
-        return;
-    }
-
     Op->Asl.AmlOpcode     = AslKeywordMapping[Index].AmlOpcode;
     Op->Asl.AcpiBtype     = AslKeywordMapping[Index].AcpiBtype;
     Op->Asl.CompileFlags |= AslKeywordMapping[Index].Flags;


### PR DESCRIPTION
https://github.com/acpica/acpica/commit/eff423cadbe44c916078d99b666406b20aea130b broke any code using the Printf macro (and possibly other macros):
```asl
DefinitionBlock ("", "DSDT", 2, "uTEST", "TESTTABL", 0xF0F0F0F0)
{
    Printf("hello world")
}
```
Results in
```
$ ./bin/iasl test1.asl

Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20260408
Copyright (c) 2000 - 2026 Intel Corporation

test1.asl      3:     Printf("hello world")
Error    6010 - Internal compiler error ^  (Invalid parse opcode in OpcGenerateAmlOpcode)

ASL Input:     test1.asl -      95 bytes      0 keywords      0 source lines

Compilation failed. 1 Errors, 0 Warnings, 0 Remarks
No AML files were generated due to compiler error(s)
```

Reverting fixes the issue