### PR TITLE
compiler: fix regression in OpcGenerateAmlOpcode bounds check

### DIFF
--- a/source/compiler/aslopcodes.c
+++ b/source/compiler/aslopcodes.c
@@ -866,8 +866,11 @@ OpcGenerateAmlOpcode (
     if ((Op->Asl.ParseOpcode < ASL_PARSE_OPCODE_BASE) ||
         (Index >= AslKeywordMappingCount))
     {
-        AslError (ASL_ERROR, ASL_MSG_COMPILER_INTERNAL, Op,
-            "Invalid parse opcode in OpcGenerateAmlOpcode");
+        /*
+         * Parse opcode is not in the keyword mapping table. This can
+         * happen for internal parser tokens (expression operators,
+         * punctuation) that don't need AML opcode generation.
+         */
         return;
     }
 


### PR DESCRIPTION
The validation added in eff423cad assumed every parse opcode encountered at runtime has a corresponding entry in AslKeywordMapping. This is not the case: the bison parser generates additional internal tokens for expression operators and punctuation that do not need keyword mapping because they are handled through other code paths or rewritten into real ASL opcodes before AML code generation.

Replace the fatal error with a silent early return for unmapped parse opcodes, matching the pre-check behavior where these cases were silently ignored.

Fixes regression where ASL using Printf, LoadTable, and other constructs that create internal parser nodes fail compilation with:
  "Internal compiler error: Invalid parse opcode in OpcGenerateAmlOpcode"

Fixes: eff423cad ("Add AslKeywordMappingCount for validation in OpcGenerateAmlOpcode")
Fixes: #1154