### PR TITLE
Get rid of strncpy to stay in line with the Linux kernel

### DIFF
--- a/source/components/utilities/utnonansi.c
+++ b/source/components/utilities/utnonansi.c
@@ -351,10 +351,23 @@ AcpiUtSafeStrncpy (
     char                    *Source,
     ACPI_SIZE               DestSize)
 {
-    /* Always terminate destination string */
+    /*
+      Always zero terminated strncpy func
+      strncpy must not be used here, because the Linux kernel
+      got rid of it
+    */
+    ACPI_SIZE StrLength;
 
-    strncpy (Dest, Source, DestSize);
-    Dest[DestSize - 1] = 0;
+    if (DestSize == 0)
+	return;
+
+    StrLength = strlen(Source);
+
+    if (StrLength > DestSize - 1)
+	StrLength = DestSize - 1;
+
+    memset (Dest, 0, DestSize);
+    memcpy (Dest, Source, StrLength);
 }
 
 #endif


### PR DESCRIPTION
Closes: https://lore.kernel.org/all/79e9e913-0fb1-4110-804b-c3b5d0edafe4@kernel.org
Reported-by: Jiri Slaby <jirislaby@kernel.org>