### PR TITLE
utilities: guard notify list traversal against invalid pointers

### DIFF
--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -698,6 +698,10 @@ AcpiUtUpdateObjectReference (
                 PrevObject = Object->CommonNotify.NotifyList[i];
                 while (PrevObject)
                 {
+                    if (PrevObject->Common.Type != ACPI_TYPE_LOCAL_NOTIFY)
+                    {
+                        break;
+                    }
                     NextObject = PrevObject->Notify.Next[i];
                     AcpiUtUpdateRefCount (PrevObject, Action);
                     PrevObject = NextObject;

--- a/source/components/utilities/utdelete.c
+++ b/source/components/utilities/utdelete.c
@@ -698,7 +698,11 @@ AcpiUtUpdateObjectReference (
                 PrevObject = Object->CommonNotify.NotifyList[i];
                 while (PrevObject)
                 {
-                    if (PrevObject->Common.Type != ACPI_TYPE_LOCAL_NOTIFY)
+                    /* Stop if list entry is not a valid notify descriptor */
+                    if (((ACPI_SIZE) PrevObject < sizeof (ACPI_OPERAND_OBJECT)) ||
+                        (ACPI_GET_DESCRIPTOR_TYPE (PrevObject) !=
+                            ACPI_DESC_TYPE_OPERAND) ||
+                        (PrevObject->Common.Type != ACPI_TYPE_LOCAL_NOTIFY))
                     {
                         break;
                     }


### PR DESCRIPTION
## Summary

This PR hardens notify-list traversal in `AcpiUtUpdateObjectReference` for DEVICE/PROCESSOR/POWER/THERMAL objects.

It stops traversal when a notify-list entry is not a valid local notify operand object.

Fixes #1208.

## Changes

1. Add pointer-sanity guard before dereferencing notify-list entries.
2. Require `ACPI_DESC_TYPE_OPERAND` descriptor type.
3. Require `ACPI_TYPE_LOCAL_NOTIFY` before following `Notify.Next[i]`.

## Why

Malformed AML can corrupt notify-list entries and cause dereference faults during teardown. This patch exits traversal safely on invalid entries.

## Validation

Reproducer:

```bash
ASAN_OPTIONS="detect_leaks=0:abort_on_error=1" ./generate/unix/bin/acpiexec -m /tmp/issue1181/10d5390008320d36.aml
```

Before:

- Crash/overflow in `AcpiUtUpdateObjectReference` path.

After:

- No crash on the same input.

## Test Artifact

- Reproducer archive (contains `10d5390008320d36.aml`):
  https://github.com/user-attachments/files/27785390/10d5390008320d36.zip

## Files Changed

- `source/components/utilities/utdelete.c`
