### PR TITLE
tables: Fix heap-buffer-overflow in AcpiTbFindTable

### DIFF
--- a/source/components/tables/tbfind.c
+++ b/source/components/tables/tbfind.c
@@ -208,8 +208,25 @@ AcpiTbFindTable (
 
     memset (&Header, 0, sizeof (ACPI_TABLE_HEADER));
     ACPI_COPY_NAMESEG (Header.Signature, Signature);
-    memcpy (Header.OemId, OemId, ACPI_OEM_ID_SIZE);
-    memcpy (Header.OemTableId, OemTableId, ACPI_OEM_TABLE_ID_SIZE);
+    if (strlen (OemId) >= ACPI_OEM_ID_SIZE)
+    {
+        memcpy (Header.OemId, OemId, ACPI_OEM_ID_SIZE);
+    }
+    else
+    {
+        memcpy (Header.OemId, OemId, strlen (OemId));
+        /* Remainder is already zeroed by memset above */
+    }
+
+    if (strlen (OemTableId) >= ACPI_OEM_TABLE_ID_SIZE)
+    {
+        memcpy (Header.OemTableId, OemTableId, ACPI_OEM_TABLE_ID_SIZE);
+    }
+    else
+    {
+        memcpy (Header.OemTableId, OemTableId, strlen (OemTableId));
+        /* Remainder is already zeroed by memset above */
+    }
 
     /* Search for the table */
 


### PR DESCRIPTION
The OEM ID and OEM Table ID string operands passed to AcpiTbFindTable can be shorter than ACPI_OEM_ID_SIZE (6) and ACPI_OEM_TABLE_ID_SIZE (8). The unconditional memcpy reads past the string allocation when the input is too short. Validate string length before memcpy and copy only what is available, relying on the prior memset to zero-pad the remainder.

Fixes: #1179