### PR TITLE
Set AML length for bytelist

### DIFF
--- a/source/components/parser/psargs.c
+++ b/source/components/parser/psargs.c
@@ -973,6 +973,8 @@ AcpiPsGetNextField (
 
                 ASL_CV_CAPTURE_COMMENTS_ONLY (ParserState);
                 Arg->Named.Value.Size = BufferLength;
+                Arg->Named.Length = (UINT32)
+                    ACPI_PTR_DIFF (PkgEnd, ParserState->Aml);
                 Arg->Named.Data = ParserState->Aml;
             }
 
@@ -1167,7 +1169,7 @@ AcpiPsGetNextArg (
 
             /* Fill in bytelist data */
 
-            Arg->Common.Value.Size = (UINT32)
+            Arg->Common.Value.Size = Arg->Named.Length = (UINT32)
                 ACPI_PTR_DIFF (ParserState->PkgEnd, ParserState->Aml);
             Arg->Named.Data = ParserState->Aml;
 


### PR DESCRIPTION
The AML length of bytelist is never set. Since the Fixes: commit, this leads to failures in the sanity check for resource templates, causing the decompiler to decompile valid resource templates as plain buffers.

Fix it by setting the AML length properly.

Fixes: 3ce09021b677 ("validate resource template buffer length and check allocation type")