### PR TITLE
fix: variable NumCarats set but not used

### DIFF
--- a/source/components/namespace/nsaccess.c
+++ b/source/components/namespace/nsaccess.c
@@ -449,7 +449,7 @@ AcpiNsLookup (
     ACPI_NAMESPACE_NODE     *CurrentNode = NULL;
     ACPI_NAMESPACE_NODE     *ThisNode = NULL;
     UINT32                  NumSegments;
-    UINT32                  NumCarats;
+    UINT32 ACPI_UNUSED_VAR  NumCarats;
     ACPI_NAME               SimpleName;
     ACPI_OBJECT_TYPE        TypeToCheckFor;
     ACPI_OBJECT_TYPE        ThisSearchType;


### PR DESCRIPTION
Close: #1159 
Close: #973 
In the gcc 16 update, gcc expanded the `-Wunused-but-set-*` warnings, causing the following compilation problem to occur with current code in gcc 16:
```
obj/acpiexamples ../../../source/components/namespace/nsaccess.c
../../../source/components/namespace/nsaccess.c: In function AcpiNsLookup:
../../../source/components/namespace/nsaccess.c:452:29: error: variable NumCarats set but not used [-Werror=unused-but-set-variable=]
452 |     UINT32                  NumCarats;
       |                             ^~~~~~~~~
cc1: all warnings being treated as errors
```

I suppressed the problem using the `ACPI_DEBUG_OUTPUT` macro, and it compiled successfully on my local machine.