### PR TITLE
exresop: Handle Package object passed to COMPUTEDATA operand

### DIFF
--- a/source/components/executer/exresop.c
+++ b/source/components/executer/exresop.c
@@ -631,6 +631,28 @@ AcpiExResolveOperands (
                 /* Valid operand */
                break;
 
+            case ACPI_TYPE_PACKAGE:
+                /*
+                 * A Package was passed where Integer/String/Buffer
+                 * is required (BIOS bug). Replace with an empty
+                 * string so the method can continue executing.
+                 */
+                ACPI_BIOS_WARNING ((AE_INFO,
+                    "Needed [Integer/String/Buffer], found [Package] "
+                    "- substituting empty String"));
+
+                *StackPtr = AcpiUtCreateStringObject (0);
+                if (!*StackPtr)
+                {
+                    return_ACPI_STATUS (AE_NO_MEMORY);
+                }
+
+                if (ObjDesc != *StackPtr)
+                {
+                    AcpiUtRemoveReference (ObjDesc);
+                }
+                break;
+
             default:
                 ACPI_ERROR ((AE_INFO,
                     "Needed [Integer/String/Buffer], found [%s] %p",


### PR DESCRIPTION
The Lenovo ThinkPad T14 Gen 1 BIOS (N2XET43W 1.33) contains an \ADBG debug-print method that passes a Package object as an argument to ToHexString, which expects Integer/String/Buffer (ARGI_COMPUTEDATA).

The \_SB.HIDD._DSM method calls \ADBG with the return value of a _DSM call, which can be a Package. The ADBG method then passes this Package directly to ToHexString without type checking. Without this fix, the following error cascade occurs:

  ACPI Error: Needed [Integer/String/Buffer], found [Package]
  ACPI Error: AE_AML_OPERAND_TYPE, While resolving operands for [ToHexString]
  ACPI Error: Aborting method \ADBG due to previous error
  ACPI Error: Aborting method \_SB.HIDD._DSM due to previous error
  ACPI: \_SB_.HIDD: failed to evaluate _DSM b356ecee-... rev:1 func:0 (0x3003)

This is a BIOS bug -- the ACPI specification does not allow Package objects as implicit source operands for COMPUTEDATA. Handle it gracefully by replacing the Package with an empty string and emitting ACPI_BIOS_WARNING, allowing the calling method to continue rather than aborting the entire call chain.

Link: https://uefi.org/specs/ACPI/6.5/19_ASL_Reference.html