### PR TITLE
Introduce a new HEST notification type for RISC-V SSE events.

### DIFF
--- a/source/include/actbl1.h
+++ b/source/include/actbl1.h
@@ -2261,7 +2261,8 @@ enum AcpiHestNotifyTypes
     ACPI_HEST_NOTIFY_SEI                = 9,    /* ACPI 6.1 */
     ACPI_HEST_NOTIFY_GSIV               = 10,   /* ACPI 6.1 */
     ACPI_HEST_NOTIFY_SOFTWARE_DELEGATED = 11,   /* ACPI 6.2 */
-    ACPI_HEST_NOTIFY_RESERVED           = 12    /* 12 and greater are reserved */
+    ACPI_HEST_NOTIFY_SSE                = 12,   /* RISC-V SSE */
+    ACPI_HEST_NOTIFY_RESERVED           = 13    /* 13 and greater are reserved */
 };
 
 /* Values for ConfigWriteEnable bitfield above */


### PR DESCRIPTION
The GHES entry's notification structure contains the notification to be used for a given error source. For error sources delivering events over SSE, it should contain the new SSE notification type.