### PR TITLE
Namespace: Bypass AE_ALREADY_EXISTS during table load

### DIFF
--- a/source/components/dispatcher/dswload2.c
+++ b/source/components/dispatcher/dswload2.c
@@ -465,6 +465,16 @@ AcpiDsLoad2BeginOp (
         Status = AcpiNsLookup (WalkState->ScopeInfo, BufferPtr, ObjectType,
             ACPI_IMODE_LOAD_PASS2, Flags, WalkState, &Node);
 
+        /*
+         * If the object already exists but its type matches the new object
+         * type (no type conflict), treat it as a benign duplicate and
+         * allow the table load to continue.
+         */
+        if (Status == AE_ALREADY_EXISTS && Node && Node->Type == ObjectType)
+        {
+            Status = AE_OK;
+        }
+
         if (ACPI_SUCCESS (Status) && (Flags & ACPI_NS_TEMPORARY))
         {
             ACPI_DEBUG_PRINT ((ACPI_DB_DISPATCH,


### PR DESCRIPTION
### Context & Symptom
This issue was originally observed on an ASUS Vivobook laptop. During ACPI table loading pass 2, the interpreter encountered benign duplicate named object definitions, causing it to abort the parsing phase early with an `AE_ALREADY_EXISTS` error. 

### The Cascading Effect (The Link to AE_NOT_FOUND)
Because the interpreter aborts parsing the remainder of the affected AML opcode method early during pass 2, any subsequent or dependent sub-objects (such as thermal/sensor definitions like `S1CT`, `S2CT`) within that scope are completely skipped and never entered into the namespace. 

Later, when the platform driver (`asus_wmi`) attempts to evaluate these missing sensor objects, it triggers cascading `AE_NOT_FOUND` errors, ultimately causing the driver to fail to load factory fan curves with error `-19` (ENODEV).

### Architectural Decision
An initial platform-level quirk patch was drafted to handle these errors inside `drivers/platform/x86/asus-wmi.c`. However, Linux kernel platform maintainer Hans de Goede pointed out that the `AE_NOT_FOUND` errors are a direct cascading consequence of the interpreter's early-abort behavior on `AE_ALREADY_EXISTS`. 

Per his architectural guidance, fixing this at the ACPICA interpreter level is the correct, generic solution, as it prevents the parser from breaking the namespace topology for benign duplicates across all platforms.

### Solution
This patch bypasses the `AE_ALREADY_EXISTS` error during table load pass 2 strictly when the existing node type matches the new object type (no type conflict). This allows the parser to safely continue loading the tables, preserving the integrity of subsequent sub-objects.

### Testing & Verification
This patch has been ported into a custom Linux kernel build and locally tested on the affected ASUS Vivobook hardware. The kernel compiled successfully, and the system booted without any regressions or side effects. Full `dmesg` logs before and after the patch can be provided upon request to verify the successful table load and driver binding.