### PR TITLE
iASL: Fix Printf/Fprintf broken by AslKeywordMapping bounds check

### DIFF
--- a/source/compiler/aslopcodes.c
+++ b/source/compiler/aslopcodes.c
@@ -866,6 +866,33 @@ OpcGenerateAmlOpcode (
     if ((Op->Asl.ParseOpcode < ASL_PARSE_OPCODE_BASE) ||
         (Index >= AslKeywordMappingCount))
     {
+        /*
+         * Some ParseOpcodes (e.g., PARSEOP_PRINTF, PARSEOP_FPRINTF) are
+         * declared after the PARSEOP_EXP_* C-style expression tokens in
+         * asltokens.y, but those expression tokens have no corresponding
+         * entries in AslKeywordMapping[].  This causes the computed Index
+         * to exceed AslKeywordMappingCount for these valid opcodes.
+         *
+         * Handle them here before reporting an error, since they do not
+         * need anything from the mapping table — their entire setup is
+         * performed by the dedicated handler functions.
+         */
+        switch (Op->Asl.ParseOpcode)
+        {
+        case PARSEOP_PRINTF:
+
+            OpcDoPrintf (Op);
+            return;
+
+        case PARSEOP_FPRINTF:
+
+            OpcDoFprintf (Op);
+            return;
+
+        default:
+            break;
+        }
+
         AslError (ASL_ERROR, ASL_MSG_COMPILER_INTERNAL, Op,
             "Invalid parse opcode in OpcGenerateAmlOpcode");
         return;


### PR DESCRIPTION
Commit eff423cad ("Add AslKeywordMappingCount for validation in OpcGenerateAmlOpcode") introduced a bounds check to prevent global- buffer-overflow when accessing AslKeywordMapping[] (Fixes: #1070).

However, PARSEOP_PRINTF and PARSEOP_FPRINTF tokens have indices that exceed AslKeywordMappingCount.  This is because 37 PARSEOP_EXP_* C-style expression tokens are declared between the bulk of the ASL keyword tokens and PRINTF/FPRINTF in asltokens.y, but these expression tokens have no corresponding entries in the AslKeywordMapping[] table. As a result, the computed index for PRINTF (ParseOpcode - BASE = 407) exceeds the table size (374), triggering the bounds check.

Since the check returns early before reaching the switch statement, OpcDoPrintf() and OpcDoFprintf() are never called.  This causes every Printf and Fprintf macro in ASL source to emit:

    Error 6010 - Internal compiler error (Invalid parse opcode
                 in OpcGenerateAmlOpcode)

Fix this by handling PARSEOP_PRINTF and PARSEOP_FPRINTF inside the bounds-check failure path.  These opcodes do not need any values from AslKeywordMapping[] — their entire setup is performed by OpcDoPrintf() and OpcDoFprintf() respectively.