### PR TITLE
Add macro for each bit of the Flags field in the IOVT IOMMU structure

### DIFF
--- a/source/include/actbl2.h
+++ b/source/include/actbl2.h
@@ -1190,6 +1190,14 @@ typedef struct acpi_iovt_iommu
 
 } ACPI_IOVT_IOMMU;
 
+/* Masks for Flags field above */
+
+#define ACPI_IOVT_IOMMU_PCI_DEVICE           (1<<0)
+#define ACPI_IOVT_IOMMU_PXM_VALID            (1<<1)
+#define ACPI_IOVT_IOMMU_MAGAGE_BY_SEGMENT    (1<<2)
+#define ACPI_IOVT_IOMMU_HW_CAP_SUPPORT       (1<<3)
+#define ACPI_IOVT_IOMMU_MSI_INT_BYPASS       (1<<4)
+
 typedef struct acpi_iovt_device_entry
 {
     UINT8                   Type;


### PR DESCRIPTION
According to the IOVT specification, define macros for each bit of the Flags field in the IOVT IOMMU structure:

Bit 0: PCI device flag.
1: The IOMMU is a PCI device.
0: The IOMMU is a platform device.

Bit 1: Proximity domain valid.
Bit 2: Whether the devices managed by the IOMMU can be classified by PCI segment
1: All devices under the root PCI bridge can be managed.
0: Manageable devices are placed in the device entry list.

Bit3: Hardware capability support.
Bit4: MSI interrupt address bypass supported.
Bit5-31: Reserved, must be zero.