### PR TITLE
generate/efi: add missing utcksum.c source file

### DIFF
--- a/generate/efi/acpidump/Makefile
+++ b/generate/efi/acpidump/Makefile
@@ -41,6 +41,7 @@ OBJECTS = \
 	$(OBJDIR)/utascii.o\
 	$(OBJDIR)/utbuffer.o\
 	$(OBJDIR)/utclib.o\
+	$(OBJDIR)/utcksum.o\
 	$(OBJDIR)/utdebug.o\
 	$(OBJDIR)/utexcep.o\
 	$(OBJDIR)/utglobal.o\

--- a/generate/efi/acpidump/acpidump_nostdlib.inf
+++ b/generate/efi/acpidump/acpidump_nostdlib.inf
@@ -34,6 +34,7 @@
   components/tables/tbxfroot.c
   components/utilities/utascii.c
   components/utilities/utbuffer.c
+  components/utilities/utcksum.c
   components/utilities/utclib.c
   components/utilities/utdebug.c
   components/utilities/utexcep.c

--- a/generate/efi/acpidump/acpidump_stdlib.inf
+++ b/generate/efi/acpidump/acpidump_stdlib.inf
@@ -33,6 +33,7 @@
   components/tables/tbxfroot.c
   components/utilities/utascii.c
   components/utilities/utbuffer.c
+  components/utilities/utcksum.c
   components/utilities/utdebug.c
   components/utilities/utexcep.c
   components/utilities/utglobal.c


### PR DESCRIPTION
The utcksum.c source file is currently missing from EFI builds, which make them to never succeed.