### PR TITLE
generate/efi: adapt to EDK2 202605

### DIFF
--- a/generate/efi/AcpiPkg_nostdlib.dsc
+++ b/generate/efi/AcpiPkg_nostdlib.dsc
@@ -22,6 +22,8 @@
   BUILD_TARGETS           = DEBUG|RELEASE
   SKUID_IDENTIFIER        = DEFAULT
 
+!include MdePkg/MdeLibs.dsc.inc
+
 [LibraryClasses]
   #
   # Entry Point Libraries

--- a/generate/efi/AcpiPkg_stdlib.dsc
+++ b/generate/efi/AcpiPkg_stdlib.dsc
@@ -22,6 +22,8 @@
   BUILD_TARGETS           = DEBUG|RELEASE
   SKUID_IDENTIFIER        = DEFAULT
 
+!include MdePkg/MdeLibs.dsc.inc
+
 [LibraryClasses]
   #
   # Entry Point Libraries

--- a/generate/efi/README
+++ b/generate/efi/README
@@ -7,7 +7,7 @@ However, the porting has only been tested in a Linux environment.
 1. Build EFI ACPICA utilities with EDK2 (Linux)
 
    In a Linux environment, you can build EFI ACPICA utilities by executing
-   the following commands (supposing you are using gcc-4.7):
+   the following commands (supposing you are using a recent GCC):
 
    # git clone https://github.com/tianocore/edk2
    # git clone https://github.com/acpica/acpica
@@ -16,12 +16,12 @@ However, the porting has only been tested in a Linux environment.
    # source ./edksetup.sh
    # ln -s ../acpica AcpiPkg
    # AcpiPkg/generate/efi/edksetup.sh
-   # build -p AcpiPkg/AcpiPkg.dsc -t GCC47
+   # build -p AcpiPkg/AcpiPkg.dsc -t GCC
 
    You can find built EFI binaries (e.x., acpidump.efi) in the following
    folders:
-     Build/Acpi/DEBUG_GCC47/IA32: i386 targets
-     Build/Acpi/DEBUG_GCC47/X64: x86_64 targets
+     Build/Acpi/DEBUG_GCC/IA32: i386 targets
+     Build/Acpi/DEBUG_GCC/X64: x86_64 targets
 
 2. Build EFI ACPICA utilities with GNU EFI (Linux)
 


### PR DESCRIPTION
Recent EDK2's BaseLib has some more dependencies declared in a .inc file in MdePkg, and the toolchain name is changed to contain no version number.

Adapt to these changes in the DSC files and README.

Depends on #1194 to pass build.