### PR TITLE
Utilities: Fix for AcpiUtVerifyChecksum warning display

### DIFF
--- a/source/components/utilities/utcksum.c
+++ b/source/components/utilities/utcksum.c
@@ -209,7 +209,7 @@ AcpiUtVerifyChecksum (
             "Incorrect checksum in table [%4.4s] - 0x%2.2X, "
             "should be 0x%2.2X",
             Table->Signature, Table->Checksum,
-            Table->Checksum - Checksum));
+            Checksum));
 
 #if (ACPI_CHECKSUM_ABORT)
         return (AE_BAD_CHECKSUM);


### PR DESCRIPTION
Remove redundant subtraction which is done already in AcpiUtGenerateChecksum.

Looks like it is a leftover from a refactor [1] where AcpiTbVerifyChecksum used to call AcpiTbChecksum which does not do the substraction (like the Acpi(Dm\Ut)GenerateChecksum does). 

Found by using iasl to generate checksum for SWFT tables.

[1]: https://github.com/acpica/acpica/commit/8ac4e5116f59d6f9ba2fbeb9ce22ab58237a278f